### PR TITLE
Update: Roots Color

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1427,7 +1427,7 @@
         },
         {
             "title": "Roots",
-            "hex": "27AE60",
+            "hex": "525DDC",
             "source": "https://roots.io/"
         },
         {


### PR DESCRIPTION
Roots now uses `#525ddc`. See [their website](//roots.io).