### PR TITLE
Split issue templates for website and package

### DIFF
--- a/.github/ISSUE_TEMPLATE/package.md
+++ b/.github/ISSUE_TEMPLATE/package.md
@@ -1,6 +1,7 @@
 ---
 name: Packages
 about: Issues and improvements for the packages
+labels: package
 ---
 
 <!-- Before opening a new issue search for duplicate or closed issues -->

--- a/.github/ISSUE_TEMPLATE/package.md
+++ b/.github/ISSUE_TEMPLATE/package.md
@@ -1,6 +1,6 @@
 ---
-name: Website & Packages
-about: For general issues and improvements
+name: Packages
+about: Issues and improvements for the packages
 ---
 
 <!-- Before opening a new issue search for duplicate or closed issues -->
@@ -9,13 +9,11 @@ about: For general issues and improvements
 ### Kind of issue <!-- Change the one that applies to `[x]`  -->
   - [ ] Improvement
   - [ ] Bug
-  - [ ] Other, namely: 
+  - [ ] Other, namely:
 
 ### This issue concerns <!-- Change the one that applies to `[x]`  -->
   - [ ] The NPM Package
   - [ ] The Packagist Package
-  - [ ] The website
-  - [ ] Other, namely: 
 
 ### Description
 
@@ -27,6 +25,5 @@ Anything relevant, for example:
   - Package issues: Version information
     - For JavaScript/NodeJS: $ node --version
     - For PHP/Packagist: $ composer --version
-  - Website issues: What browser do you use
   - etc.
 -->

--- a/.github/ISSUE_TEMPLATE/website.md
+++ b/.github/ISSUE_TEMPLATE/website.md
@@ -1,0 +1,23 @@
+---
+name: Website
+about: Issues and improvements for the website
+---
+
+<!-- Before opening a new issue search for duplicate or closed issues -->
+
+
+### Kind of issue <!-- Change the one that applies to `[x]`  -->
+  - [ ] Improvement
+  - [ ] Bug
+  - [ ] Other, namely:
+
+### Description
+
+
+<!--
+Anything relevant, for example:
+  - For bugs: "Steps to reproduce" and "Expected behavior"
+  - For improvements: An example of a use case
+  - Website issues: What browser do you use
+  - etc.
+-->

--- a/.github/ISSUE_TEMPLATE/website.md
+++ b/.github/ISSUE_TEMPLATE/website.md
@@ -1,6 +1,7 @@
 ---
 name: Website
 about: Issues and improvements for the website
+labels: website
 ---
 
 <!-- Before opening a new issue search for duplicate or closed issues -->


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:** _None_


### Checklist

n/a


### Description

A small change to our issue templates that splits the currently existing issue template for both the website and our packages into two separate templates, mainly so that the `website` and `package` labels (respectively) can be applied automatically.