### PR TITLE
Add RTLZWEI

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3383,7 +3383,7 @@
         },
         {
             "title": "RTLZWEI",
-            "hex": "00BDF6",
+            "hex": "00BCF6",
             "source": "https://www.rtl2.de/"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3382,6 +3382,11 @@
             "source": "https://www.rstudio.com/about/logos/"
         },
         {
+            "title": "RTLZWEI",
+            "hex": "00BDF6",
+            "source": "https://www.rtl2.de/"
+        },
+        {
             "title": "Ruby",
             "hex": "CC342D",
             "source": "https://www.ruby-lang.org/en/about/logo/"

--- a/icons/rtlzwei.svg
+++ b/icons/rtlzwei.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>RTLZWEI icon</title><path d="M0 0v24h7.38v-3.69H3.692L3.69 3.69h9.229V0H0zm16.61 0v3.69h3.7v16.62h-9.238V24H24V0h-7.39zm-.003 6.49l-3.689.717v9.227l3.69-.715V6.49zm-5.535 1.076l-3.69.715v9.229l3.69-.717V7.566z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:**


### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->

The official logo has "RTLZWEI" written underneath, but as the website itself uses just the upper part as favicon I think this version is the right choice.

https://www.rtl2.de/