### PR TITLE
Add icon count to website & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </a>
 <h3 align="center">Simple Icons</h3>
 <p align="center">
-Free SVG icons for popular brands. See them all on one page at <a href="https://simpleicons.org">SimpleIcons.org</a>. Contributions, corrections & requests can be made on GitHub. Started by <a href="https://twitter.com/bathtype">Dan Leech</a>.</p>
+Over 1000 Free SVG icons for popular brands. See them all on one page at <a href="https://simpleicons.org">SimpleIcons.org</a>. Contributions, corrections & requests can be made on GitHub. Started by <a href="https://twitter.com/bathtype">Dan Leech</a>.</p>
 </p>
 
 ## Usage

--- a/index.html
+++ b/index.html
@@ -174,16 +174,16 @@
     <link rel="preconnect" href="//cdn.carbonads.com">
     <link rel="preconnect" href="//github.com">
     <title>Simple Icons</title>
-    <meta name="description" content="Free SVG icons for popular brands.">
+    <meta name="description" content="Over 1000 Free SVG icons for popular brands.">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Simple Icons">
-    <meta property="og:description" content="Free SVG icons for popular brands.">
+    <meta property="og:description" content="Over 1000 Free SVG icons for popular brands.">
     <meta property="og:url" content="https://simpleicons.org">
     <meta property="og:site_name" content="Simple Icons">
     <meta property="og:image" content="https://simpleicons.org/images/og.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Simple Icons">
-    <meta name="twitter:description" content="Free SVG icons for popular brands.">
+    <meta name="twitter:description" content="Over 1000 Free SVG icons for popular brands.">
     <meta name="twitter:site" content="@bathtype">
     <meta name="twitter:domain" content="Simple Icons">
     <meta name="twitter:image:src" content="https://simpleicons.org/images/og.png">
@@ -220,7 +220,7 @@
         </ul>
     </header>
     <main role="main">
-        <p class="hero">Free <abbr title="Scalable Vector Graphic">SVG</abbr> icons for popular&nbsp;brands</p>
+        <p class="hero">Over&nbsp;1000 Free <abbr title="Scalable Vector Graphic">SVG</abbr> icons for popular&nbsp;brands</p>
         <div class="search">
             <div class="search__wrapper">
                 <div class="search__close"><span>&times;</span></div>


### PR DESCRIPTION
We could do with touting the fact that, come the next release, we'll have over 1000 icons in our library ([Wear OS was the 1000th](https://github.com/simple-icons/simple-icons/pull/2305#issuecomment-573322864)).

Do we want the count on the website to be live or not (assuming it's possible)? Personally, I always prefer the "over `X`" phrasing to the exact figure - dunno why that is!