### PR TITLE
Added Square Enix icon (#1604)

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3778,6 +3778,11 @@
             "source": "https://squareup.com/"
         },
         {
+            "title": "Square Enix",
+            "hex": "ED1C24",
+            "source": "https://www.square-enix.com/"
+        },
+        {
             "title": "Squarespace",
             "hex": "000000",
             "source": "http://squarespace.com/brand-guidelines"

--- a/icons/squareenix.svg
+++ b/icons/squareenix.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Square Enix icon</title><path d="M1.723 0v24h20.554v-4.496H7.037V4.088h15.006V0zm9.751 9.46v4.497h8.584V9.459z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue: #1604**


### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO ~or SVGOMG~
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
Extracted "E" to match [favicon](https://square-enix-games.com/static/favicon.ico) from [official .svg](https://square-enix-games.com/static/images/squareenix_logo.svg)(thanks to @PeterShaggyNoble for finding 👍 ).

![favicon](https://square-enix-games.com/static/favicon.ico)

Hex value chosen is `#ed1c24` from logo. 