### PR TITLE
Update issue labels table in Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,12 +153,15 @@ We use several labels to help organize and identify issues. You can find all lab
 
 | Label Name | Description |
 | :---- | :---- |
-| [icon](https://github.com/simple-icons/simple-icons/labels/icon) | Issues for adding or updating an icon. |
+| [new icon](https://github.com/simple-icons/simple-icons/labels/new%20icon) | Issues for adding a new icon. |
+| [icon outdated](https://github.com/simple-icons/simple-icons/labels/icon%20outdated) | Issues regarding icons that are outdated, this can be the SVG or color or both. |
+| [website](https://github.com/simple-icons/simple-icons/labels/website) | Issues for the website [simpleicons.org](http://simpleicons.org/). |
 | [docs](https://github.com/simple-icons/simple-icons/labels/docs) | Issues for improving or updating documentation. |
+| [meta](https://github.com/simple-icons/simple-icons/labels/meta) | Issues regarding the project or repository itself. |
 | [good first issue](https://github.com/simple-icons/simple-icons/labels/good%20first%20issue) | Issues we believe are simple and a good first stab at contributing to the project. |
 | [help wanted](https://github.com/simple-icons/simple-icons/labels/help%20wanted) | Issues we would like help from the community to resolve. |
 | [awaiting reply](https://github.com/simple-icons/simple-icons/labels/awaiting%20reply) | Issues awaiting reply from an individual (issue author or 3rd party) before it may be addressed. |
-| [icon outdated](https://github.com/simple-icons/simple-icons/labels/icon%20outdated) | Issues regarding icons that are outdated, this can be the SVG or color or both. |
+| [won't add](https://github.com/simple-icons/simple-icons/labels/won%27t%20add) | Icon requests or other features that won't be added. |
 
 ## Building Locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,7 @@ We use several labels to help organize and identify issues. You can find all lab
 | [help wanted](https://github.com/simple-icons/simple-icons/labels/help%20wanted) | Issues we would like help from the community to resolve. |
 | [awaiting reply](https://github.com/simple-icons/simple-icons/labels/awaiting%20reply) | Issues awaiting reply from an individual (issue author or 3rd party) before it may be addressed. |
 | [won't add](https://github.com/simple-icons/simple-icons/labels/won%27t%20add) | Icon requests or other features that won't be added. |
+| [release](https://github.com/simple-icons/simple-icons/pulls?q=is%3Apr+label%3Arelease+is%3Aclosed) | Pull requests that released a new version. |
 
 ## Building Locally
 


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:** n/a


### Description
Updated the table of labels and their descriptions in the Contributing Guidelines. Added the `website`, `meta`, and `won't add` labels, and fixed the broken link and outdated name for the `new icon` label.

The labels `abandoned`, `Hacktoberfest`, and `invalid` are still not part of the table as I don't think they're relevant to the reader. But I could be persuaded otherwise.

This might also be a place to start the discussion on using labels for pull requests as well as issues?