### PR TITLE
Use GitHub Actions to automatically label Pull Requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,7 @@
   - on: added
   - icons/*.svg
 
-# Add `new outdated` label when there is an SVG modified to the icons/ directory
+# Add `icon outdated` label when there is an SVG modified to the icons/ directory
 "icon outdated":
   - on: modified
   - icons/*.svg

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+# Configuration file for the Pull Request Labeler bot
+
+# Add `new icon` label when there is an SVG added to the icons/ directory
+"new icon":
+  - on: added
+  - icons/*.svg
+
+# Add `new outdated` label when there is an SVG modified to the icons/ directory
+"icon outdated":
+  - on: modified
+  - icons/*.svg

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -1,0 +1,11 @@
+name: Pull Requests
+on: [pull_request]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: ericcornelissen/labeler@master
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
**Issue:** _None_


### Checklist

n/a


### Description

We got access to [GitHub Actions](https://github.com/features/actions) a while back when it was still beta-access only but unfortunately haven't used it yet (we initially wanted to use it for #982) and I want to start using it to implement some stuff, among others #2380 and https://github.com/simple-icons/simple-icons-font/issues/1. However, I decided to start with something that is a bit simpler, namely:

**Feature**: Adding the labels `new icon` and `updated icon` to Pull Requests automatically based on the files added or changed in the Pull Request.<sup>1</sup>

For those unfamiliar with GitHub Actions the file `.github/workflows/pull_requests.yml` defines a "workflow", which is analogous to a build defined in `.travis.yml`. In it I say that `on: [pull_requests]` I want to do some stuff, run one or more "actions", namely I want to `run(s-)on: ubuntu-latest` a step as defined by `ericcornelissen/labeler@master`. In the case of the "action" is configured by `.github/labeler.yml` (which is a hard requirement from the "action" itself). The (currently incomplete) documentation for the configuration can be found in the [project's README](https://github.com/ericcornelissen/labeler/blob/master/README.md).

I tested the workflow in my fork of this repository, you can see the final results in [this Pull Request](https://github.com/ericcornelissen/simple-icons/pull/36) and [this Pull Request](https://github.com/ericcornelissen/simple-icons/pull/37) (and a bunch more attempts in the [list of closed Pull Requests](https://github.com/ericcornelissen/simple-icons/pulls?q=is%3Apr+is%3Aclosed)). ~~Also, the action should run on this Pull Request, but it does nothing as the files changed don't match the globs in the configuration.~~ Based on [this article](https://github.community/t5/GitHub-Actions/Run-a-GitHub-action-on-pull-request-for-PR-opened-from-a-forked/td-p/15426) it looks like the actions won't start running until this is merged because this PR is coming from a fork (rather than this repo) so I hope it will start working 🤞 

Why do this with GitHub Action rather than Travis CI? To try it out and learn, but also because I think it is easier to use and work with especially when you want to do stuff like in #2380. We don't need to move our Travis CI builds to GitHub Actions, but we could do that as well. Also, I like it very much that all the configuration is in the `.github/` directory 🙃 

PS. I'm using my personal fork of [actions/labeler](https://github.com/actions/labeler) (namely [ericcornelissen/labeler](https://github.com/ericcornelissen/labeler)) because I could not any labeling action that checked whether a file was added or changed (or removed for that matter). I do have [an open issue regarding this feature](https://github.com/actions/labeler/issues/47) to see if there is more interest, if so it may get merged and then we can update this action accordingly.

---

<sup>1: I would personally have preferred if multiple PR templates was a thing, just like multiple Issue templates are...</sup>