### PR TITLE
Update GoldenLine

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -667,7 +667,7 @@
         },
         {
             "title": "GoldenLine",
-            "hex": "FBBF00",
+            "hex": "F1B92B",
             "source": "http://www.goldenline.pl"
         },
         {


### PR DESCRIPTION
closes #821 (#616 relevant), updated the color of GoldenLine, taken straight from [the SVG](https://www.goldenline.pl/images/4e39dee-923c2c7.svg) found on their [homepage](https://www.goldenline.pl/)