### PR TITLE
Update TripAdvisor teal

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1667,8 +1667,8 @@
         },
         {
             "title": "TripAdvisor",
-            "hex": "589442",
-            "source": "http://www.tripadvisor.co.uk/PressCenter"
+            "hex": "00AF87",
+            "source": "https://tripadvisor.mediaroom.com/download/TripAdvisor_Logo_Guidelines_5_15_17.pdf"
         },
         {
             "title": "Trulia",


### PR DESCRIPTION
#616 
The TripAdvisor logo is now teal instead of green