### PR TITLE
Update the travis build to work in stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jobs:
       name: "NPM Package"
       language: node_js
       node_js: 8
+      if: branch = master
 
       deploy:
         provider: npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,24 @@
-matrix:
+jobs:
   include:
-    - language: node_js
-      node_js:
-        - "8"
-
+    - stage: "Test"
+      name: "Lint"
+      language: node_js
+      node_js: 8
       script:
         - npm run jsonlint
         - npm run svglint
+    - name: "Build website"
+      language: ruby
+      rvm: 2.4.1
+      install:
+        - gem install jekyll
+      script:
+        - jekyll build
 
-      notifications:
-        email:
-          on_success: never
-          on_failure: change
+    - stage: deploy
+      name: "NPM Package"
+      language: node_js
+      node_js: 8
 
       deploy:
         provider: npm
@@ -20,17 +27,7 @@ matrix:
         on:
           branch: master
 
-    - language: ruby
-      rvm:
-        - 2.4.1
-
-      install:
-        - gem install jekyll
-
-      script:
-        - jekyll build
-
-      notifications:
-        email:
-          on_success: never
-          on_failure: change
+notifications:
+  email:
+    on_success: never
+    on_failure: change

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2,7 +2,7 @@
     "icons": [
         {
             "title": ".NET",
-            "hex": "not a hexadecimally encoded color",
+            "hex": "5C2D91",
             "source": "https://docs.microsoft.com/en-us/dotnet/images/hub/net.svg"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1,8 +1,8 @@
 {
     "icons": [
         {
-            "title": ".NE",
-            "hex": "5C2D91",
+            "title": ".NET",
+            "hex": "not a hexadecimally encoded color",
             "source": "https://docs.microsoft.com/en-us/dotnet/images/hub/net.svg"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1,7 +1,7 @@
 {
     "icons": [
         {
-            "title": ".NET",
+            "title": ".NE",
             "hex": "5C2D91",
             "source": "https://docs.microsoft.com/en-us/dotnet/images/hub/net.svg"
         },


### PR DESCRIPTION
Improve the CI (test, build, and deploy) process by using [build stages](https://docs.travis-ci.com/user/build-stages/#examples) rather than a (somewhat hard to understand and arbitrary) [build matrix](https://docs.travis-ci.com/user/customizing-the-build/#build-matrix). For now it just improves the readability of the `.travis.yml` file and the understandability of the [build status page](https://travis-ci.org/simple-icons/simple-icons).

For clarity, I added two commits showing the build report when something goes wrong. The first is when the [website cannot be build](https://travis-ci.org/simple-icons/simple-icons/builds/420875745?utm_source=github_status&utm_medium=notification), and the second is when there is a [linting error](https://travis-ci.org/simple-icons/simple-icons/builds/420876383?utm_source=github_status&utm_medium=notification). As seen in the images below:

![build website error](https://user-images.githubusercontent.com/3742559/44633736-9fbe3a00-a997-11e8-8f4e-3b6b0a02e958.png)

![linting error](https://user-images.githubusercontent.com/3742559/44633744-aea4ec80-a997-11e8-81db-0690f826ec89.png)

* * *

To summarize, Travis will now first lint & build the website (in parallel), and only if both succeed will it try to deploy. That only happens if the commit is on `master`. So it is ignored most of the time, as seen [here](https://travis-ci.org/simple-icons/simple-icons/builds/420876894?utm_source=github_status&utm_medium=notification).

In the future, with #898 in mind, this would make it easier to build to website in one step, and have it be deployed in another one (if that is even needed 🤔), Possibly we could even load external files (e.g. [simple-icons-pdf](https://github.com/simple-icons/simple-icons-pdf)), and include them in the website. Also, extra test steps (such as described in #905) are now easier to add.