### PR TITLE
Add Crehana (#1865)

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -767,6 +767,11 @@
             "source": "https://creativecommons.org/"
         },
         {
+            "title": "Crehana",
+            "hex": "4B22F4",
+            "source": "https://www.crehana.com/"
+        },
+        {
             "title": "Crunchbase",
             "hex": "0288D1",
             "source": "https://www.crunchbase.com/home"

--- a/icons/crehana.svg
+++ b/icons/crehana.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Crehana icon</title><path d="M8,24H0v-8h8V24z M8,0H0v8h8V0z M16,0v8H8v8h8v8h8V0H16z"/></svg>

--- a/icons/crehana.svg
+++ b/icons/crehana.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Crehana icon</title><path d="M8,24H0v-8h8V24z M8,0H0v8h8V0z M16,0v8H8v8h8v8h8V0H16z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Crehana icon</title><path d="M12,0C5.371,0,0,5.371,0,12c0,6.626,5.371,12,12,12s12-5.374,12-12C24,5.371,18.626,0,12,0z M17.94,9.843v7.915h-3.957 v-3.892h-3.895v3.83H6.13v-3.957h3.833V9.843H6.06V5.948h3.957v3.895h3.965V5.948h3.957V9.843z"/></svg>


### PR DESCRIPTION


<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:**
Closes  #1865

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
This one is quite discussable...
On their website they are not really using their logo (except as a loading icon and favicon of course).
However, they do appear in their [apps](https://apps.apple.com/us/app/crehana/id1353031284).
The logo is super easy, so it was not hard to recreate. Still: this leaves no real trace of a source. At the moment I just put there the website. My spanish is bad, but usable. Still didn't found any kind of press kit.
The color is also debatable. In the app they have the small mint rectangle and the blue/purple background. This `#4B22F4` is also used to big extents on their website, so I used that.
