### PR TITLE
Add CEVO icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -336,6 +336,11 @@
             "source": "http://supertop.co/castro/press/"
         },
         {
+            "title": "CEVO",
+            "hex": "1EABE2",
+            "source": "https://cevo.com/event/cs-globaloffensive/downloads/"
+        },
+        {
             "title": "Circle",
             "hex": "8669AE",
             "source": "https://www.circle.com/"

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -338,7 +338,7 @@
         {
             "title": "CEVO",
             "hex": "1EABE2",
-            "source": "https://cevo.com/event/cs-globaloffensive/downloads/"
+            "source": "https://cevo.com/"
         },
         {
             "title": "Circle",

--- a/icons/cevo.svg
+++ b/icons/cevo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img" viewBox="0 0 24 24"><title>CEVO icon</title><path d="M3.5 6h12l6 10.3L24 12 18 1.6H6L3.5 6zm-.9 1.5L0 12l6 10.4h12l2.6-4.5-2.5-4.3-2.6 4.5h-7L5 12l2.6-4.5h-5z"/></svg>


### PR DESCRIPTION
### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description

The brand guide only has rasters available so I used image trace in Adobe Illustrator and tweaked some of the anchors to keep the edges perfectly straight. I picked the color from their logo. Their Alexa rank is ~197K.