### PR TITLE
[Sanitary 🚽] Removed ugly whitespace after comma of Itch.io JSON block.

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1229,7 +1229,7 @@
             "title": "Itch.io",
             "hex": "FA5C5C",
             "source": "https://itch.io/press-kit"
-        },        
+        },
         {
             "title": "Jabber",
             "hex": "CC0000",


### PR DESCRIPTION
#1315 contained some ugly whitespace after the comma in its JSON block.

![image](https://user-images.githubusercontent.com/5056880/54945453-20e1ad80-4f36-11e9-866f-dc657e29d6b2.png)

It would be better to merge this single commit than all following PRs (in which code optimization would attempt to fix this) conflicting with each other from here on.