### PR TITLE
Reduce impact of path value on package size

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -20,7 +20,7 @@ function iconToKeyValue(icon) {
   return `'${icon.title}':${iconToObject(icon)}`;
 }
 function iconToObject(icon) {
-  return `{title:'${icon.title}',svg:'${icon.svg}',path:'${icon.path}',source:'${icon.source.replace(/'/g, "\\'")}',hex:'${icon.hex}'}`;
+  return `{title:'${icon.title}',svg:'${icon.svg}',get path(){return this.svg.match(/<path\\s+d="([^"]*)/)[1];},source:'${icon.source.replace(/'/g, "\\'")}',hex:'${icon.hex}'}`;
 }
 
 // 'main'

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -15,18 +15,29 @@ const fs = require("fs");
 
 const { titleToFilename } = require("./utils");
 
-const icons = {};
+// Local helper functions
+function iconToKeyValue(icon) {
+  return `'${icon.title}':${iconToObject(icon)}`;
+}
+function iconToObject(icon) {
+  return `{title:'${icon.title}',svg:'${icon.svg}',path:'${icon.path}',source:'${icon.source.replace(/'/g, "\\'")}',hex:'${icon.hex}'}`;
+}
+
+// 'main'
+const icons = [];
 data.icons.forEach(icon => {
     const filename = titleToFilename(icon.title);
     icon.svg = fs.readFileSync(`${iconsDir}/${filename}.svg`, "utf8");
     icon.path = icon.svg.match(/<path\s+d="([^"]*)/)[1];
-    icons[icon.title] = icon;
+    icons.push(icon)
+
     // write the static .js file for the icon
     fs.writeFileSync(
         `${iconsDir}/${filename}.js`,
-        `module.exports=${JSON.stringify(icon)};`
+        `module.exports=${iconToObject(icon)};`
     );
 });
 
 // write our generic index.js
-fs.writeFileSync(indexFile, `module.exports=${JSON.stringify(icons)};`);
+const iconsString = icons.map(iconToKeyValue).join(',');
+fs.writeFileSync(indexFile, `module.exports={${iconsString}};`);

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -20,10 +20,7 @@ function iconToKeyValue(icon) {
   return `'${icon.title}':${iconToObject(icon)}`;
 }
 function iconToObject(icon) {
-  return `{title:'${icon.title}',svg:'${icon.svg}',source:'${icon.source.replace(/'/g, "\\'")}',hex:'${icon.hex}'}`;
-}
-function getObjectDefinesPropertyString(subject) {
-  return `Object.defineProperty(${subject},'path',{get:function(){return this.svg.match(/<path\\s+d="([^"]*)/)[1];}})`;
+  return `{title:'${icon.title}',svg:'${icon.svg}',get path(){return this.svg.match(/<path\\s+d="([^"]*)/)[1];},source:'${icon.source.replace(/'/g, "\\'")}',hex:'${icon.hex}'}`;
 }
 
 // 'main'
@@ -36,10 +33,10 @@ data.icons.forEach(icon => {
     // write the static .js file for the icon
     fs.writeFileSync(
         `${iconsDir}/${filename}.js`,
-        `module.exports=${iconToObject(icon)};${getObjectDefinesPropertyString("module.exports")}`
+        `module.exports=${iconToObject(icon)};`
     );
 });
 
 // write our generic index.js
 const iconsString = icons.map(iconToKeyValue).join(',');
-fs.writeFileSync(indexFile, `module.exports={${iconsString}};for(var i in module.exports){${getObjectDefinesPropertyString("module.exports[i]")}}`);
+fs.writeFileSync(indexFile, `module.exports={${iconsString}};`);

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -31,7 +31,6 @@ const icons = [];
 data.icons.forEach(icon => {
     const filename = titleToFilename(icon.title);
     icon.svg = fs.readFileSync(`${iconsDir}/${filename}.svg`, "utf8");
-    icon.path = icon.svg.match(/<path\s+d="([^"]*)/)[1];
     icons.push(icon)
 
     // write the static .js file for the icon

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -20,7 +20,10 @@ function iconToKeyValue(icon) {
   return `'${icon.title}':${iconToObject(icon)}`;
 }
 function iconToObject(icon) {
-  return `{title:'${icon.title}',svg:'${icon.svg}',get path(){return this.svg.match(/<path\\s+d="([^"]*)/)[1];},source:'${icon.source.replace(/'/g, "\\'")}',hex:'${icon.hex}'}`;
+  return `{title:'${icon.title}',svg:'${icon.svg}',source:'${icon.source.replace(/'/g, "\\'")}',hex:'${icon.hex}'}`;
+}
+function getObjectDefinesPropertyString(subject) {
+  return `Object.defineProperty(${subject},'path',{get:function(){return this.svg.match(/<path\\s+d="([^"]*)/)[1];}})`;
 }
 
 // 'main'
@@ -34,10 +37,10 @@ data.icons.forEach(icon => {
     // write the static .js file for the icon
     fs.writeFileSync(
         `${iconsDir}/${filename}.js`,
-        `module.exports=${iconToObject(icon)};`
+        `module.exports=${iconToObject(icon)};${getObjectDefinesPropertyString("module.exports")}`
     );
 });
 
 // write our generic index.js
 const iconsString = icons.map(iconToKeyValue).join(',');
-fs.writeFileSync(indexFile, `module.exports={${iconsString}};`);
+fs.writeFileSync(indexFile, `module.exports={${iconsString}};for(var i in module.exports){${getObjectDefinesPropertyString("module.exports[i]")}}`);


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:** continues on #1519 

### Description
This PR replaces the hardcoded value for the path data by a getter for the path `{ get path() { ... }, ... }` which calculates the path data in realtime based on the icons SVG value.

I implemented and committed a version using getters and `Object.defineProperty`, a size comparison for both solutions can be found below. In the end I used getters as they seem to have better support in older browsers, but it doesn't matter for NodeJS(?).

### Size comparison with `get path`

> For compatability see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get#Browser_compatibility

| What | Size before (in bytes) | Size after (in bytes) |
|---|---|---|
| Just `index.js` | 1,972,191 | 1,087,327 |
| All `icons/*.js` combined | 1,974,786 | 1,089,922 |

### Size comparison with `Object.defineProperty()`

> For compatability see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#Browser_compatibility

| What | Size before (in bytes) | Size after (in bytes) |
|---|---|---|
| Just `index.js` | 1,972,191 | 1,048,291 |
| All `icons/*.js` combined | 1,974,786 | 1,122,572 |