### PR TITLE
Add CMake

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -356,6 +356,11 @@
             "source": "https://www.cloudflare.com/logo/"
         },
         {
+            "title": "CMake",
+            "hex": "064F8C",
+            "source": "https://www.kitware.com/platforms/"
+        },
+        {
             "title": "Codacy",
             "hex": "222F29",
             "source": "https://www.codacy.com/blog/"

--- a/icons/cmake.svg
+++ b/icons/cmake.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img" viewBox="0 0 24 24"><title>CMake icon</title><path d="M11.769.066L.067 23.206l12.76-10.843zM23.207 23.934L7.471 17.587 0 23.934zM24 23.736L12.298.463l1.719 19.24zM12.893 12.959l-5.025 4.298 5.62 2.248z"/></svg>


### PR DESCRIPTION
**Issue:** #1084 

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description

The icon is extracted from an SVG on the [Kitware website](https://www.kitware.com/platforms/), which is the maker of CMake. I didn't see a specified primary brand color, so I choose used the blue color from the logo, as it seemed to be used the most on the website.
