### PR TITLE
Fix grid item overflow due to text

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,7 +349,7 @@
             .grid {
                 display: grid;
                 grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
-                grid-auto-rows: 6.25rem;
+                grid-auto-rows: min-content;
                 grid-column-gap: 0.375rem;
                 grid-row-gap: 0.375rem;
                 grid-auto-flow: dense;
@@ -423,8 +423,6 @@
             font-weight: 400;
             line-height: 1rem;
             margin: 0;
-            overflow: hidden;
-            text-overflow: ellipsis;
         }
 
         .grid-item__subtitle {

--- a/index.html
+++ b/index.html
@@ -349,7 +349,7 @@
             .grid {
                 display: grid;
                 grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
-                grid-auto-rows: 6rem;
+                grid-auto-rows: 6.25rem;
                 grid-column-gap: 0.375rem;
                 grid-row-gap: 0.375rem;
                 grid-auto-flow: dense;
@@ -367,6 +367,10 @@
 
         .grid-item {
             background-color: #757575;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            padding: 1rem;
             text-align: center;
         }
         .grid-item--light {
@@ -405,7 +409,6 @@
 
         .grid-item__link {
             display: block;
-            padding: 1rem 1rem 0;
             text-align: center;
             width: 100%;
         }
@@ -422,7 +425,6 @@
             margin: 0;
             overflow: hidden;
             text-overflow: ellipsis;
-            white-space: nowrap;
         }
 
         .grid-item__subtitle {


### PR DESCRIPTION
Closes #682 

Solved the grid overflow bug by allowing for wrapping in grid item titles, and centering the contents of grid-items using flexbox. Also slightly increased the size of grid-items.
Note that this solution only works properly as long as titles don't get longer than two lines, which I don't expect to happen 🙂 

@rosslh can you confirm if this solves the problem on Ubuntu as well?