### PR TITLE
Add Farfetch

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1611,6 +1611,11 @@
             "source": "https://fandomdesignsystem.com/"
         },
         {
+            "title": "Farfetch",
+            "hex": "000000",
+            "source": "https://www.farfetch.com/"
+        },
+        {
             "title": "Fastly",
             "hex": "FF282D",
             "source": "https://assets.fastly.com/style-guide/docs/"

--- a/icons/farfetch.svg
+++ b/icons/farfetch.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Farfetch icon</title><path d="M9.635 0L4.883 4.811V24h4.752v-9.593h7.119V9.6H9.635V4.811h9.482V0Z"/></svg>


### PR DESCRIPTION
![Farfetch](https://user-images.githubusercontent.com/15157491/75796300-5c524200-5d6b-11ea-9fcf-3e8dd5d7e10f.png)

**Issue:** Templarian/MaterialDesign#1805

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Icon from [SVG](https://cdn-static.farfetch-contents.com/v2-33-20062-476/static/images/bobLogo.svg) in website header, using the `F` as they do in their favicon and [app](https://play.google.com/store/apps/details?id=com.farfetch.farfetchshop) icon.

**Alexa rank:** [799](https://www.alexa.com/siteinfo/farfetch.com), which surprised me!