### PR TITLE
Improve Formula for Display Colours

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,26 +98,14 @@
         {% assign rgbMin = rgbBlue %}
     {% endif %}
 
-    {% if rgbRed <= 0.03928 %}
-        {% assign lRed = rgbRed | divided_by: 12.92 | times: 0.2126 %}
-    {% else %}
-      {% assign lRed = rgbRed | times: 0.3053 | plus: 0.6822 | times: rgbRed | plus: 0.0125 | times: rgbRed | times: 0.2126 %}
-    {% endif %}
-    {% if rgbGreen <= 0.03928 %}
-        {% assign lGreen = rgbGreen | divided_by: 12.92 | times: 0.7152 %}
-    {% else %}
-        {% assign lGreen = rgbGreen | times: 0.3053 | plus: 0.6822 | times: rgbGreen | plus: 0.0125 | times: rgbGreen | times: 0.7152 %}
-    {% endif %}
-    {% if rgbBlue <= 0.03928 %}
-        {% assign lBlue = rgbBlue | divided_by: 12.92 | times: 0.0722 %}
-    {% else %}
-        {% assign lBlue = rgbBlue | times: 0.3053 | plus: 0.6822 | times: rgbBlue | plus: 0.0125 | times: rgbBlue | times: 0.0722 %}
-    {% endif %}
-    {% assign luminance = lRed | plus: lGreen | plus: lBlue %}
-    {% if luminance >= 0.83 %}
-        {% assign class = "grid-item--dark" %}
-    {% else %}
+    {% assign redLuminance   = rgbArray[0] | times: 16 | plus: rgbArray[1] | times: 0.299 | round: 0 %}
+    {% assign greenLuminance = rgbArray[2] | times: 16 | plus: rgbArray[3] | times: 0.587 | round: 0 %}
+    {% assign blueLuminance  = rgbArray[4] | times: 16 | plus: rgbArray[5] | times: 0.114 | round: 0 %}
+    {% assign luminance = redLuminance | plus: greenLuminance | plus: blueLuminance %}
+    {% if luminance < 210 %}
         {% assign class = "grid-item--light" %}
+    {% else %}
+        {% assign class = "grid-item--dark" %}
     {% endif %}
 
     {% assign hslLuminance = rgbMax | plus: rgbMin | times: 50.0 %}

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
     {% assign greenLuminance = rgbArray[2] | times: 16 | plus: rgbArray[3] | times: 0.587 | round: 0 %}
     {% assign blueLuminance  = rgbArray[4] | times: 16 | plus: rgbArray[5] | times: 0.114 | round: 0 %}
     {% assign luminance = redLuminance | plus: greenLuminance | plus: blueLuminance %}
-    {% if luminance < 210 %}
+    {% if luminance < 160 %}
         {% assign class = "grid-item--light" %}
     {% else %}
         {% assign class = "grid-item--dark" %}


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:** Closes  #2315


### Checklist

n/a

### Description

As per the discussion in #2315 I updated the logic that determines if an icon is displayed in black or white depending on the brand colour. Rather than a threshold of `128` (which is better for a11y) I put a threshold of `210` (which is more in line with what we already have, and, I think, looks better).

I put a screenshot of the whole site with both thresholds below or you can play with the value yourself by changing it on line 105 of index.html.

Feedback is welcome, I'm fine with changing the threshold value as this one is kind of arbitrary 😄

PS. I still use the term "luminance" in the code even though I'm not sure if the current computation is still about luminance... 

| 128 | 210 |
|---|---|
| ![128](https://user-images.githubusercontent.com/3742559/72466579-da6d8000-37e1-11ea-87d9-2c9eec14ffb9.png) | ![210](https://user-images.githubusercontent.com/3742559/72466568-d4779f00-37e1-11ea-82b6-8737612dd494.png) |
| <p align="center"><b>160</b></p> | |
| ![Screenshot_2020-01-17 Simple Icons](https://user-images.githubusercontent.com/3742559/72633950-34954f00-3962-11ea-8905-3aab05cd5671.png) | |

