### PR TITLE
Don't enumerate the get method

### DIFF
--- a/scripts/templates/index.js
+++ b/scripts/templates/index.js
@@ -1,17 +1,21 @@
 var icons = {%s};
 
-module.exports = icons;
-module.exports.get = function(targetName) {
-  if (icons[targetName]) {
-    return icons[targetName];
-  } else {
-    var normalizedName = targetName.toLowerCase();
-    for (var iconName in icons) {
-      var icon = icons[iconName];
-      if ((icon.title && icon.title.toLowerCase() === normalizedName)
-       || (icon.slug && icon.slug === normalizedName)) {
-         return icon;
+Object.defineProperty(icons, "get", {
+  enumerate: false,
+  value: function(targetName) {
+    if (icons[targetName]) {
+      return icons[targetName];
+    } else {
+      var normalizedName = targetName.toLowerCase();
+      for (var iconName in icons) {
+        var icon = icons[iconName];
+        if ((icon.title && icon.title.toLowerCase() === normalizedName)
+         || (icon.slug && icon.slug === normalizedName)) {
+           return icon;
+        }
       }
     }
   }
-}
+});
+
+module.exports = icons;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -44,3 +44,11 @@ icons.forEach(icon => {
     expect(found.title).toEqual(icon.title);
   });
 });
+
+test(`Iterating over simpleIcons only exposes icons`, () => {
+  const iconArray = Object.values(simpleIcons);
+  for (let icon of iconArray) {
+    expect(icon).toBeDefined();
+    expect(typeof icon).toBe('object');
+  }
+});


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:** Resolves #1554


### Description
Adds, and tests, functionality that hides the `.get` method (introduced in #1522) when iterating over the values (and keys) of `const simpleIcons = require('simple-icons');`.