### PR TITLE
Add Monster icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2242,6 +2242,11 @@
             "source": "http://monogram.me"
         },
         {
+            "title": "Monster",
+            "hex": "6E46AE",
+            "source": "https://www.monster.com/"
+        },
+        {
             "title": "Monzo",
             "hex": "14233C",
             "source": "https://monzo.com/press/"

--- a/icons/monster.svg
+++ b/icons/monster.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Monster icon</title><path d="M0 0V24H5.42V12.39L12 18.19L18.58 12.39V24H24V0L12 11.23L0 0Z"/></svg>


### PR DESCRIPTION
**Issue:** #1734
![monster](https://user-images.githubusercontent.com/15157491/68387061-577ed800-0155-11ea-8efe-03ac5497f19f.png)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
No brand guidelines or media kit that I could find so icon and colour were both extracted from their website. See #1734 for an alternative version of the icon, taken from their logo.