### PR TITLE
Capitalize XD in Adobe XD

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -86,7 +86,7 @@
             "source": "https://helpx.adobe.com/content/dam/help/mnemonics/tk_appicon_RGB.svg"
         },
         {
-            "title": "Adobe Xd",
+            "title": "Adobe XD",
             "hex": "FF2BC2",
             "source": "https://www.adobe.com/products/xd.html"
         },


### PR DESCRIPTION
This puts it in line with how [Adobe](https://www.adobe.com/products/xd.html) refers to the product.