### PR TITLE
Update Facebook colour

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1153,8 +1153,8 @@
         },
         {
             "title": "Facebook",
-            "hex": "4172B8",
-            "source": "https://en.facebookbrand.com/#brand-guidelines-assets"
+            "hex": "1877F2",
+            "source": "https://en.facebookbrand.com/"
         },
         {
             "title": "FACEIT",


### PR DESCRIPTION
**Issue:** n/a

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
Colour found at https://en.facebookbrand.com/facebookapp/advertisers-and-partners/