### PR TITLE
Page search find .NET Google+ etc

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,12 @@
     </script>
     <script>
       function normalizeSearchTerm(value) {
-          return value.toLowerCase().replace(/ /g, '');
+          return value.toLowerCase()
+              .replace(/\+/g, "plus")
+              .replace(/^\./, "dot-")
+              .replace(/\.$/, "-dot")
+              .replace(/\./g, "-dot-")
+              .replace(/[ !’]/g, '');
       }
       var icons = [{{ allIconNames }}].map(normalizeSearchTerm);
     </script>


### PR DESCRIPTION
closes #902
Allow search to find `.NET`, `Google+` etc.