### PR TITLE
Add bower.json to allow publishing on Bower.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,14 @@ Icons can be downloaded as SVGs directly from [our website](https://simpleicons.
 
 ### Node Usage
 
-The icons are also available through our npm package. To install, simply run:
+The icons are also available through our npm and bower packages. To install, simply run:
 
-```
+```bash
+# For npm
 $ npm install simple-icons
+
+# For Bower
+$ bower install simple-icons
 ```
 
 The API can then be used as follows:

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "simple-icons",
   "version": "1.2.7",
   "description": "SVG icons for popular brands https://simpleicons.org",
-  "homepage": "https://www.simpleicons.org",
+  "homepage": "https://simpleicons.org",
   "license": "CC0",
   "author": "Simple Icons Collaborators",
   "main": "index.js",
@@ -14,13 +14,15 @@
     "type": "git",
     "url": "git+ssh://git@github.com/simple-icons/simple-icons.git"
   },
-  "bugs": {
-    "url": "https://github.com/simple-icons/simple-icons/issues"
-  },
   "devDependencies": {
     "jsonlint": "^1.6.2"
   },
-  "scripts": {
-    "jsonlint": "jsonlint _data/simple-icons.json -q -V .jsonlintschema"
-  }
+  "ignore": [
+    "images/",
+    ".*",
+    "CNAME",
+    "CONTRIBUTING.md",
+    "index.html",
+    "package.json"
+  ]
 }


### PR DESCRIPTION
As requested in #387, when merged to `master` we can publish to [bower.io](https://bower.io/)

Added a `bower.json` file based on the existing `package.json` and `.npmignore` (see the ignore section). Also changed the order of the keys in `package.json`

/cc @timgluz