### PR TITLE
Update guidelines for source URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ Make sure the icon is added in alphabetical order. If you're in doubt, you can a
 
 #### Source Guidelines
 
-We use the source URL as a reference for the current SVG in our repository and as a jumping-off point to find updates if the logo changes. If you used one of the sources listed below, make sure to follow these guidelines.
+We use the source URL as a reference for the current SVG in our repository and as a jumping-off point to find updates if the logo changes. If you used one of the sources listed below, make sure to follow these guidelines. If you're unsure about the source URL you can open a Pull Request and ask for help from others.
 
 If the new SVG is sourced from:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ Official high quality brand logos and brand colors can usually be found in the f
 1. Website headers (you can use [svg-grabber](https://chrome.google.com/webstore/detail/svg-grabber-get-all-the-s/ndakggdliegnegeclmfgodmgemdokdmg) for Chrome)
 1. Favicons
 1. Wikimedia (which should provide a source)
+1. GitHub repositories
 
 Working with an SVG version of the logo is best. In the absence of an SVG version, other vector filetypes may work as well (e.g. EPS, AI, PDF). In the absence of vector logos, a vector can be created from a high quality rasterized image, however this is much more labor intensive.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,9 @@ If the new SVG is sourced from:
 
 - **Branding page**: For an SVG from a branding page the source URL should simply link to the branding page.
 - **Company website**: If the SVG is found on the company website (but there is no branding page) the source URL should link to a common page, such as the home page or about page, that includes the source material.
-- **GitHub**: For an SVG from a GitHub repository the source URL should link to the file that was used as source material. If the color comes from another file in the repository the URL should link to the repository itself. In either case the commit hash should be part of the URL. You can get the correct URL by pressing <kbd>y</kbd> on the GitHub page you want to link to. You can get help at the [getting permanent links to files page](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files).
+- **GitHub**: For an SVG from a GitHub (GitLab, BitBucket, etc.) repository the source URL should link to the file that was used as source material. If the color comes from another file in the repository the URL should link to the repository itself.
+
+  In any case the commit hash should be part of the URL. On GitHub, you can get the correct URL by pressing <kbd>y</kbd> on the GitHub page you want to link to. You can get help at the [getting permanent links to files page](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files).
 
 - **Wikipedia**: For an SVG from Wikipedia/Wikimedia the source URL should link to the logo file's page on the relevant site, and not the brand's Wikipedia pages. For example, [this is the link for AmericanExpress](https://commons.wikimedia.org/wiki/File:American_Express_logo.svg).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ Icon metadata should be added to the `_data/simple-icons.json` file. Each icon i
 
   * The `title` of the new SVG.
   * A `hex` color value that matches the brand's primary color. All uppercase and without the `#` pound symbol.)
-  * The `source` URL of the logo being used. This is used to find updates if the logo ever changes.
+  * The `source` URL of the logo being used. There are [more details below](#source-guidelines).
 
 Here is the object for The Movie Database as an example:
 
@@ -148,6 +148,19 @@ Here is the object for The Movie Database as an example:
 ```
 
 Make sure the icon is added in alphabetical order. If you're in doubt, you can always run `npm run our-lint` - this will tell you if any of the JSON data is in the wrong order.
+
+#### Source guidelines
+
+We use the source URL as a reference for the current SVG in our repository and as a jumping-off point to find updates if the logo changes. If you used one of the sources listed below, make sure to follow these guidelines.
+
+If the new SVG is sourced from:
+
+- **Branding page**: For an SVG from a branding page the source URL should simply link to the branding page.
+- **Company website**: If the SVG is found on the company website (but there is no branding page) the source URL should link to a common page, such as the home page or about page, that includes the source material.
+- **GitHub**: For an SVG from a GitHub repository the source URL should link to the file that was used as source material. If the color comes from another file in the repository the URL should link to the repository itself. In either case the commit hash should be part of the URL.
+- **Wikimedia**: For an SVG from Wikipedia/Wikimedia the source URL should be the Wikimedia link for the file that was use as a source.
+
+In general, make sure the URL does not contain any tracking identifiers.
 
 ### 7. Create a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,8 @@ If the new SVG is sourced from:
 
 - **Branding page**: For an SVG from a branding page the source URL should simply link to the branding page.
 - **Company website**: If the SVG is found on the company website (but there is no branding page) the source URL should link to a common page, such as the home page or about page, that includes the source material.
-- **GitHub**: For an SVG from a GitHub repository the source URL should link to the file that was used as source material. If the color comes from another file in the repository the URL should link to the repository itself. In either case the commit hash should be part of the URL.
+- **GitHub**: For an SVG from a GitHub repository the source URL should link to the file that was used as source material. If the color comes from another file in the repository the URL should link to the repository itself. In either case the commit hash should be part of the URL. You can get the correct URL by pressing <kbd>y</kbd> on the GitHub page you want to link to. You can get help at the [getting permanent links to files page](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files).
+
 - **Wikipedia**: For an SVG from Wikipedia/Wikimedia the source URL should link to the logo file's page on the relevant site, and not the brand's Wikipedia pages. For example, [this is the link for AmericanExpress](https://commons.wikimedia.org/wiki/File:American_Express_logo.svg).
 
 In general, make sure the URL does not contain any tracking identifiers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ Make sure the icon is added in alphabetical order. If you're in doubt, you can a
 
 We use the source URL as a reference for the current SVG in our repository and as a jumping-off point to find updates if the logo changes. If you used one of the sources listed below, make sure to follow these guidelines. If you're unsure about the source URL you can open a Pull Request and ask for help from others.
 
-If the new SVG is sourced from:
+If the SVG is sourced from:
 
 - **Branding page**: For an SVG from a branding page the source URL should simply link to the branding page.
 - **Company website**: If the SVG is found on the company website (but there is no branding page) the source URL should link to a common page, such as the home page or about page, that includes the source material.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ If the new SVG is sourced from:
 - **Branding page**: For an SVG from a branding page the source URL should simply link to the branding page.
 - **Company website**: If the SVG is found on the company website (but there is no branding page) the source URL should link to a common page, such as the home page or about page, that includes the source material.
 - **GitHub**: For an SVG from a GitHub repository the source URL should link to the file that was used as source material. If the color comes from another file in the repository the URL should link to the repository itself. In either case the commit hash should be part of the URL.
-- **Wikimedia**: For an SVG from Wikipedia/Wikimedia the source URL should be the Wikimedia link for the file that was use as a source.
+- **Wikipedia**: For an SVG from Wikipedia/Wikimedia the source URL should link to the page containing file information (e.g. [this one for AmericanExpress](https://commons.wikimedia.org/wiki/File:American_Express_logo.svg)).
 
 In general, make sure the URL does not contain any tracking identifiers.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ If the new SVG is sourced from:
 - **Branding page**: For an SVG from a branding page the source URL should simply link to the branding page.
 - **Company website**: If the SVG is found on the company website (but there is no branding page) the source URL should link to a common page, such as the home page or about page, that includes the source material.
 - **GitHub**: For an SVG from a GitHub repository the source URL should link to the file that was used as source material. If the color comes from another file in the repository the URL should link to the repository itself. In either case the commit hash should be part of the URL.
-- **Wikipedia**: For an SVG from Wikipedia/Wikimedia the source URL should link to the page containing file information (e.g. [this one for AmericanExpress](https://commons.wikimedia.org/wiki/File:American_Express_logo.svg)).
+- **Wikipedia**: For an SVG from Wikipedia/Wikimedia the source URL should link to the logo file's page on the relevant site, and not the brand's Wikipedia pages. For example, [this is the link for AmericanExpress](https://commons.wikimedia.org/wiki/File:American_Express_logo.svg).
 
 In general, make sure the URL does not contain any tracking identifiers.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ Here is the object for The Movie Database as an example:
 
 Make sure the icon is added in alphabetical order. If you're in doubt, you can always run `npm run our-lint` - this will tell you if any of the JSON data is in the wrong order.
 
-#### Source guidelines
+#### Source Guidelines
 
 We use the source URL as a reference for the current SVG in our repository and as a jumping-off point to find updates if the logo changes. If you used one of the sources listed below, make sure to follow these guidelines.
 


### PR DESCRIPTION
**Issue:** Following https://github.com/simple-icons/simple-icons/pull/2499#issuecomment-580798030


### Description

Updated the guidelines for the `source` URL,: slightly changing what we use them for, and providing more detailed guidelines for common sources.

This is more like draft, would appreciate feedback on the wording etc. 🙂 
