### PR TITLE
Add Material Design Icons icon (#2369)

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2682,7 +2682,7 @@
         },
         {
             "title": "Material Design Icons",
-            "hex": "2196f3",
+            "hex": "2196F3",
             "source": "https://materialdesignicons.com/icon/vector-square"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2681,6 +2681,11 @@
             "source": "https://material.io/design/"
         },
         {
+            "title": "Material Design Icons",
+            "hex": "2196f3",
+            "source": "https://materialdesignicons.com/icon/vector-square"
+        },
+        {
             "title": "Material-UI",
             "hex": "0081CB",
             "source": "https://material-ui.com/"

--- a/icons/materialdesignicons.svg
+++ b/icons/materialdesignicons.svg
@@ -1,0 +1,1 @@
+<svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Material Design Icons icon</title><path d="M0 0h7.2v2.4h9.6V0H24v7.2h-2.4v9.6H24V24h-7.2v-2.4H7.2V24H0v-7.2h2.4V7.2H0V0m16.8 7.2V4.8H7.2v2.4H4.8v9.6h2.4v2.4h9.6v-2.4h2.4V7.2h-2.4M2.4 2.4v2.4h2.4V2.4H2.4m16.8 0v2.4h2.4V2.4h-2.4M2.4 19.2v2.4h2.4v-2.4H2.4m16.8 0v2.4h2.4v-2.4z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue: #2369**


### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
Source is official [.svg](https://materialdesignicons.com/icon/vector-square).

Hex value is `#2196f3`.

Thanks to @PeterShaggyNoble 