### PR TITLE
Increase specificity of source URL pattern for JSONLint

### DIFF
--- a/.jsonlintschema
+++ b/.jsonlintschema
@@ -23,7 +23,7 @@
                     "source": {
                         "description": "The website from which the icon originated",
                         "type": "string",
-                        "pattern": "^https?://",
+                        "pattern": "^https?:\/\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=\\(\\)';!]*)$",
                         "required": true
                     }
                 },

--- a/.jsonlintschema
+++ b/.jsonlintschema
@@ -23,7 +23,7 @@
                     "source": {
                         "description": "The website from which the icon originated",
                         "type": "string",
-                        "pattern": "^https?:\/\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=\\(\\)';!]*)$",
+                        "pattern": "^https?://[^\\s]+$",
                         "required": true
                     }
                 },

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1523,7 +1523,7 @@
         {
             "title": "Kodi",
             "hex": "17B2E7",
-            "source": "https://kodi.tv/ "
+            "source": "https://kodi.tv/"
         },
         {
             "title": "Koding",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1523,7 +1523,7 @@
         {
             "title": "Kodi",
             "hex": "17B2E7",
-            "source": "https://kodi.tv/"
+            "source": "https://kodi.tv/ "
         },
         {
             "title": "Koding",


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:** https://github.com/simple-icons/simple-icons/pull/1494#discussion_r298812951


### Description
Update the JSONLint scheme to be more specific about what constitutes a valid source URL, based on the discussion [in this Stackoverflow thread](https://stackoverflow.com/a/3809435/4132379).

Perhaps such a specific pattern is undesirable as I already had to modify it (adding `\\(\\)';!` near the end) to accept all existing URLs 🤔 I'm open to other suggestions.
