### PR TITLE
Updated StackShare's hex value

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2737,7 +2737,7 @@
         },
         {
             "title": "StackShare",
-            "hex": "0690FA",
+            "hex": "000000",
             "source": "https://stackshare.io/branding"
         },
         {


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:**

We got a couple of complaints about our logo not being A11y friendly on [our Shields.io badge](https://img.shields.io/badge/Follow%20on-StackShare-blue.svg?logo=stackshare&style=flat)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->

All I did was update `_data/simple-icons.json`. I'm hoping this will make the StackShare icon white on shields.io for those who have trouble with contrast.
