### PR TITLE
Add Hurriyetemlak icon (#1344)

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1542,6 +1542,11 @@
             "source": "https://support.humblebundle.com/hc/en-us/articles/202742060-Bundle-Logos"
         },
         {
+            "title": "Hurriyetemlak",
+            "hex": "E02826",
+            "source": "https://ilan.hurriyetemlak.com/emlak-ilani-yayinlama-kurallari"
+        },
+        {
             "title": "Iata",
             "hex": "004E81",
             "source": "https://upload.wikimedia.org/wikipedia/commons/f/f7/IATAlogo.svg"

--- a/icons/hurriyetemlak.svg
+++ b/icons/hurriyetemlak.svg
@@ -1,0 +1,1 @@
+<svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Hurriyetemlak icon</title><path d="M24 16.085L11.994 4.091 0 16.097l3.817 3.812 8.182-8.189 8.189 8.182z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue: #1344 **


### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
1/4 PRs to resolve issue #1344 

Source is the official favicon [.svg](https://v.fastcdn.co/u/dc82a638/27598627-0-ok.svg), extracted from the page [here](https://ilan.hurriyetemlak.com/emlak-ilani-yayinlama-kurallari) which is also the link I've used in the .json file.

Predominant brand colour is the hex value `#E02826` is taken from the logo.

Built on GitPod, working as expected.