### PR TITLE
Add A-Frame

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -21,14 +21,14 @@
             "source": "https://about.500px.com/press"
         },
         {
-            "title": "ABB RobotStudio",
-            "hex": "FF9E0F",
-            "source": "https://new.abb.com/products/robotics/en/robotstudio/downloads"
-        },
-        {
             "title": "A-Frame",
             "hex": "EF2D5E",
             "source": "https://aframe.io/docs/"
+        },
+        {
+            "title": "ABB RobotStudio",
+            "hex": "FF9E0F",
+            "source": "https://new.abb.com/products/robotics/en/robotstudio/downloads"
         },
         {
             "title": "About.me",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -26,6 +26,11 @@
             "source": "https://new.abb.com/products/robotics/en/robotstudio/downloads"
         },
         {
+            "title": "A-Frame",
+            "hex": "EF2D5E",
+            "source": "https://aframe.io/docs/"
+        },
+        {
             "title": "About.me",
             "hex": "00A98F",
             "source": "https://about.me/assets"

--- a/icons/a-frame.svg
+++ b/icons/a-frame.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>A-Frame icon</title><path d="M17.37 17.07H6.57L4.24 24H3.01l8.23-24h1.52l8.23 24h-1.3zm-.39-1.13l-5-14.96-5.03 14.98h10.03Z"/></svg>


### PR DESCRIPTION
![A-Frame](https://user-images.githubusercontent.com/15157491/76103491-b2242580-5fc9-11ea-89ea-231026820482.png)

**Issue:** Templarian/MaterialDesign#3965

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Icon & colour from [SVG](https://aframe.io/images/aframe-name-pink.svg) in menu header. Not sure whether I should have gone with a boxed version as they do in their favicon - I'm assuming that's just to provide better contrast, given how thin the `A` is.

**Alexa rank:** [147760](https://www.alexa.com/siteinfo/aframe.io)