### PR TITLE
Add a missing dash to the svgo precision option in the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ All icons in Simple Icons have been optimized with the [SVGO tool](https://githu
   * Install SVGO
     * With npm: `npm install -g svgo`
     * With Homebrew: `brew install svgo`
-  * Run the following command `svgo -precision=3 icon.svg icon.min.svg`
+  * Run the following command `svgo --precision=3 icon.svg icon.min.svg`
   * Check if there is a loss of quality in the output, if so increase the precision.
 * The [SVGOMG Online Tool](https://jakearchibald.github.io/svgomg/)
   * Click "Open SVG" and select an SVG file.


### PR DESCRIPTION
This confused me at first, then I figured that it's just two dashes as with every other normal program aswell.

Basically the [CONTRIBUGING.md](https://github.com/simple-icons/simple-icons/blob/a402a50c06600fab083527bbc23f4b01a9b75429/CONTRIBUTING.md#3-optimize-the-icon) document tells you to use `-precision=3` instead of `--precision=3` which just yields `Unknown option: -precision=3`.

That's all.