### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Most of the icons and brand colors on SimpleIcons have been derived from officia
 Official high quality brand logos and brand colors can usually be found in the following locations:
 
 1. About pages, Press pages, Media Kits, and Brand Guidelines.
-1. Website headers (you can use [svg-grabber](https://github.com/ngti/svg-grabber) for Chrome)
+1. Website headers (you can use [svg-grabber](https://chrome.google.com/webstore/detail/svg-grabber-get-all-the-s/ndakggdliegnegeclmfgodmgemdokdmg) for Chrome)
 1. Favicons
 1. Wikimedia (which should provide a source)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Most of the icons and brand colors on SimpleIcons have been derived from officia
 Official high quality brand logos and brand colors can usually be found in the following locations:
 
 1. About pages, Press pages, Media Kits, and Brand Guidelines.
-1. Website headers
+1. Website headers (you can use [svg-grabber](https://github.com/ngti/svg-grabber) for Chrome)
 1. Favicons
 1. Wikimedia (which should provide a source)
 


### PR DESCRIPTION
Add svg-grabber with the "Website headers" option for where you can find brand logos. svg-grabber is a tool (for Google Chrome) which I recently discovered, it quickly shows you all the available SVG files on a website in order. So most of the time the company logo will be listed somewhere at the top. This might make the process of finding the SVG easier for some.

This is just a simple suggestion, if no one thinks its relevant this PR can be ignored. If you think it should be worded different/listed somewhere else let me know 🙂 