### PR TITLE
Update SVGLint dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -182,9 +182,9 @@
       }
     },
     "@types/node": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
-      "integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng==",
+      "version": "12.6.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
+      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
       "dev": true
     },
     "@types/q": {
@@ -698,13 +698,13 @@
       }
     },
     "cheerio": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
-      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
       "dev": true,
       "requires": {
         "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.0",
+        "dom-serializer": "~0.1.1",
         "entities": "~1.1.1",
         "htmlparser2": "^3.9.1",
         "lodash": "^4.15.0",
@@ -1606,13 +1606,12 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "3.12.16",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.12.16.tgz",
-      "integrity": "sha512-7ePrHTK4K9BLzY3+6ZOv2YEPOpdYJg3ohyMHxacG6kp1A0Y8KNyjrFfEHJuo8G4T7vT7cIlIXGWoHdIWu9U41A==",
+      "version": "3.12.17",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.12.17.tgz",
+      "integrity": "sha512-gyvL0R5PGOW3gQssS/IVhANnsz1ANMK7tmE7YwqcdS7sAN8vDVKwXdQPZw5KH+nrSKSl5sXiGfhFnNflZwSgPQ==",
       "dev": true,
       "requires": {
         "configstore": "^4.0.0",
-        "lodash": "^4.17.11",
         "nimnjs": "^1.3.2"
       }
     },
@@ -2462,9 +2461,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -5465,9 +5464,9 @@
       }
     },
     "svglint": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/svglint/-/svglint-1.0.4.tgz",
-      "integrity": "sha512-yq/uVpZQ4yWONvpLAC4J9Gkzu55EPsCLx3D02MCkEJwQHk0ccTEtk5fIVtE2+2X4+JbFX6EMFi6NMz1Aumflag==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/svglint/-/svglint-1.0.5.tgz",
+      "integrity": "sha512-GztnFzJjzW0ccfrTmIzOeme+6aWpDhXOlU1o2/toqWr3FhxlTOoHEcVAuL9uzYW375UCMfBdeaYgeUEBdRY10A==",
       "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "editorconfig-checker": "^2.0.8",
     "jest": "^24.1.0",
     "jsonlint2": "^1.7.1",
-    "svglint": "^1.0.4",
+    "svglint": "^1.0.5",
     "svgo": "^1.3.0",
     "uglify-js": "^3.6.0"
   },


### PR DESCRIPTION
Update SVGLint dependency from `v1.0.4` to `v1.0.5` in order to make use of the fix for https://github.com/birjolaxew/svglint/issues/5.
