### PR TITLE
SVGO config update

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -38,6 +38,10 @@ plugins:
       attrs:
         - baseProfile
 
+  # remove paths with fill="none"
+  - removeUselessStrokeAndFill:
+      removeNone: true
+
   # Enable everything else
   - removeDoctype
   - removeXMLProcInst
@@ -57,7 +61,6 @@ plugins:
   - cleanupListOfValues
   - convertColors
   - removeNonInheritableGroupAttrs
-  - removeUselessStrokeAndFill
   - removeViewBox
   - cleanupEnableBackground
   - removeHiddenElems


### PR DESCRIPTION
SVGO config again! :)

### Description
Includes now the by default disabled `removeNone` param @ `removeUselessStrokeAndFill`.
This is done so it will remove those paths, which have `fill="none"` == are invisible.
(I use them to align my icons properly into their 24×24 box).
It must be enabled because it ain't by default.

