### PR TITLE
Add link to Drupal module to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ echo file_get_contents('path/to/package/icons/simple-icons.svg');
 
 Icons are also available on WordPress through a simple plugin created by [@tjtaylo](https://github.com/tjtaylo), which you can find [here](https://wordpress.org/plugins/simple-icons/).
 
+### Drupal
+
+Icons are also availabe on Drupal through a module created by [Phil Wolstenholme](https://www.drupal.org/u/phil-wolstenholme), which you can find [here](https://www.drupal.org/project/simple_icons).
+
 ## Status
 
 [![Build Status](https://travis-ci.com/simple-icons/simple-icons.svg?branch=develop)](https://travis-ci.com/simple-icons/simple-icons)


### PR DESCRIPTION
First-time pull-requester, long-time fan of Simple Icons!

I've published a Drupal module to make it easier for Drupal users to use Simple Icons in their Drupal sites.

The module can be found here: https://www.drupal.org/project/simple_icons and the code for it here: https://git.drupalcode.org/project/simple_icons.

I thought this might be a useful addition to the README and would sit nicely alongside the link to the WordPress plugin.