### PR TITLE
Use dark color icons/text on light backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,9 +78,9 @@
     {% endif %}
     {% assign luminance = lRed | plus: lGreen | plus: lBlue %}
     {% if luminance >= 0.83 %}
-        {% assign class = "dark" %}
+        {% assign class = "grid-item--dark" %}
     {% else %}
-        {% assign class = "light" %}
+        {% assign class = "grid-item--light" %}
     {% endif %}
 
     {% assign hslLuminance = rgbMax | plus: rgbMin | times: 50.0 %}
@@ -177,25 +177,9 @@
         }
 
         svg {
+            fill: currentColor;
             height: 1.5rem;
             width: 1.5rem;
-        }
-
-        .grid-item.light path,
-        .grid-item.light rect,
-        .grid-item.light circle,
-        .grid-item.light h2,
-        .grid-item.light p {
-            color: #FFF;
-            fill: #FFF;
-        }
-        .grid-item.dark path,
-        .grid-item.dark rect,
-        .grid-item.dark circle,
-        .grid-item.dark h2,
-        .grid-item.dark p {
-            color: #000;
-            fill: #000;
         }
 
         #carbonads {
@@ -376,6 +360,15 @@
             background-color: #757575;
             text-align: center;
         }
+        .grid-item--light {
+            color: #FFF;
+        }
+        .grid-item--dark {
+            color: #000;
+        }
+        .grid-item__link {
+            color: inherit;
+        }
         @supports not (display: grid) {
             .grid-item {
                 border: 0.1875rem solid #FFF;
@@ -402,7 +395,6 @@
         }
 
         .grid-item__link {
-            color: #FFFFFF;
             display: block;
             padding: 1rem 1rem 0;
             text-align: center;
@@ -425,7 +417,6 @@
         }
 
         .grid-item__subtitle {
-            color: #FFFFFF;
             font-size: 0.75rem;
             line-height: 1rem;
             margin: 0;

--- a/index.html
+++ b/index.html
@@ -60,6 +60,32 @@
     {% if rgbBlue < rgbMin %}
         {% assign rgbMin = rgbBlue %}
     {% endif %}
+
+
+    {% if rgbRed <= 0.03928 %}
+        {% assign lRed = rgbRed | divided_by: 12.92 | times: 0.2126 %}
+    {% else %}
+      {% assign lRed = rgbRed | times: 0.3053 | plus: 0.6822 | times: rgbRed | plus: 0.0125 | times: rgbRed | times: 0.2126 %}
+    {% endif %}
+    {% if rgbGreen <= 0.03928 %}
+        {% assign lGreen = rgbGreen | divided_by: 12.92 | times: 0.7152 %}
+    {% else %}
+        {% assign lGreen = rgbGreen | times: 0.3053 | plus: 0.6822 | times: rgbGreen | plus: 0.0125 | times: rgbGreen | times: 0.7152 %}
+    {% endif %}
+    {% if rgbBlue <= 0.03928 %}
+        {% assign lBlue = rgbBlue | divided_by: 12.92 | times: 0.0722 %}
+    {% else %}
+        {% assign lBlue = rgbBlue | times: 0.3053 | plus: 0.6822 | times: rgbBlue | plus: 0.0125 | times: rgbBlue | times: 0.0722 %}
+    {% endif %}
+    {% assign L = lRed | plus: lGreen | plus: lBlue %}
+
+    {% if L >= 0.6 %}
+        {% assign class = "dark" %}
+    {% else %}
+        {% assign class = "light" %}
+    {% endif %}
+
+
     {% assign hslLuminance = rgbMax | plus: rgbMin | times: 50.0 %}
     {% assign rgbDelta = rgbMax | minus: rgbMin %}
     {% if rgbDelta == 0 %}
@@ -84,10 +110,10 @@
     {% endif %}
     {% if hslSaturation < 10 %}
         {% assign hslLuminance = hslLuminance | round: 0 | prepend: "000" | slice: -3, 3 %}
-        {% capture greyscaleIconsUnsortedString %}{{ greyscaleIconsUnsortedString }}{{ hslLuminance }},{{ filename }},{{ hslHue }},{{ hslSaturation }},{{ hex }},{{ title }}{% unless forloop.last %};{% endunless %}{% endcapture %}
+        {% capture greyscaleIconsUnsortedString %}{{ greyscaleIconsUnsortedString }}{{ hslLuminance }},{{ filename }},{{ hslHue }},{{ hslSaturation }},{{ hex }},{{ title }},{{ class }},{{ L }}{% unless forloop.last %};{% endunless %}{% endcapture %}
     {% else %}
         {% assign hslHue = hslHue | round: 0 | prepend: "000" | slice: -3, 3 %}
-        {% capture iconsUnsortedString %}{{ iconsUnsortedString }}{{ hslHue }},{{ hslSaturation }},{{ hslLuminance }},{{ filename }},{{ hex }},{{ title }}{% unless forloop.last %};{% endunless %}{% endcapture %}
+        {% capture iconsUnsortedString %}{{ iconsUnsortedString }}{{ hslHue }},{{ hslSaturation }},{{ hslLuminance }},{{ filename }},{{ hex }},{{ title }},{{ class }},{{ L }}{% unless forloop.last %};{% endunless %}{% endcapture %}
     {% endif %}
 {% endfor %}
 {% assign iconsArray = iconsUnsortedString | split: ";" %}
@@ -158,8 +184,21 @@
             width: 1.5rem;
         }
 
-        path, rect, circle {
+        .grid-item.light path,
+        .grid-item.light rect,
+        .grid-item.light circle,
+        .grid-item.light h2,
+        .grid-item.light p {
+            color: #FFF;
             fill: #FFF;
+        }
+        .grid-item.dark path,
+        .grid-item.dark rect,
+        .grid-item.dark circle,
+        .grid-item.dark h2,
+        .grid-item.dark p {
+            color: #000;
+            fill: #000;
         }
 
         #carbonads {
@@ -461,7 +500,7 @@
             </li>
             {% for icon in iconsArray %}
                 {% assign iconArray = icon | split: "," %}
-                <li class="grid-item" style="background-color: #{{ iconArray[4] }}">
+                <li class="grid-item {{ iconArray[6] }}" style="background-color: #{{ iconArray[4] }}">
                     <a class="grid-item__link" href="/icons/{{ iconArray[3] }}.svg" download>
                         {% assign filePath = iconArray[3] | prepend: "icons/" | append: ".svg" %}
                         {% include_relative {{ filePath }} %}
@@ -472,7 +511,7 @@
             {% endfor %}
             {% for icon in greyscaleIconsArray %}
                 {% assign iconArray = icon | split: "," %}
-                <li class="grid-item" style="background-color: #{{ iconArray[4] }}">
+                <li class="grid-item {{ iconArray[6] }}" style="background-color: #{{ iconArray[4] }}">
                     <a class="grid-item__link" href="/icons/{{ iconArray[1] }}.svg" download>
                         {% assign filePath = iconArray[1] | prepend: "icons/" | append: ".svg" %}
                         {% include_relative {{ filePath }} %}

--- a/index.html
+++ b/index.html
@@ -61,7 +61,6 @@
         {% assign rgbMin = rgbBlue %}
     {% endif %}
 
-
     {% if rgbRed <= 0.03928 %}
         {% assign lRed = rgbRed | divided_by: 12.92 | times: 0.2126 %}
     {% else %}
@@ -77,14 +76,12 @@
     {% else %}
         {% assign lBlue = rgbBlue | times: 0.3053 | plus: 0.6822 | times: rgbBlue | plus: 0.0125 | times: rgbBlue | times: 0.0722 %}
     {% endif %}
-    {% assign L = lRed | plus: lGreen | plus: lBlue %}
-
-    {% if L >= 0.6 %}
+    {% assign luminance = lRed | plus: lGreen | plus: lBlue %}
+    {% if luminance >= 0.83 %}
         {% assign class = "dark" %}
     {% else %}
         {% assign class = "light" %}
     {% endif %}
-
 
     {% assign hslLuminance = rgbMax | plus: rgbMin | times: 50.0 %}
     {% assign rgbDelta = rgbMax | minus: rgbMin %}
@@ -110,10 +107,10 @@
     {% endif %}
     {% if hslSaturation < 10 %}
         {% assign hslLuminance = hslLuminance | round: 0 | prepend: "000" | slice: -3, 3 %}
-        {% capture greyscaleIconsUnsortedString %}{{ greyscaleIconsUnsortedString }}{{ hslLuminance }},{{ filename }},{{ hslHue }},{{ hslSaturation }},{{ hex }},{{ title }},{{ class }},{{ L }}{% unless forloop.last %};{% endunless %}{% endcapture %}
+        {% capture greyscaleIconsUnsortedString %}{{ greyscaleIconsUnsortedString }}{{ hslLuminance }},{{ filename }},{{ hslHue }},{{ hslSaturation }},{{ hex }},{{ title }},{{ class }}{% unless forloop.last %};{% endunless %}{% endcapture %}
     {% else %}
         {% assign hslHue = hslHue | round: 0 | prepend: "000" | slice: -3, 3 %}
-        {% capture iconsUnsortedString %}{{ iconsUnsortedString }}{{ hslHue }},{{ hslSaturation }},{{ hslLuminance }},{{ filename }},{{ hex }},{{ title }},{{ class }},{{ L }}{% unless forloop.last %};{% endunless %}{% endcapture %}
+        {% capture iconsUnsortedString %}{{ iconsUnsortedString }}{{ hslHue }},{{ hslSaturation }},{{ hslLuminance }},{{ filename }},{{ hex }},{{ title }},{{ class }}{% unless forloop.last %};{% endunless %}{% endcapture %}
     {% endif %}
 {% endfor %}
 {% assign iconsArray = iconsUnsortedString | split: ";" %}

--- a/index.html
+++ b/index.html
@@ -364,7 +364,7 @@
             color: #FFF;
         }
         .grid-item--dark {
-            color: #000;
+            color: #222;
         }
         .grid-item__link {
             color: inherit;


### PR DESCRIPTION
Implements the feature specified in #480

It is using [this formula](https://www.w3.org/TR/WCAG20/#relativeluminancedef) for relative luminance combined with [this approximation](http://chilliant.blogspot.nl/2012/08/srgb-approximations-for-hlsl.html) to find the contrast ratio between the background (which is the brand color) and white (the default color of the icon/text). If this value, which is between 0 and 1, is to high it will make sure the brand icon, brand name and hex-value of the color are displayed in black (currently `#000`) instead of the current default white.
The color change is achieved by adding a class to the `li.grid-item`, either `.dark` or `.light`.

