### PR TITLE
Handle accented brand names

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -13,5 +13,13 @@ module.exports = {
             .replace(/&$/, "-and")
             .replace(/&/g, "-and-")
             .replace(/[ !’]/g, "")
+            .replace(/à|á|â|ã|ä/, "a")
+            .replace(/ç/, "c")
+            .replace(/è|é|ê|ë/, "e")
+            .replace(/ì|í|î|ï/, "i")
+            .replace(/ò|ó|ô|õ|ö/, "o")
+            .replace(/ù|ú|û|ü/, "u")
+            .replace(/ñ/, "n")
+            .replace(/ý|ÿ/, "y")
     )
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -17,9 +17,9 @@ module.exports = {
             .replace(/ç/, "c")
             .replace(/è|é|ê|ë/, "e")
             .replace(/ì|í|î|ï/, "i")
+            .replace(/ñ/, "n")
             .replace(/ò|ó|ô|õ|ö/, "o")
             .replace(/ù|ú|û|ü/, "u")
-            .replace(/ñ/, "n")
             .replace(/ý|ÿ/, "y")
     )
 }


### PR DESCRIPTION
**Issue:** N/A

### Description
I updated the utils.js to handle brand names with accents. It converts accented characters to their unaccented version for filenames.

This should address the failed test in #1398.