### PR TITLE
Fix Yandex and Y Combinator icons

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1723,7 +1723,7 @@
         {
             "title": "Ubuntu",
             "hex": "E95420",
-            "source": "https://insights.ubuntu.com/press-centre"
+            "source": "https://design.ubuntu.com/brand/ubuntu-logo/"
         },
         {
             "title": "Udacity",
@@ -1878,7 +1878,7 @@
         {
             "title": "Xing",
             "hex": "005A5F",
-            "source": "https://worldvectorlogo.com/logo/xing-icon"
+            "source": "https://dev.xing.com/logo_rules"
         },
         {
             "title": "Y Combinator",
@@ -1918,7 +1918,7 @@
         {
             "title": "Zendesk",
             "hex": "03363D",
-            "source": "https://www.zendesk.com"
+            "source": "https://www.zendesk.com/company/brand-assets/#logo"
         },
         {
             "title": "Zerply",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1897,7 +1897,7 @@
         },
         {
             "title": "Yandex",
-            "hex": "FF0000",
+            "hex": "DA3332",
             "source": "https://yandex.com/company/general_info/logotype_rules"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1882,7 +1882,7 @@
         },
         {
             "title": "Y Combinator",
-            "hex": "F0652F",
+            "hex": "E15D29",
             "source": "https://www.ycombinator.com/press/"
         },
         {


### PR DESCRIPTION
Since the colors are not specified in their webpage, I just downloaded the assets and open them up to get the correct color code.

Also added update to the soruce of Ubuntu, Zendesk, and XING

Part of #616 