### PR TITLE
Add linting tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 
+# NodeJS
+
+node_modules/
+
 # Created by https://www.gitignore.io/api/sass,macos,jekyll
 
 ### Jekyll ###

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,12 +39,6 @@
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
     },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
-    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -57,16 +51,10 @@
       "integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
       "dev": true
     },
-    "xml2js": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
-      "dev": true
-    },
-    "xmlbuilder": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+    "xmldoc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-1.1.0.tgz",
+      "integrity": "sha1-JckvCPJj80TayNCzI3CnAe6dDpM=",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,12 @@
       "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
       "dev": true
     },
+    "ci-info": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
+      "integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ=",
+      "dev": true
+    },
     "color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
@@ -39,10 +45,34 @@
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true
+    },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+      "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+      "dev": true
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
     "supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,73 @@
+{
+  "name": "simple-icons",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "ansi-styles": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.1.0.tgz",
+      "integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
+      "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true
+    },
+    "color-name": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
+      "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz",
+      "integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "dev": true
+    },
+    "xmlbuilder": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "license": "CCO",
   "devDependencies": {
     "chalk": "^2.0.1",
+    "husky": "^0.14.3",
     "xmldoc": "^1.1.0"
+  },
+  "scripts":{
+    "precommit": "tools/lint-staged"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
   "main": "_data/simple-icons.json",
   "repository": "git@github.com:danleech/simple-icons.git",
   "author": "Dan Leech",
-  "license": "CCO"
+  "license": "CCO",
+  "devDependencies": {
+    "chalk": "^2.0.1",
+    "xml2js": "^0.4.17"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "license": "CCO",
   "devDependencies": {
     "chalk": "^2.0.1",
-    "xml2js": "^0.4.17"
+    "xmldoc": "^1.1.0"
   }
 }

--- a/tools/lint-staged
+++ b/tools/lint-staged
@@ -9,7 +9,7 @@ const lintSVG = require("./lint-svg");
 
     const svgs = stagedFiles.filter(file => /\.svg$/.test(file.path));
     for (let svg of svgs) {
-        const result = await lintSVG(svg.path, svg.content);
+        const result = lintSVG(svg.path, svg.content);
         success = success && result;
     }
 

--- a/tools/lint-staged
+++ b/tools/lint-staged
@@ -9,9 +9,8 @@ const lintSVG = require("./lint-svg");
 
     const svgs = stagedFiles.filter(file => /\.svg$/.test(file.path));
     for (let svg of svgs) {
-        if (!lintSVG(svg)) {
-            success = false;
-        }
+        const result = await lintSVG(svg.path, svg.content);
+        success = success && result;
     }
 
     process.exit(success ? 0 : 1);

--- a/tools/lint-staged
+++ b/tools/lint-staged
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+const exec = require("child_process").exec;
+const lintSVG = require("./lint-svg");
+
+// Lint all staged files
+(async function(){
+    let success = true;
+    const stagedFiles = await getStagedFiles();
+
+    const svgs = stagedFiles.filter(file => /\.svg$/.test(file.path));
+    for (let svg of svgs) {
+        if (!lintSVG(svg)) {
+            success = false;
+        }
+    }
+
+    process.exit(success ? 0 : 1);
+})();
+
+/**
+ * @typedef {Object} StagedFile
+ * @property {String} status  A single-letter status. See man git-diff --diff-filter
+ * @property {String} path  The relative path to the file
+ * @property {String} content  The full content of the staged file
+ */
+/**
+ * Gets currently staged files from Git
+ * Resolves to an array of StagedFile's
+ * @returns {Promise<Array<StagedFile>>}
+ */
+async function getStagedFiles() {
+    const filesStr = await execute("git diff --cached --name-status");
+    const files = filesStr
+        .trim().split("\n")
+        .map(fileStr => {
+            const match = /([A-Z])\s*([^\s]+)/.exec(fileStr);
+            if (!match) { return undefined; }
+            return {
+                status: match[1],
+                path: match[2],
+                content: undefined
+            };
+        })
+        .filter(Boolean);
+    
+    const filePromises = files
+        .map(async file => {
+            if (file.status === "D") { return file; }
+
+            file.content = await execute(`git show :${file.path}`);
+            return file;
+        });
+    
+    return Promise.all(filePromises);
+}
+
+/**
+ * Executes a shell command
+ * Resolves to stdout
+ * @returns {Promise<String>}
+ */
+function execute(command) {
+    return new Promise((res,rej)=>{
+        exec(command, (e, stdout)=>{
+            if (e) { return rej(e); }
+            res(stdout);
+        });
+    });
+}

--- a/tools/lint-svg
+++ b/tools/lint-svg
@@ -110,8 +110,6 @@ function extractChildren(elm) {
         return [];
     }
 
-    console.log("Extracting",elm);
-
     const children = elm.children
         .filter(elm => !elm.hasOwnProperty("text"))
         .reduce((elms, elm) => elms.concat(extractChildren(elm).concat(elm)), []);

--- a/tools/lint-svg
+++ b/tools/lint-svg
@@ -12,30 +12,25 @@ const inspect = value => util.inspect(value, {colors: true});
  * Should throw an error if it fails
  */
 const RULES = [
-    function viewBox(svg) {
-        const expected = "0 0 24 24";
-        if (svg.$.viewBox !== expected) {
-            throw new Error("Expected viewBox to be "+
-                inspect(expected)+
-                ", got "+
-                inspect(svg.$.viewBox));
-        }
-    },
-
     function rootAttributes(svg) {
-        const expected = ["xmlns", "viewBox", "aria-labelledby", "role"];
+        const expected = {
+            xmlns: "http://www.w3.org/2000/svg", 
+            viewBox: "0 0 24 24", 
+            "aria-labelledby": "title", 
+            role: "img"
+        };
         let msg = [];
-        
-        const expectedNotFound = expected.filter(attr => !svg.$.hasOwnProperty(attr));
-        if (expectedNotFound.length) {
-            msg.push(`Expected SVG attribute${expectedNotFound.length>1?"s":""} not found: `+
-                expectedNotFound.map(inspect));
+
+        for (let attr in expected) {
+            if (svg.$[attr] !== expected[attr]) {
+                msg.push(`Attribute ${chalk.bold(attr)} should be ${inspect(expected[attr])}, was ${inspect(svg.$[attr])}`);
+            }
         }
-        const unexpected = Object.keys(svg.$).filter(attr => !expected.includes(attr));
-        if (unexpected.length) {
-            msg.push(`Unexpected SVG attribute${unexpected.length>1?"s":""}: `+
-                unexpected.map(inspect));
-        }
+        Object.keys(svg.$)
+            .filter(attr => !expected.hasOwnProperty(attr))
+            .forEach(attr => {
+                msg.push(`Unexpected attribute ${chalk.bold(attr)}`);
+            });
 
         if (msg.length) {
             throw new Error(msg.join("\n"));

--- a/tools/lint-svg
+++ b/tools/lint-svg
@@ -19,21 +19,21 @@ const RULES = [
             "aria-labelledby": "title", 
             role: "img"
         };
-        let msg = [];
+        const msgs = [];
 
         for (let attr in expected) {
             if (svg.attr[attr] !== expected[attr]) {
-                msg.push(`Attribute ${chalk.bold(attr)} should be ${inspect(expected[attr])}, was ${inspect(svg.attr[attr])}`);
+                msgs.push(`SVG attribute ${chalk.bold(attr)} should be ${inspect(expected[attr])}, was ${inspect(svg.attr[attr])}`);
             }
         }
         Object.keys(svg.attr)
             .filter(attr => !expected.hasOwnProperty(attr))
             .forEach(attr => {
-                msg.push(`Attribute ${chalk.bold(attr)} should not exist`);
+                msgs.push(`SVG attribute ${chalk.bold(attr)} should not exist`);
             });
 
-        if (msg.length) {
-            throw new Error(msg.join("\n"));
+        if (msgs.length) {
+            throw new Error(msgs.join("\n"));
         }
     },
 
@@ -50,12 +50,42 @@ const RULES = [
         if (!title.val || !/icon$/.test(title.val)) {
             throw new Error(`${chalk.bold("<title>")} should have format ${inspect("[name] icon")}, was ${inspect(title.val)}`);
         }
+    },
+
+    function elementAttributes(svg) {
+        const children = extractChildren(svg);
+        const msgs = [];
+
+        const attrWhitelist = [
+            "cx", "cy", "r", // <circle>
+            "rx", "ry", // <ellipsis>
+            "x1", "x2", "y1", "y2", // <line>
+            "d", // <path>
+            "points", // <polygon>,
+            "x", "y", "width", "height", // <rect>
+        ];
+
+        for (let child of children) {
+            if (child.attr.hasOwnProperty("stroke")) {
+                msgs.push(`Attribute stroke should be converted to paths on ${chalk.bold("<"+child.name+">")}`);
+            }
+            for (let attr in child.attr) {
+                if (attr === "stroke") { continue; }
+                if (attrWhitelist.indexOf(attr) === -1) {
+                    msgs.push(`Attribute ${chalk.bold(attr)} should not exist on ${chalk.bold("<"+child.name+">")} (${child.line}:${child.column})`)
+                }
+            }
+        }
+
+        if (msgs.length) {
+            throw new Error(msgs.join("\n"));
+        }
     }
 ];
 
 function lintSVG(svgStr) {
     const svg = new XMLDoc(svgStr);
-
+    
     const messages = [];
     for (let rule of RULES) {
         try {
@@ -73,11 +103,15 @@ function lintSVG(svgStr) {
  * @returns {Array<Object>}
  */
 function extractChildren(elm) {
-    const children = Object.keys(elm)
-            .filter(tag => tag !== "$" && tag !== "_")
-            .reduce((elms,tag) => elms.concat(elm[tag]), [])
-            .map(child => child instanceof Array ? extractChildren(child) : child)
-            .concat(elm);
+    if (!elm.children || !elm.children.length) {
+        return [];
+    }
+
+    console.log("Extracting",elm);
+
+    const children = elm.children
+        .filter(elm => !elm.hasOwnProperty("text"))
+        .reduce((elms, elm) => elms.concat(extractChildren(elm).concat(elm)), []);
     
     return children;
 }

--- a/tools/lint-svg
+++ b/tools/lint-svg
@@ -57,12 +57,15 @@ const RULES = [
         const msgs = [];
 
         const attrWhitelist = [
+            "id",
             "cx", "cy", "r", // <circle>
             "rx", "ry", // <ellipsis>
             "x1", "x2", "y1", "y2", // <line>
             "d", // <path>
             "points", // <polygon>,
             "x", "y", "width", "height", // <rect>
+            "fx", "fy", "fr", // <radialGradient>
+            "stop-color", "offset", // <stop>
         ];
 
         for (let child of children) {

--- a/tools/lint-svg
+++ b/tools/lint-svg
@@ -23,13 +23,13 @@ const RULES = [
 
         for (let attr in expected) {
             if (svg.attr[attr] !== expected[attr]) {
-                msgs.push(`SVG attribute ${chalk.bold(attr)} should be ${inspect(expected[attr])}, was ${inspect(svg.attr[attr])}`);
+                msgs.push(`SVG attribute ${chalk.bold(attr)} is ${inspect(svg.attr[attr])}; should be ${inspect(expected[attr])}`);
             }
         }
         Object.keys(svg.attr)
             .filter(attr => !expected.hasOwnProperty(attr))
             .forEach(attr => {
-                msgs.push(`SVG attribute ${chalk.bold(attr)} should not exist`);
+                msgs.push(`SVG attribute ${chalk.bold(attr)} is unexpected`);
             });
 
         if (msgs.length) {
@@ -43,12 +43,12 @@ const RULES = [
             throw new Error(`${chalk.bold("<title>")} must exist`);
         }
         if (titles.length > 1) {
-            throw new Error(`${chalk.bold("<title>")} should exists once, found ${inspect(titles.length)}`);
+            throw new Error(`${chalk.bold("<title>")} should exist once, found ${inspect(titles.length)}`);
         }
 
         const title = titles[0];
         if (!title.val || !/icon$/.test(title.val)) {
-            throw new Error(`${chalk.bold("<title>")} should have format ${inspect("[name] icon")}, was ${inspect(title.val)}`);
+            throw new Error(`${chalk.bold("<title>")} is ${inspect(title.val)}, should have format ${inspect("[name] icon")}`);
         }
     },
 
@@ -75,7 +75,7 @@ const RULES = [
             for (let attr in child.attr) {
                 if (attr === "stroke") { continue; }
                 if (attrWhitelist.indexOf(attr) === -1) {
-                    msgs.push(`Attribute ${chalk.bold(attr)} should not exist on ${chalk.bold("<"+child.name+">")} (${child.line}:${child.column})`)
+                    msgs.push(`Attribute ${chalk.bold(attr)} is unexpected on ${chalk.bold("<"+child.name+">")} (${child.line}:${child.column})`)
                 }
             }
         }

--- a/tools/lint-svg
+++ b/tools/lint-svg
@@ -29,11 +29,26 @@ const RULES = [
         Object.keys(svg.attr)
             .filter(attr => !expected.hasOwnProperty(attr))
             .forEach(attr => {
-                msg.push(`Unexpected attribute ${chalk.bold(attr)}`);
+                msg.push(`Attribute ${chalk.bold(attr)} should not exist`);
             });
 
         if (msg.length) {
             throw new Error(msg.join("\n"));
+        }
+    },
+
+    function checkTitle(svg) {
+        const titles = svg.children.filter(elm => elm.name === "title");
+        if (titles.length === 0) {
+            throw new Error(`${chalk.bold("<title>")} must exist`);
+        }
+        if (titles.length > 1) {
+            throw new Error(`${chalk.bold("<title>")} should exists once, found ${inspect(titles.length)}`);
+        }
+
+        const title = titles[0];
+        if (!title.val || !/icon$/.test(title.val)) {
+            throw new Error(`${chalk.bold("<title>")} should have format ${inspect("[name] icon")}, was ${inspect(title.val)}`);
         }
     }
 ];

--- a/tools/lint-svg
+++ b/tools/lint-svg
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const xml2js = require("xml2js").parseString;
+const XMLDoc = require("xmldoc").XmlDocument;
 const chalk = require("chalk");
 const util = require("util");
 util.inspect.styles.string = "cyan";
@@ -22,11 +22,11 @@ const RULES = [
         let msg = [];
 
         for (let attr in expected) {
-            if (svg.$[attr] !== expected[attr]) {
-                msg.push(`Attribute ${chalk.bold(attr)} should be ${inspect(expected[attr])}, was ${inspect(svg.$[attr])}`);
+            if (svg.attr[attr] !== expected[attr]) {
+                msg.push(`Attribute ${chalk.bold(attr)} should be ${inspect(expected[attr])}, was ${inspect(svg.attr[attr])}`);
             }
         }
-        Object.keys(svg.$)
+        Object.keys(svg.attr)
             .filter(attr => !expected.hasOwnProperty(attr))
             .forEach(attr => {
                 msg.push(`Unexpected attribute ${chalk.bold(attr)}`);
@@ -38,8 +38,8 @@ const RULES = [
     }
 ];
 
-async function lintSVG(svgStr) {
-    const svg = (await parseXML(svgStr)).svg;
+function lintSVG(svgStr) {
+    const svg = new XMLDoc(svgStr);
 
     const messages = [];
     for (let rule of RULES) {
@@ -53,19 +53,18 @@ async function lintSVG(svgStr) {
 }
 
 /**
- * Parses an XML string to a JS object
- * @param {String} xmlStr  The XML string
- * @returns {Promise<Object>}
+ * Gets all children of an element. The resulting array is flat
+ * @param {Object} elm
+ * @returns {Array<Object>}
  */
-function parseXML(xmlStr) {
-    return new Promise((res,rej)=>{
-        xml2js(xmlStr, (err, result)=>{
-            if (err) {
-                return rej(err);
-            }
-            res(result);
-        });
-    });
+function extractChildren(elm) {
+    const children = Object.keys(elm)
+            .filter(tag => tag !== "$" && tag !== "_")
+            .reduce((elms,tag) => elms.concat(elm[tag]), [])
+            .map(child => child instanceof Array ? extractChildren(child) : child)
+            .concat(elm);
+    
+    return children;
 }
 
 module.exports = async (name, content) => {

--- a/tools/lint-svg
+++ b/tools/lint-svg
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+const xml2js = require("xml2js").parseString;
+const chalk = require("chalk");
+const util = require("util");
+util.inspect.styles.string = "cyan";
+util.inspect.styles.regexp = "grey";
+const inspect = value => util.inspect(value, {colors: true});
+
+/**
+ * All the rules we use for SVG linting
+ * Are given a single argument, the parsed SVG object
+ * Should throw an error if it fails
+ */
+const RULES = [
+    function viewBox(svg) {
+        const expected = "0 0 24 24";
+        if (svg.$.viewBox !== expected) {
+            throw new Error("Expected viewBox to be "+
+                inspect(expected)+
+                " got "+
+                inspect(svg.$.viewBox));
+        }
+    }
+];
+
+async function lintSVG(svgStr) {
+    const svg = (await parseXML(svgStr)).svg;
+
+    const messages = [];
+    for (let rule of RULES) {
+        try {
+            rule(svg);
+        } catch (e) {
+            messages.push(e.message);
+        }
+    }
+    return messages;
+}
+
+/**
+ * Parses an XML string to a JS object
+ * @param {String} xmlStr  The XML string
+ * @returns {Promise<Object>}
+ */
+function parseXML(xmlStr) {
+    return new Promise((res,rej)=>{
+        xml2js(xmlStr, (err, result)=>{
+            if (err) {
+                return rej(err);
+            }
+            res(result);
+        });
+    });
+}
+
+module.exports = async (name, content) => {
+    const messages = await lintSVG(content);
+    if (messages.length) {
+        console.log(chalk.red(`✖ ${name}`));
+        for (let msg of messages) {
+            console.log(`    ${chalk.red(msg)}`);
+        }
+    } else {
+        console.log(chalk.green(`✔ ${name}`));
+    }
+    return !messages.length;
+};
+if (require.main === module) {
+    // TODO: get file paths from argv and lint them
+}

--- a/tools/lint-svg
+++ b/tools/lint-svg
@@ -132,5 +132,12 @@ module.exports = async (name, content) => {
     return !messages.length;
 };
 if (require.main === module) {
-    // TODO: get file paths from argv and lint them
+    (async function(){
+        const [,, ...files] = process.argv;
+        const fs = require("fs");
+        for (let file of files) {
+            const content = fs.readFileSync(file);
+            await module.exports(file, content);
+        }
+    })();
 }

--- a/tools/lint-svg
+++ b/tools/lint-svg
@@ -17,8 +17,28 @@ const RULES = [
         if (svg.$.viewBox !== expected) {
             throw new Error("Expected viewBox to be "+
                 inspect(expected)+
-                " got "+
+                ", got "+
                 inspect(svg.$.viewBox));
+        }
+    },
+
+    function rootAttributes(svg) {
+        const expected = ["xmlns", "viewBox", "aria-labelledby", "role"];
+        let msg = [];
+        
+        const expectedNotFound = expected.filter(attr => !svg.$.hasOwnProperty(attr));
+        if (expectedNotFound.length) {
+            msg.push(`Expected SVG attribute${expectedNotFound.length>1?"s":""} not found: `+
+                expectedNotFound.map(inspect));
+        }
+        const unexpected = Object.keys(svg.$).filter(attr => !expected.includes(attr));
+        if (unexpected.length) {
+            msg.push(`Unexpected SVG attribute${unexpected.length>1?"s":""}: `+
+                unexpected.map(inspect));
+        }
+
+        if (msg.length) {
+            throw new Error(msg.join("\n"));
         }
     }
 ];
@@ -58,7 +78,9 @@ module.exports = async (name, content) => {
     if (messages.length) {
         console.log(chalk.red(`✖ ${name}`));
         for (let msg of messages) {
-            console.log(`    ${chalk.red(msg)}`);
+            console.log(msg.split("\n")
+                .map(msg => `    ${chalk.red(msg)}`)
+                .join("\n"));
         }
     } else {
         console.log(chalk.green(`✔ ${name}`));


### PR DESCRIPTION
Fixes #485. Adds two tools:

- `lint-staged` which lints all currently staged files (ran by precommit Git hook)
- `lint-svg` which lints SVG files in accordance to CONTRIBUTING.md

Also adds `lint-staged` as precommit hook. This means that you can't commit SVG files that aren't up to our standards (unless you force it to).

The linters can be run manually from the command line (e.g. `tools/lint-svg icons/*`), or as NodeJS modules. A future PR could add a CI to run it on all pull requests.

Note that you must run `npm install` to install the dev dependencies (including the precommit hook).