### PR TITLE
add Azure DevOps

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -201,6 +201,11 @@
             "source": "https://www.aventrix.com/press"
         },
         {
+            "title": "Azure DevOps",
+            "hex": "0078D7",
+            "source": "http://azure.com/devops"
+        },
+        {
             "title": "Baidu",
             "hex": "2319DC",
             "source": "https://en.wikipedia.org/wiki/File:Baidu.svg"

--- a/icons/azuredevops.svg
+++ b/icons/azuredevops.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Azure DevOps icon</title><path d="M0 8.899l2.247-2.966 8.405-3.416V.045l7.37 5.393L2.966 8.36v8.224L0 15.73zm24-4.45v14.652L18.247 24l-9.303-3.056V24l-5.978-7.416 15.057 1.798V5.438z"/></svg>


### PR DESCRIPTION
### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description

Azure DevOps logo appears as used at:

https://twitter.com/azuredevops
https://azuremarketplace.microsoft.com/en-us/marketplace/apps/aad.vsonline
https://docs.microsoft.com/en-gb/azure/devops/

Name is generally styled as DevOps not Devops

Possible colours: `#FFFFFF`,  `#0078D7`

![azuredevops](https://user-images.githubusercontent.com/6025893/50378173-836b9a80-0623-11e9-94ff-bca6771433c7.png)
