### PR TITLE
Make docs more "casual"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,6 @@ The final icon should:
   * This means the icon should be touching at least two sides of the viewbox.
 * Be vertically and horizontally centered.
 * Be minified to a single line with no formatting.
-* Contain only one single path.
 * Not contain extraneous attributes.
   * This includes: `width`, `height`, `fill`, `stroke`, `clip`, `font`, etc.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,19 +11,18 @@ Simple Icons welcomes contributions and corrections. Before contributing, please
 
 ## Requesting An Icon
 
-We welcome icon requests. However, before you submit a new issue please make sure the icon:
+We welcome icon requests, before you submit a new issue please make sure the icon:
 
 * Is of a _popular_ brand.
 * Has not already been requested.
-* Can be represented in a monochromatic format.
 
-When submitting a request for a new or updated icon, please submit the issue with the following information:
+When submitting a request for a new or updated icon include helpful information such as:
 
-* **Issue Title:** Include the brand name. For example:
+* **Issue Title:** The brand name. For example:
   * New Icons: `Request: GitHub Icon`
   * Icon Updates: `Update: GitHub Color` or `Update: GitHub Icon`
 
-* **Issue Body:** Include links to official sources for the brand's icon and official colors (e.g. media kits, brand guidelines, SVG files etc.)
+* **Issue Body:** Links to official sources for the brand's icon and colors (e.g. media kits, brand guidelines, SVG files etc.)
 
 ## Adding or Updating An Icon
 
@@ -138,7 +137,7 @@ Here is the object for the Adobe Photoshop icon as an example:
 
 ## Labeling Issues
 
-We use several labels to help organize and identify issues. Here's what they represent and how we use them:
+We use several labels to help organize and identify issues. You can find all labels [here](https://github.com/simple-icons/simple-icons/labels). Here's what they represent and how we use them:
 
 | Label Name | Description |
 | :---- | :---- |
@@ -147,8 +146,6 @@ We use several labels to help organize and identify issues. Here's what they rep
 | [good first issue](https://github.com/simple-icons/simple-icons/labels/good%20first%20issue) | Issues we believe are simple and a good first stab at contributing to the project. |
 | [help wanted](https://github.com/simple-icons/simple-icons/labels/help%20wanted) | Issues we would like help from the community to resolve. |
 | [awaiting reply](https://github.com/simple-icons/simple-icons/labels/awaiting%20reply) | Issues awaiting reply from an individual (issue author or 3rd party) before it may be addressed. |
-
-See all the issue labels [here](https://github.com/simple-icons/simple-icons/labels).
 
 ## Building Locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Simple Icons welcomes contributions and corrections. Before contributing, please
 
 ## Requesting An Icon
 
-We welcome icon requests, before you submit a new issue please make sure the icon:
+We welcome icon requests. Before you submit a new issue please make sure the icon:
 
 * Is of a _popular_ brand.
 * Has not already been requested.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
-Before opening a new issue, please search for duplicate or closed issues.
+Before opening a new issue search for duplicate or closed issues.
 
-When requesting a new or updated icon, please include:
-* The requested icon’s brand name in the title. Example: Request: GitHub Icon
-* Links to official sources for the brand's icon and official colors (e.g. media kits, brand guidelines, SVG files etc.)
+When requesting a new or updated icon include helpful information such as:
+* The requested icon’s brand name, preferably in the title.
+* Links to official sources for the brand's icon and colors (e.g. media kits, brand guidelines, SVG files etc.)

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 Before opening a new issue search for duplicate or closed issues.
 
 When requesting a new or updated icon include helpful information such as:
-* The requested icon’s brand name, preferably in the title.
-* Links to official sources for the brand's icon and colors (e.g. media kits, brand guidelines, SVG files etc.)
+* The requested icon’s brand name in the title.
+* Links to official sources for the brand's icon and colors (e.g. media kits, brand guidelines, SVG files etc.).


### PR DESCRIPTION
Small update to the changes #640 and d9f180d to make both the Contributing Guidelines and Issue Template a bit more casual/friendly/inviting as suggested by @birjolaxew ([ref](https://github.com/simple-icons/simple-icons/pull/640#pullrequestreview-69704075)):

> ... There could also be a point in thinking about how the rules are worded (e.g. instead of please make sure the issue includes ..., a more casual it'd help if your issue includes ... might be more welcoming)

I welcome any feedback to these changes, as they can probably be improved/are not complete!
