### PR TITLE
Update MailChimp, ProtonMail and VueJS color

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1272,7 +1272,7 @@
         },
         {
             "title": "ProtonMail",
-            "hex": "9596C6",
+            "hex": "8B89CC",
             "source": "https://protonmail.com/media-kit"
         },
         {
@@ -1792,7 +1792,7 @@
         },
         {
             "title": "Vue.js",
-            "hex": "41B883",
+            "hex": "4FC08D",
             "source": "https://github.com/vuejs/art"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -922,7 +922,7 @@
         },
         {
             "title": "MailChimp",
-            "hex": "2C9AB7",
+            "hex": "239AB9",
             "source": "http://mailchimp.com/about/brand-assets"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1792,7 +1792,7 @@
         },
         {
             "title": "Vue.js",
-            "hex": "4FC08D",
+            "hex": "41B883",
             "source": "https://github.com/vuejs/art"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1272,7 +1272,7 @@
         },
         {
             "title": "ProtonMail",
-            "hex": "9497CE",
+            "hex": "9596C6",
             "source": "https://protonmail.com/media-kit"
         },
         {


### PR DESCRIPTION
As per #616 

- The old color of ProtonMail was slightly off, I picked the color from [the purple logo](https://protonmail.com/images/media/logos/protonmail-logo-dark.svg) on the media kit page
- ~~The color of VueJS was also slightly off as well, I extracted the new color from [the png version of the logo](https://github.com/vuejs/art/blob/master/logo.png)~~
- Same for MailChimp, I picked the color most similar to the old color on their [Brand Assets page](https://mailchimp.com/about/brand-assets/)