### PR TITLE
Add Travis CI deploy step for release tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
       language: node_js
       node_js: 8
       script:
-        - export TEST=${cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//'}
+        - export TEST=$(cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//')
         - echo "The current version of the package is $TEST"
 
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,22 @@ jobs:
         - npm run test
 
     - stage: deploy
-      name: "NPM Package"
+      name: "Git tag"
+      language: node_js
+      node_js: 8
+      if: branch = master
+
+      before_deploy:
+        # Set up git user name and tag this commit
+        - git config --local user.name "YOUR GIT USER NAME"
+        - git config --local user.email "YOUR GIT USER EMAIL"
+        - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
+        - git tag $TRAVIS_TAG
+      deploy:
+        provider: releases
+        api_key: "$GITHUB_KEY"
+        skip_cleanup: true
+    - name: "NPM Package"
       language: node_js
       node_js: 8
       if: branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,12 @@ jobs:
       node_js: 8
       script:
         - npm run test
+    
+    - stage: Test deploy
+      name: Test extract version from package.json
+      script:
+        - export TEST=`cat package.json | grep 'version' | sed 's/"version": //' | sed 's/[ ",]//g'`
+        - echo "The current version of the package is $TEST"
 
     - stage: deploy
       name: "Git tag"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ jobs:
 
       before_deploy:
         # Set up git user name and tag this commit
-        - git config --local user.name "YOUR GIT USER NAME"
-        - git config --local user.email "YOUR GIT USER EMAIL"
+        - git config --local user.name "$GITHUB_USERNAME"
+        - git config --local user.email "$GITHUB_EMAIL"
         - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
         - git tag $TRAVIS_TAG
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,16 @@ jobs:
       name: Test extract version from package.json
       language: node_js
       node_js: 8
-      script:
-        - export TEST=$(cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//')
-        - echo "The current version of the package is $TEST"
+      before_deploy:
+        - git config --local user.name "Example name"
+        - git config --local user.email "name@example.com"
+        - export PACKAGE_VERSION=$(cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//')
+        - echo "The current version of the package is $VERSION, creating tag for that"
+        - git tag $PACKAGE_VERSION
+      deploy:
+        provider: releases
+        api_key: "$GITHUB_KEY"
+        skip_cleanup: true
 
     - stage: deploy
       name: "Git tag"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,19 +23,16 @@ jobs:
 
     - stage: deploy
       name: "Git tag"
-      language: node_js
-      node_js: 8
       if: branch = master
 
       before_deploy:
-        # Set up git user name and tag this commit
         - git config --local user.name "$GITHUB_USERNAME"
         - git config --local user.email "$GITHUB_EMAIL"
         - export PACKAGE_VERSION=$(cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//')
         - git tag $PACKAGE_VERSION
       deploy:
         provider: releases
-        api_key: "$GITHUB_KEY"
+        api_key: "$GITHUB_TOKEN"
         skip_cleanup: true
     - name: "NPM Package"
       language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,12 @@ jobs:
       name: Test extract version from package.json
       language: node_js
       node_js: 8
-      before_deploy:
+      script:
         - git config --local user.name "Example name"
         - git config --local user.email "name@example.com"
         - export PACKAGE_VERSION=$(cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//')
         - echo "The current version of the package is $VERSION, creating tag for that"
         - git tag $PACKAGE_VERSION
-      deploy:
-        provider: releases
-        api_key: "$GITHUB_KEY"
-        skip_cleanup: true
 
     - stage: deploy
       name: "Git tag"
@@ -46,8 +42,8 @@ jobs:
         # Set up git user name and tag this commit
         - git config --local user.name "$GITHUB_USERNAME"
         - git config --local user.email "$GITHUB_EMAIL"
-        - export TRAVIS_TAG=${TRAVIS_TAG:-$(date +'%Y%m%d%H%M%S')-$(git log --format=%h -1)}
-        - git tag $TRAVIS_TAG
+        - export PACKAGE_VERSION=$(cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//')
+        - git tag $PACKAGE_VERSION
       deploy:
         provider: releases
         api_key: "$GITHUB_KEY"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,17 +21,6 @@ jobs:
       script:
         - npm run test
 
-    - stage: Test deploy
-      name: Test extract version from package.json
-      language: node_js
-      node_js: 8
-      script:
-        - git config --local user.name "Example name"
-        - git config --local user.email "name@example.com"
-        - export PACKAGE_VERSION=$(cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//')
-        - echo "The current version of the package is $VERSION, creating tag for that"
-        - git tag $PACKAGE_VERSION
-
     - stage: deploy
       name: "Git tag"
       language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
       language: node_js
       node_js: 8
       script:
-        - export TEST=${cat package.json | grep 'version' | sed 's/"version": //' | sed 's/[ ",]//g'}
+        - export TEST=${cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//'}
         - echo "The current version of the package is $TEST"
 
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,13 @@ jobs:
       node_js: 8
       script:
         - npm run test
-    
+
     - stage: Test deploy
       name: Test extract version from package.json
+      language: node_js
+      node_js: 8
       script:
-        - export TEST=`cat package.json | grep 'version' | sed 's/"version": //' | sed 's/[ ",]//g'`
+        - export TEST=${cat package.json | grep 'version' | sed 's/"version": //' | sed 's/[ ",]//g'}
         - echo "The current version of the package is $TEST"
 
     - stage: deploy


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:** #747, #1427


### Description

This adds a new step to the Travis CI deploy stage that will tag the current commit on `master` and push the commit to GitHub so that it will appear in the repository's [releases page](https://github.com/simple-icons/simple-icons/releases).

This automatically includes the tags in git as well, making it easier to find releases straight from the source code. This is also the way [Packagist](https://packagist.org/) will version the package, which is the original reason for adding this.

### Todo

- [x] Configure a git user to author the tag.
- [x] It should find the version number from `./package.json`.
- [ ] Further testing