### PR TITLE
Add Disroot logo to json data

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -386,6 +386,11 @@
             "source": "https://www.discovernetwork.com/en-us/business-resources/free-signage-logos"
         },
         {
+            "title": "Disroot",
+            "hex": "50162D",
+            "source": "https://git.fosscommunity.in/disroot/assests/blob/master/d.svg"
+        },
+        {
             "title": "Disqus",
             "hex": "2E9FFF",
             "source": "https://disqus.com/brand"


### PR DESCRIPTION
Disroot doesn't seem to have an actual color or branding guide, so the color code #50162d is from the original SVG itself.