### PR TITLE
Push footer to bottom of the page

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,7 @@
 
         :root {
             font-size: 100%;
+            height: 100%;
         }
 
         a {
@@ -172,9 +173,12 @@
 
         body {
             background-color: #FFFFFF;
+            display: flex;
+            flex-direction: column;
             color: #263238;
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
             font-size: 0.875rem;
+            height: 100%;
             line-height: 1.5rem;
             margin: 0;
         }
@@ -222,6 +226,7 @@
 
         .footer {
             background-color: #EEE;
+            margin-top: auto;
             padding: 1.5rem;
         }
         @media (min-width: 45rem) {


### PR DESCRIPTION
Now the `<footer>` is pushed to the bottom of the page when the icons don't fill up the screen.

(background color changed only in screenshots for clarity)

**Before:** 
![before](https://user-images.githubusercontent.com/3742559/30522566-7dd4702c-9bd2-11e7-9655-31372a475d40.png)

**After:**
![after](https://user-images.githubusercontent.com/3742559/30522565-7b88322c-9bd2-11e7-99cc-92956d5109b0.png)

