### PR TITLE
Update index.js filename mapping to match site

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@ const icons = {};
 data.icons.forEach(i => {
   const filename = i.title.toLowerCase()
     .replace(/\+/g, "plus")
-    .replace(/[ .\-!’]/g, '');
+    .replace(/^\./, "dot-")
+    .replace(/\.$/, "-dot")
+    .replace(/\./g, "-dot-")
+    .replace(/[ !’]/g, '');
   i.svg = fs.readFileSync(`${__dirname}/icons/${filename}.svg`, 'utf8');
   icons[i.title] = i
 });


### PR DESCRIPTION
Updates index.js filename mapping to match the Jekyll implementation.
This was missed in #888 (we should implement tests to avoid this in the future).
The JS implementation is a direct translation of the Jekyll one.

Closes #904