### PR TITLE
Add Transport for Ireland

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -4291,6 +4291,11 @@
             "source": "https://trakt.tv"
         },
         {
+            "title": "Transport for Ireland",
+            "hex": "00B274",
+            "source": "https://www.transportforireland.ie/"
+        },
+        {
             "title": "Travis CI",
             "hex": "3EAAAF",
             "source": "https://travis-ci.com/logo"

--- a/icons/transportforireland.svg
+++ b/icons/transportforireland.svg
@@ -1,0 +1,1 @@
+<svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Transport for Ireland icon</title><path d="M0 0v12c0 6.62 5.38 12 12 12h12V11.978h-.022c0-6.62-5.38-11.978-12-11.978zm3.376 8.145h6.337v1.546h-2.33v6.12H5.706v-6.12h-2.33zm8.014 0h5.837V9.67h-4.138v1.633h3.659v1.546h-3.659v2.962H11.39zm7.535 0h1.678v7.666h-1.678Z"/></svg>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15157491/72063292-6b6bc500-32d1-11ea-9012-dbb18e14f77e.png)

**Issue:** Closes #2313

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Icon & colour taken from [logo](https://www.transportforireland.ie/wp-content/themes/transportforireland/assets/img/branding/transport-for-ireland-logo.svg) in website header.