### PR TITLE
Add URL friendy/slugged name as property to package icon objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ console.log(simpleIcons['Simple Icons']);
 /*
 {
     title: 'Simple Icons',
-    name: 'simpleicons',
+    slug: 'simpleicons',
     hex: '111111',
     source: 'https://simpleicons.org/',
     svg: '<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">...</svg>',
@@ -67,7 +67,7 @@ console.log(icon);
 /*
 {
     title: 'Simple Icons',
-    name: 'simpleicons',
+    slug: 'simpleicons',
     hex: '111111',
     source: 'https://simpleicons.org/',
     svg: '<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">...</svg>',

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ console.log(simpleIcons['Simple Icons']);
 /*
 {
     title: 'Simple Icons',
+    name: 'simpleicons',
     hex: '111111',
     source: 'https://simpleicons.org/',
     svg: '<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">...</svg>',
@@ -66,6 +67,7 @@ console.log(icon);
 /*
 {
     title: 'Simple Icons',
+    name: 'simpleicons',
     hex: '111111',
     source: 'https://simpleicons.org/',
     svg: '<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">...</svg>',

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -20,7 +20,7 @@ function iconToKeyValue(icon) {
   return `'${icon.title}':${iconToObject(icon)}`;
 }
 function iconToObject(icon) {
-  return `{title:'${icon.title}',name:'${icon.name}',svg:'${icon.svg}',get path(){return this.svg.match(/<path\\s+d="([^"]*)/)[1];},source:'${icon.source.replace(/'/g, "\\'")}',hex:'${icon.hex}'}`;
+  return `{title:'${icon.title}',slug:'${icon.slug}',svg:'${icon.svg}',get path(){return this.svg.match(/<path\\s+d="([^"]*)/)[1];},source:'${icon.source.replace(/'/g, "\\'")}',hex:'${icon.hex}'}`;
 }
 
 // 'main'
@@ -28,7 +28,7 @@ const icons = [];
 data.icons.forEach(icon => {
     const filename = titleToFilename(icon.title);
     icon.svg = fs.readFileSync(`${iconsDir}/${filename}.svg`, "utf8");
-    icon.name = filename;
+    icon.slug = filename;
     icons.push(icon)
 
     // write the static .js file for the icon

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -20,6 +20,7 @@ data.icons.forEach(icon => {
     const filename = titleToFilename(icon.title);
     icon.svg = fs.readFileSync(`${iconsDir}/${filename}.svg`, "utf8");
     icon.path = icon.svg.match(/<path\s+d="([^"]*)/)[1];
+    icon.name = filename;
     icons[icon.title] = icon;
     // write the static .js file for the icon
     fs.writeFileSync(

--- a/tests/icons.test.js
+++ b/tests/icons.test.js
@@ -27,7 +27,7 @@ icons.forEach(icon => {
     expect(subject.path).toMatch(/[MmZzLlHhVvCcSsQqTtAa0-9-,.\s]/g);
   });
 
-  test(`${icon.title} has a "name"`, () => {
-    expect(typeof subject.name).toBe('string');
+  test(`${icon.title} has a "slug"`, () => {
+    expect(typeof subject.slug).toBe('string');
   });
 });

--- a/tests/icons.test.js
+++ b/tests/icons.test.js
@@ -26,4 +26,8 @@ icons.forEach(icon => {
     expect(typeof subject.path).toBe('string');
     expect(subject.path).toMatch(/[MmZzLlHhVvCcSsQqTtAa0-9-,.\s]/g);
   });
+
+  test(`${icon.title} has a "name"`, () => {
+    expect(typeof subject.name).toBe('string');
+  });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -25,4 +25,8 @@ icons.forEach(icon => {
     expect(typeof subject.path).toBe('string');
     expect(subject.path).toMatch(/^[MmZzLlHhVvCcSsQqTtAa0-9-,.\s]+$/g);
   });
+
+  test(`${icon.title} has a "name"`, () => {
+    expect(typeof subject.name).toBe('string');
+  });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -26,7 +26,7 @@ icons.forEach(icon => {
     expect(subject.path).toMatch(/^[MmZzLlHhVvCcSsQqTtAa0-9-,.\s]+$/g);
   });
 
-  test(`${icon.title} has a "name"`, () => {
-    expect(typeof subject.name).toBe('string');
+  test(`${icon.title} has a "slug"`, () => {
+    expect(typeof subject.slug).toBe('string');
   });
 });


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:** #1362 


### Description
This adds a new key to the icon object called `name` (this is open for discussion) that has a URL friendly/slugged name (that is basically the SVG's filename. E.g. for **Let's Encrypt**:

```diff
 {
   title: "Let's Encrypt",
   svg: "<svg>...</svg>",
   path: "[PATH]",
   source: "[URL]",
   hex: "XXXXXX",
+  name: "letsencrypt"
 }
```

### Testing

Currently I only test if every icon has the new property, I'm not sure how to make it more advanced without using the exact code that is used to set the property... 🤔 