### PR TITLE
Fix for issue #651 "Cut off footer"

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,6 +232,7 @@
         @media (min-width: 45rem) {
             .footer {
                 display: flex;
+                align-items: center;
                 justify-content: space-between;
                 padding: 3rem;
           }


### PR DESCRIPTION
It looks like there was an issue with `<main>` taking up too much space when filled out by all the icons.
 
When I used the search/filter input to reduce the visible icons the issue eventually resolves itself when there's enough room.

I've added `align-items: center` to the `.footer` rule and it's all good now, on the tested browsers.
- Chrome v61
- Safari v11
- Opera v48
- Firefox v56