### PR TITLE
Local relief for #2061

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -20,6 +20,7 @@ plugins:
   # Compound all <path>s into one
   - mergePaths:
       force: true
+      noSpaceAfterFlags: false
 
   # Keep the <title>
   - removeTitle: false


### PR DESCRIPTION
This should help with the overzealous whitespace removal in paths which will break many viewers/editors (even tho most browsers are fine with this).
It was already set on `ConvertPathData`. but this alone is not enough.

