### PR TITLE
Add Kotlin icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1041,6 +1041,11 @@
             "source": "https://koding.com/About"
         },
         {
+            "title": "Kotlin",
+            "hex": "497BBC",
+            "source": "https://resources.jetbrains.com/storage/products/kotlin/docs/kotlin_logos.zip"
+        },
+        {
             "title": "Ko-fi",
             "hex": "F16061",
             "source": "https://ko-fi.com/home/about"

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1042,7 +1042,7 @@
         },
         {
             "title": "Kotlin",
-            "hex": "497BBC",
+            "hex": "0095D5",
             "source": "https://resources.jetbrains.com/storage/products/kotlin/docs/kotlin_logos.zip"
         },
         {

--- a/icons/kotlin.svg
+++ b/icons/kotlin.svg
@@ -1,0 +1,1 @@
+<svg aria-labelledby="simpleicons-kotlin-icon" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title id="simpleicons-kotlin-icon">Kotlin icon</title><path d="M1.3 24l11.3-11.5L24 24zM0 0h12L0 12.5zM13.4 0L0 14v10l12-12L24 0z"/></svg>


### PR DESCRIPTION
Relevant issue: #469

The guidelines for the Kotlin logo (found [here](https://resources.jetbrains.com/storage/products/kotlin/docs/kotlin_logos.zip)) provide us with three options for the Kotlin logo, all of which can be found below. I converted all three of them into SVG (see the commit messages), but included the second option in this PR.

1)
![opt1](https://user-images.githubusercontent.com/3742559/46571501-b4222900-c97e-11e8-9a57-0e9e2744c2c1.png)

2)
![opt2](https://user-images.githubusercontent.com/3742559/46571499-a40a4980-c97e-11e8-8352-5019278e862a.png)

3)
![opt3](https://user-images.githubusercontent.com/3742559/46571500-a40a4980-c97e-11e8-9257-4f0a4434e592.png)

