### PR TITLE
Update Campaign Monitor Colour

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -543,8 +543,8 @@
         },
         {
             "title": "Campaign Monitor",
-            "hex": "509CF6",
-            "source": "https://www.campaignmonitor.com/brand"
+            "hex": "111324",
+            "source": "https://www.campaignmonitor.com/company/brand/"
         },
         {
             "title": "Canva",


### PR DESCRIPTION
**Issue:** n/a

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
`#7856ff` would make more sense to me but https://www.campaignmonitor.com/company/brand/color/ specifically states:

> Dark purple is our primary color