### PR TITLE
Add RubyGems icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1986,6 +1986,11 @@
             "source": "https://www.ruby-lang.org/en/about/logo/"
         },
         {
+            "title": "RubyGems",
+            "hex": "E9573F",
+            "source": "https://rubygems.org/pages/about"
+        },
+        {
             "title": "Runkeeper",
             "hex": "2DC9D7",
             "source": "https://runkeeper.com/partnerships"

--- a/icons/rubygems.svg
+++ b/icons/rubygems.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>RubyGems icon</title><path d="M7.81 7.9l-2.97 2.95 7.19 7.18 2.96-2.95 4.22-4.23-2.96-2.96v-.01H7.8z"/><path d="M12 0L1.53 6v12L12 24l10.47-6V6L12 0zm8.47 16.85L12 21.73l-8.47-4.88V7.12L12 2.24l8.47 4.88v9.73z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:** #1237


### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
he SVG can be downloaded at the bottom of [the specified source](https://rubygems.org/pages/about), the color is taken from the `background-color` property on the `<body>` of [the homepage](https://rubygems.org/).

It could be argued that their official name is "RubyGems.org" rather than "RubyGems", I'm open to changing that if preferred 👍 