### PR TITLE
Removed labels from Contribution Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,23 +147,6 @@ Here is the object for The Movie Database as an example:
 
 Once you've completed the previous steps, create a pull request to merge your edits into the *develop* branch.
 
-## Labeling Issues
-
-We use several labels to help organize and identify issues. You can find all labels [here](https://github.com/simple-icons/simple-icons/labels). Here's what they represent and how we use them:
-
-| Label Name | Description |
-| :---- | :---- |
-| [new icon](https://github.com/simple-icons/simple-icons/labels/new%20icon) | Issues for adding a new icon. |
-| [icon outdated](https://github.com/simple-icons/simple-icons/labels/icon%20outdated) | Issues regarding icons that are outdated, this can be the SVG or color or both. |
-| [website](https://github.com/simple-icons/simple-icons/labels/website) | Issues for the website [simpleicons.org](http://simpleicons.org/). |
-| [docs](https://github.com/simple-icons/simple-icons/labels/docs) | Issues for improving or updating documentation. |
-| [meta](https://github.com/simple-icons/simple-icons/labels/meta) | Issues regarding the project or repository itself. |
-| [good first issue](https://github.com/simple-icons/simple-icons/labels/good%20first%20issue) | Issues we believe are simple and a good first stab at contributing to the project. |
-| [help wanted](https://github.com/simple-icons/simple-icons/labels/help%20wanted) | Issues we would like help from the community to resolve. |
-| [awaiting reply](https://github.com/simple-icons/simple-icons/labels/awaiting%20reply) | Issues awaiting reply from an individual (issue author or 3rd party) before it may be addressed. |
-| [won't add](https://github.com/simple-icons/simple-icons/labels/won%27t%20add) | Icon requests or other features that won't be added. |
-| [release](https://github.com/simple-icons/simple-icons/pulls?q=is%3Apr+label%3Arelease+is%3Aclosed) | Pull requests that released a new version. |
-
 ## Building Locally
 
 * Make sure you have [Ruby](https://www.ruby-lang.org/en/downloads/) installed.


### PR DESCRIPTION
Back in 2017, I added a table linking to and describing our labels in the contribution guidelines. Since then, it seems GitHub had a similar thought and on 2/22/18 they added support for descriptions on the  [labels page](https://github.com/simple-icons/simple-icons/labels), rendering our table redundant. As a result, I added our existing descriptions to the labels page and created this PR to remove the duplicate label descriptions from the Contribution Guidelines.

We still need to add descriptions to some of the previously "unlisted" labels such as `invalid`, but I wasn't confident in my ability to do that since I didn't add them and didn't want to misrepresent their intended purpose.

Additionally, we probably should update the wording on some of them seeing as they are now intended to be shared between issues and PRs.

Github Blog introducing the feature:
https://github.blog/2018-02-22-label-improvements-emoji-descriptions-and-more/