### PR TITLE
Add PeerTube (#1973)

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2732,6 +2732,11 @@
             "source": "https://www.paypal-marketing.com/html/partner/na/portal-v2/pdf/PP_Masterbrandguidelines_v21_mm.pdf"
         },
         {
+            "title": "PeerTube",
+            "hex": "F1680D",
+            "source": "https://github.com/Chocobozzz/PeerTube/tree/develop/client/src/assets/images"
+        },
+        {
             "title": "Periscope",
             "hex": "40A4C4",
             "source": "https://www.periscope.tv/press"

--- a/icons/peertube.svg
+++ b/icons/peertube.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>PeerTube icon</title><path fill="#211F20" d="M3,0v12l9-6L3,0z M3,12v12l9-6L3,12z M12,6v12l9-6L12,6z"/></svg>

--- a/icons/peertube.svg
+++ b/icons/peertube.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>PeerTube icon</title><path fill="#211F20" d="M3,0v12l9-6L3,0z M3,12v12l9-6L3,12z M12,6v12l9-6L12,6z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>PeerTube icon</title><path d="M3,0v12l9-6L3,0z M3,12v12l9-6L3,12z M12,6v12l9-6L12,6z"/></svg>


### PR DESCRIPTION


<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:**
Closes #1973

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
The svg is taken from their [official Github Repo](https://github.com/Chocobozzz/PeerTube/tree/develop/client/src/assets/images), the color of `#F1680D` was extracted from said logo (consisting of a triforce icon; two triangles in grey/black, in this bright orange).