### PR TITLE
Fixed Google Drive color.

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -817,7 +817,7 @@
         },
         {
             "title": "Google Drive",
-            "hex": "4386FC",
+            "hex": "4285F4",
             "source": "https://developers.google.com/drive/web/branding"
         },
         {


### PR DESCRIPTION
Google Drive's color was slightly off. Corrected it so it's now the same as the primary blue color as seen on the official brand guidelines and in the Google and Google Chrome icons.

Also, confirmed we are using the correct color for Google. It's the same hex as seen in other official resources:
https://design.google/library/evolving-google-identity/
