### PR TITLE
Added Manjaro icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1541,6 +1541,11 @@
             "source": "http://www.makerbot.com/makerbot-press-assets"
         },
         {
+            "title": "Manjaro",
+            "hex": "35BF5C",
+            "source": "https://commons.wikimedia.org/wiki/File:Manjaro-logo.svg"
+        },
+        {
             "title": "Markdown",
             "hex": "000000",
             "source": "https://github.com/dcurtis/markdown-mark"

--- a/icons/manjaro.svg
+++ b/icons/manjaro.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Manjaro icon</title><path d="M0 0v24h6.75V6.75h8.625V0H0zm8.625 8.625V24h6.75V8.625h-6.75zM17.25 0v24H24V0h-6.75z"/></svg>


### PR DESCRIPTION
**Issue:** #1160 

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Color was picked from the logo (`#35BF5C`). I added the link to the site, where is the official Manjaro logo.
