### PR TITLE
Add icon count to website & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </a>
 <h3 align="center">Simple Icons</h3>
 <p align="center">
-Free SVG icons for popular brands. See them all on one page at <a href="https://simpleicons.org">SimpleIcons.org</a>. Contributions, corrections & requests can be made on GitHub. Started by <a href="https://twitter.com/bathtype">Dan Leech</a>.</p>
+Over 1000 Free SVG icons for popular brands. See them all on one page at <a href="https://simpleicons.org">SimpleIcons.org</a>. Contributions, corrections & requests can be made on GitHub. Started by <a href="https://twitter.com/bathtype">Dan Leech</a>.</p>
 </p>
 
 ## Usage

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 ---
 
+{% assign iconCount = site.data.simple-icons.icons.size %}
 {% assign iconsUnsortedString = "" %}
 {% assign greyscaleIconsUnsortedString = "" %}
 {% for icon in site.data.simple-icons.icons %}
@@ -162,16 +163,16 @@
     <link rel="preconnect" href="//cdn.carbonads.com">
     <link rel="preconnect" href="//github.com">
     <title>Simple Icons</title>
-    <meta name="description" content="Free SVG icons for popular brands.">
+    <meta name="description" content="{{ iconCount }} Free SVG icons for popular brands.">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Simple Icons">
-    <meta property="og:description" content="Free SVG icons for popular brands.">
+    <meta property="og:description" content="{{ iconCount }} Free SVG icons for popular brands.">
     <meta property="og:url" content="https://simpleicons.org">
     <meta property="og:site_name" content="Simple Icons">
     <meta property="og:image" content="https://simpleicons.org/images/og.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Simple Icons">
-    <meta name="twitter:description" content="Free SVG icons for popular brands.">
+    <meta name="twitter:description" content="{{ iconCount }} Free SVG icons for popular brands.">
     <meta name="twitter:site" content="@bathtype">
     <meta name="twitter:domain" content="Simple Icons">
     <meta name="twitter:image:src" content="https://simpleicons.org/images/og.png">
@@ -208,7 +209,7 @@
         </ul>
     </header>
     <main role="main">
-        <p class="hero">Free <abbr title="Scalable Vector Graphic">SVG</abbr> icons for popular&nbsp;brands</p>
+        <p class="hero">{{ iconCount }} Free <abbr title="Scalable Vector Graphic">SVG</abbr> icons for popular&nbsp;brands</p>
         <div class="search">
             <div class="search__wrapper">
                 <div class="search__close"><span>&times;</span></div>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:** Replaces #2365


### Description

As per (the discussion in) #2365 this adds _"Over 1000" (Free SVG icons)_ to the README and inserts the actual number of icons into our website (including the normal, og, and twitter metadata)
