### PR TITLE
Website/sort and search

### DIFF
--- a/site_script.js
+++ b/site_script.js
@@ -96,14 +96,19 @@
     }).sort(function(a, b) {
       return a.score - b.score;
     }).forEach(function(item, index) {
-      item.element.classList.remove('hidden');
+      var element = item.element;
+      element.classList.remove('hidden');
 
       if (query !== '') {
         // Order according to relevance (i.e. score) if there is a query
-        item.element.style.order = index;
+        element.style.order = index;
       } else {
         // Use color-based order if there is no query
-        item.element.style.removeProperty('order');
+        if ($sortColor.classList.contains('active')) {
+          element.style.order = null;
+        } else {
+          element.style.order = element.getAttribute('order');
+        }
       }
     });
 
@@ -149,12 +154,16 @@
   }, false);
 
   $sortColor.addEventListener('click', function() {
+    if ($sortColor.hasAttribute('disabled')) return;
+
     $icons.forEach(icon => { icon.style.order = null; });
 
     $sortColor.classList.add('active');
     $sortAlpha.classList.remove('active');
   });
   $sortAlpha.addEventListener('click', function() {
+    if ($sortAlpha.hasAttribute('disabled')) return;
+
     $icons.forEach(icon => { icon.style.order = icon.getAttribute('order'); });
 
     $sortAlpha.classList.add('active');

--- a/site_script.js
+++ b/site_script.js
@@ -108,6 +108,13 @@
     });
 
     $grid.classList.toggle('search__empty', hiddenCounter == icons.length);
+    if (query === '') {
+      $sortColor.removeAttribute('disabled');
+      $sortAlpha.removeAttribute('disabled');
+    } else {
+      $sortColor.setAttribute('disabled', true);
+      $sortAlpha.setAttribute('disabled', true);
+    }
   }
 
   document.addEventListener('DOMContentLoaded', function() {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -170,35 +170,40 @@ a.share-button {
   margin-left: .5rem;
   opacity: .5;
 }
-.sort-btn.active {
-  opacity: 1;
-}
 .sort-btn:first-of-type {
   margin-left: 1rem;
 }
-
-.sort-btn:hover {
+.sort-btn:not([disabled]).active {
   opacity: 1;
 }
-.sort-btn:hover path:first-of-type {
+
+.sort-btn:not([disabled]):hover {
+  opacity: 1;
+}
+.sort-btn:not([disabled]):hover path:first-of-type {
   opacity: 0.8;
 }
 
-#sort-color:hover path:nth-of-type(2) {
+.sort-btn[disabled] {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+#sort-color:not([disabled]):hover path:nth-of-type(2) {
   fill: #E57373;
 }
-#sort-color:hover path:nth-of-type(3) {
+#sort-color:not([disabled]):hover path:nth-of-type(3) {
   fill: #F44336;
 }
-#sort-color:hover path:nth-of-type(4) {
+#sort-color:not([disabled]):hover path:nth-of-type(4) {
   fill: #D32F2F;
 }
-#sort-color:hover path:nth-of-type(5) {
+#sort-color:not([disabled]):hover path:nth-of-type(5) {
   fill: #B71C1C;
 }
 
-#sort-alphabetically:hover path:nth-of-type(2),
-#sort-alphabetically:hover path:nth-of-type(3) {
+#sort-alphabetically:not([disabled]):hover path:nth-of-type(2),
+#sort-alphabetically:not([disabled]):hover path:nth-of-type(3) {
   opacity: 1;
 }
 


### PR DESCRIPTION
Addresses the problem described in and closes #908

Previously, when there was a search query and you pressed on of the sort buttons (color or alphabetically), the search query was more or less forgotten. **My solution** is to disable the sort buttons when there is an active search query, as they're not relevant anyway. They're not relevant because we use a fuzzy search algorithm which orders the icons resulting from the search based on a scoring system. Note that when the search query is removed (i.e. `query === ""`) the ordering that was last active is used automatically.