### PR TITLE
Adding ZEIT

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2626,6 +2626,11 @@
             "source": "https://zapier.com/about/brand"
         },
         {
+            "title": "Zeit",
+            "hex": "000000",
+            "source": "https://zeit.co/design/brand"
+        },
+        {
             "title": "Zendesk",
             "hex": "03363D",
             "source": "https://www.zendesk.com/company/brand-assets/#logo"

--- a/icons/zeit.svg
+++ b/icons/zeit.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Zeit icon</title><path d="M24 24H0L12 2.95 24 24z"/></svg>

--- a/icons/zeit.svg
+++ b/icons/zeit.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Zeit icon</title><path d="M24 24H0L12 2.95 24 24z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Zeit icon</title><path d="M24 22.525H0l12-21.05 12 21.05z"/></svg>

--- a/icons/zeit.svg
+++ b/icons/zeit.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Zeit icon</title><path d="M24 22.05H0L12 1L24 22.05Z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Zeit icon</title><path d="M24 24H0L12 2.95 24 24z"/></svg>

--- a/icons/zeit.svg
+++ b/icons/zeit.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Zeit icon</title><path d="M24 24H0L12 2.95 24 24z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Zeit icon</title><path d="M24 22.05H0L12 1L24 22.05Z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:** #1148 


### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Main colours are indicated on the brand-page to be black(#000000) and white(#ffffff), the black coloured logo is used on their homepage and seems to be prevalent. 
