### PR TITLE
Add McAfee icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1846,6 +1846,11 @@
             "source": "http://mttr.net"
         },
         {
+            "title": "McAfee",
+            "hex": "C01818",
+            "source": "https://www.mcafee.com/"
+        },
+        {
             "title": "MediaFire",
             "hex": "1299F3",
             "source": "https://www.mediafire.com/press/"

--- a/icons/mcafee.svg
+++ b/icons/mcafee.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>McAfee icon</title><path d="M12 4.843L1.608.033v19.124L12 23.967l10.392-4.81V.033zm6.155 11.594l-6.126 2.835-6.127-2.835V6.704l6.127 2.834 6.126-2.834z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:** #1668 


### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->

The logo can be found in the header of the [website](https://www.mcafee.com/) as an SVG file. 
It is also featured on the hero banner (as another SVG file). 
I've got the logo file from the header. 

The brand color is chosen from inspecting the website. 
You can see it from the links and sections. 
If you also inspect the [favicon of the site](view-source:https://www.mcafee.com/enterprise/en-us/img/favicon.ico), it is somewhat closer to the chosen brand color. 

The SVG on the hero banner features the logo in original color though IDK what is the brand color to choose from it. 
I also can't find an up-to-date brand guide from the site yet. 
In any case, what brand color should be discussed from here. 