### PR TITLE
add main file for npm

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,0 +1,11 @@
+const SimpleIcons = require('./');
+
+console.log(SimpleIcons['500px'].svg);
+
+/*
+{ title: '500px',
+  hex: '0099E5',
+  source: 'https://about.500px.com/press',
+  name: '500px',
+  svg: '<svg aria-labelledby="simpleicons-500px-icon" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">...</svg>' }
+*/

--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+const dataFile = './_data/simple-icons.json';
+const data = require(dataFile);
+const fs = require('fs');
+
+let Icons = {};
+
+data.icons.forEach(i => {
+  i.name = i.title.toLowerCase().replace(/[^a-z0-9]/gim, '');
+  i.svg = fs.readFileSync(`./icons/${i.name}.svg`, 'utf8');
+  Icons[i.name] = i
+});
+
+module.exports = Icons;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "svg",
     "icons"
   ],
-  "main": "_data/simple-icons.json",
+  "main": "index.js",
   "repository": "git@github.com:danleech/simple-icons.git",
   "author": "Dan Leech",
   "license": "CCO",


### PR DESCRIPTION
makes is possible to import all icons with the SVG content, see example.js for usage
Discussion at https://github.com/simple-icons/simple-icons/pull/446

**Usage:**
```
const SimpleIcons = require('simple-icons');

console.log(SimpleIcons['500px'].svg);

/*
{ title: '500px',
  hex: '0099E5',
  source: 'https://about.500px.com/press',
  name: '500px',
  svg: '<svg aria-labelledby="simpleicons-500px-icon" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">...</svg>' }
*/

```