### PR TITLE
Add PlayStation 2

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3766,6 +3766,11 @@
             "source": "http://uk.playstation.com/media/DPBjbK0o/CECH-4202_4203%20PS3_QSG_GB_Eastern_3_web_vf1.pdf"
         },
         {
+            "title": "PlayStation 2",
+            "hex": "003791",
+            "source": "https://commons.wikimedia.org/wiki/File:PlayStation_2_logo.svg"
+        },
+        {
             "title": "PlayStation 3",
             "hex": "003791",
             "source": "https://commons.wikimedia.org/wiki/File:PlayStation_3_Logo_neu.svg#/media/File:PS3.svg"

--- a/icons/playstation2.svg
+++ b/icons/playstation2.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>PlayStation 2 icon</title><path d="M7.46 13.779v.292h4.142v-3.85h3.796V9.93h-4.115v3.85zm16.248-3.558v1.62h-7.195v2.23H24v-.292h-7.168v-1.646H24V9.929h-7.487v.292zm-16.513 0v1.62H0v2.23h.292v-1.938H7.46V9.929H0v.292Z"/></svg>


### PR DESCRIPTION
![PlayStation 2](https://user-images.githubusercontent.com/15157491/75366224-4f8aa580-58b6-11ea-93d7-9cd2769419a0.png)

**Issue:** Closes #2671

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Went with the same colour as our existing PlayStation icons