### PR TITLE
Add Json validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ Temporary Items
 *.css.map
 
 # End of https://www.gitignore.io/api/sass,macos,jekyll
+
+
+# NPM dependencies
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - "6"
+
+script:
+  - npm run jsonlint
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -4,7 +4,7 @@
             "title": "500px",
             "hex": "0099E5",
             "source": "https://about.500px.com/press"
-        }
+        },
         {
             "title": "About.me",
             "hex": "044A75",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -4,7 +4,7 @@
             "title": "500px",
             "hex": "0099E5",
             "source": "https://about.500px.com/press"
-        },
+        }
         {
             "title": "About.me",
             "hex": "044A75",

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   "license": "CCO",
   "devDependencies": {
     "jsonlint": "^1.6.2"
+  },
+  "scripts": {
+    "jsonlint": "jsonlint _data/simple-icons.json -q"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "main": "_data/simple-icons.json",
   "repository": "git@github.com:danleech/simple-icons.git",
   "author": "Dan Leech",
-  "license": "CCO"
+  "license": "CCO",
+  "devDependencies": {
+    "jsonlint": "^1.6.2"
+  }
 }


### PR DESCRIPTION
In response to #521, I added a JSON validator to validate the validity of `_data/simple-icons.json` that could/should be used with Continuous Integration (currently configured for [Travis CI](https://travis-ci.org/), but we could change to e.g. [CircleCI](https://circleci.com/) or [AppVeyor](https://www.appveyor.com/)). You can see it effects [here](https://github.com/ericcornelissen/simple-icons/commits/json-validator) or in the screenshot below (I intentionally made a commit with an incorrect .json file)
![preview](https://user-images.githubusercontent.com/3742559/30369641-81b9d962-9875-11e7-827f-276ec01f1b27.png)


I used [jsonlint](https://www.npmjs.com/package/jsonlint) for this, which I added as a `devDependency` to the project in `package.json`. To make it easier to use I also added a npm script called jsonlint which automatically lints `_data/simple-icons.json` (without this script the command would have to look something like `node_modules/.bin/jsonlint _data/simple-icons.json -q` in case jsonlint is not available globally).

In the future we could even make use of JSON Schemes (which jsonlint supports :+1:) to enforce e.g. certain data types on certain fields. You can find out more [here](http://json-schema.org/) and [here](https://spacetelescope.github.io/understanding-json-schema/).