### PR TITLE
Add Gitpod icon.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,7 @@
 ports:
   - port: 4000
-    onOpen: open-preview
+    onOpen: ignore
 tasks:
+  - command: gp await-port 4000 && sleep 3 && gp preview $(gp url 4000)
   - init: gem install jekyll bundler
     command: jekyll serve --host 0.0.0.0

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1091,6 +1091,11 @@
             "source": "https://about.gitlab.com/press/"
         },
         {
+            "title": "Gitpod",
+            "hex": "1AA6E4",
+            "source": "https://www.gitpod.io/"
+        },
+        {
             "title": "Gitter",
             "hex": "ED1965",
             "source": "https://gitter.im/"

--- a/icons/gitpod.svg
+++ b/icons/gitpod.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Gitpod icon</title><path d="M3.6 17V7.6L1.5 6.4v11.8L11.7 24v-2.4z M11.7 19.2v-6.9l-6-3.5v7zM12 2.4l8.1 4.7 2.1-1.2L12 0 1.8 5.9l2.1 1.2z M18 8.3l-6-3.5-6 3.5 6 3.5zM12.3 19.3l6-3.5v-2.4l-4.1 2.4v-2.4l6.2-3.6V17l-8.1 4.6V24l10.2-5.8V6.4l-10.2 5.9zM12 12.1z"/></svg>


### PR DESCRIPTION
Hi simple-icons team! 👋

I ([still](https://github.com/simple-icons/simple-icons/pull/1164)) work on gitpod.io at TypeFox, and I've always dreamed of contributing a Gitpod logo here. 🙂 Hopefully everything is right with this SVG file.

FYI, Gitpod is no longer in Beta (since [April 2019](https://www.gitpod.io/blog/gitpod-launch/)) and currently has an Alexa rank of about [180K](https://www.alexa.com/siteinfo/gitpod.io) (it was < 150K recently, but then we accidentally messed up a few canonical links...).

Also, as an unrelated drive-by fix, I noticed that sometimes the Gitpod preview opens too fast for this repository, so I added a small delay in the Gitpod configuration to fix that (it seems that the Jekyll server opens port 4000 before the web app is fully ready, sometimes causing a broken preview).

**Issue:** (none)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with ~~SVGO or~~ SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->

- The hex color is the [official brand color](https://github.com/gitpod-io/website/blob/55e494a7141730c1e0e997c59c45d17307b30c25/src/styles/variables.ts#L4)
- Official Gitpod logos are found at: https://www.gitpod.io/media/
- The white logo was extracted from the official `Open in Gitpod` button: https://gitpod.io/button/open-in-gitpod.svg