### PR TITLE
Replace jsonlint by jsonlint2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Simple Icons Collaborators",
   "license": "CC0",
   "devDependencies": {
-    "jsonlint": "^1.6.2"
+    "jsonlint2": "^1.7.1"
   },
   "scripts": {
     "jsonlint": "jsonlint _data/simple-icons.json -q -V .jsonlintschema"


### PR DESCRIPTION
[jsonlint2](https://www.npmjs.com/package/jsonlint2) is a fork of [jsonlint](https://www.npmjs.com/package/jsonlint) that is still being updated. Relevant discussion: https://github.com/zaach/jsonlint/pull/105