### PR TITLE
[WIP] better npm package support for browser 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,13 @@ Icons can be served from a CDN such as [JSDelivr](https://www.jsdelivr.com/packa
 The icons are also available through our npm package. To install, simply run:
 
 ```
-$ npm install simple-icons
+$ npm install --save simple-icons
 ```
 
-The API can then be used as follows:
+In a NodeJS environment the API can be used as follows:
 
 ```javascript
 const simpleIcons = require('simple-icons');
-
 console.log(simpleIcons['Google+']);
 
 /*
@@ -43,6 +42,22 @@ console.log(simpleIcons['Google+']);
     hex: 'DC4E41',
     source: 'https://developers.google.com/+/branding-guidelines',
     svg: '<svg aria-labelledby="simpleicons-googleplus-icon" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">...</svg>'
+}
+*/
+```
+
+In a browser the API can be used as follows:
+
+```javascript
+const simpleIcons = require('simple-icons');
+console.log(simpleIcons['Google+']);
+
+/*
+{
+    title: 'Google+',
+    hex: 'DC4E41',
+    source: 'https://developers.google.com/+/branding-guidelines',
+    svg: 'https://unpkg.com/simple-icons@latest/icons/googleplus.svg'
 }
 */
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,4 @@
-const dataFile = './_data/simple-icons.json';
-const data = require(dataFile);
-const fs = require('fs');
+const data = require('./_data/simple-icons.json');
 
 const icons = {};
 

--- a/index.js
+++ b/index.js
@@ -8,8 +8,15 @@ data.icons.forEach(i => {
   const filename = i.title.toLowerCase()
     .replace(/\+/g, "plus")
     .replace(/[ .\-!’]/g, '');
-  i.svg = fs.readFileSync(`${__dirname}/icons/${filename}.svg`, 'utf8');
-  icons[i.title] = i
+
+  if (typeof window !== 'undefined') {
+    i.svg = `https://unpkg.com/simple-icons@latest/icons/${filename}.svg`;
+  } else {
+    const fs = require('fs');
+    i.svg = fs.readFileSync(`${__dirname}/icons/${filename}.svg`, 'utf8');
+  }
+
+  icons[i.title] = i;
 });
 
 module.exports = icons;


### PR DESCRIPTION
I decided to quickly implement a solution I came up with for #751. I simply check if the script is being run in a browser and depending on that change what value is set for the `svg` key for each icon. The SVG source in a Node environment and a unpkg.com url in a browser.

:warning: Before this is merged, I believe it needs some more testing. I only did two quick tests 1) in the latest Mozilla Firefox browser with a script transpiled using webpack/babel, and 2) in a simple node example. :warning: