### PR TITLE
Add PyUp icon (#1814)

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2782,6 +2782,11 @@
             "source": "https://github.com/pytorch/pytorch/tree/master/docs/source/_static/img"
         },
         {
+            "title": "PyUp",
+            "hex": "5B4638",
+            "source": "https://pyup.io/"
+        },
+        {
             "title": "Qgis",
             "hex": "589632",
             "source": "https://www.qgis.org/en/site/getinvolved/styleguide.html"

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2783,7 +2783,7 @@
         },
         {
             "title": "PyUp",
-            "hex": "5B4638",
+            "hex": "9F55FF",
             "source": "https://pyup.io/"
         },
         {

--- a/icons/pyup.svg
+++ b/icons/pyup.svg
@@ -1,0 +1,1 @@
+<svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>PyUp icon</title><path d="M12 0L1.608 6v12l3.984 2.3v-12L12 4.6l6.408 3.7v7.4L12 19.4l-2.95-1.705v4.602L12 24l10.392-6V6zm0 8.593l-2.95 1.703v3.408L12 15.407l2.95-1.703v-3.408z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue: #1814**


### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with ~SVGO or~ SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
Manual vector of [official logo .png](https://pyup.io/static/marketing/img/logo-light.png).

Chosen hex value `#9F55FF` is from the [website](https://pyup.io/).

Built on GitPod, working as expected.