### PR TITLE
Update CDN URLs in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Icons can be downloaded as SVGs directly from [our website](https://simpleicons.
 
 ### CDN Usage
 
-Icons can be served from a CDN such as [JSDelivr](https://www.jsdelivr.com/package/npm/simple-icons) or [Unpkg](https://unpkg.com). Simply use the `simple-icons` npm package and specify a version in the URL like the following:
+Icons can be served from a CDN such as [JSDelivr](https://www.jsdelivr.com/package/npm/simple-icons) or [Unpkg](https://unpkg.com/browse/simple-icons/). Simply use the `simple-icons` npm package and specify a version in the URL like the following:
 
 ```html
 <img height="32" width="32" src="https://cdn.jsdelivr.net/npm/simple-icons@v2/icons/[ICON NAME].svg" />

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ Icons can be downloaded as SVGs directly from [our website](https://simpleicons.
 Icons can be served from a CDN such as [JSDelivr](https://www.jsdelivr.com/package/npm/simple-icons) or [Unpkg](https://unpkg.com). Simply use the `simple-icons` npm package and specify a version in the URL like the following:
 
 ```html
-<img height="32" width="32" src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/[ICON NAME].svg" />
-<img height="32" width="32" src="https://unpkg.com/simple-icons@latest/icons/[ICON NAME].svg" />
+<img height="32" width="32" src="https://cdn.jsdelivr.net/npm/simple-icons@v2/icons/[ICON NAME].svg" />
+<img height="32" width="32" src="https://unpkg.com/simple-icons@v2/icons/[ICON NAME].svg" />
 ```
 
 Where `[ICON NAME]` is replaced by the icon name, for example:
 
 ```html
-<img height="32" width="32" src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/simpleicons.svg" />
-<img height="32" width="32" src="https://unpkg.com/simple-icons@latest/icons/simpleicons.svg" />
+<img height="32" width="32" src="https://cdn.jsdelivr.net/npm/simple-icons@v2/icons/simpleicons.svg" />
+<img height="32" width="32" src="https://unpkg.com/simple-icons@v2/icons/simpleicons.svg" />
 ```
 
 ### Node Usage

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Where `[ICON NAME]` is replaced by the icon name, for example:
 <img height="32" width="32" src="https://unpkg.com/simple-icons@v2/icons/simpleicons.svg" />
 ```
 
+These examples use the latest major version. This means you won't receive any updates following the next major release. You can use `@latest` instead to receive updates indefinitely. However, this will result in a `404` error if the icon is removed.
+
 ### Node Usage
 
 The icons are also available through our npm package. To install, simply run:


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/MDI-Sandbox/simpleicons/preview/
-->

**Issue:** -

### Checklist
n/a 

### Description


#### Update example URLs

Before, the example links included `@latest`. This is a problem when we make a major release. If anyone is using an icon we removed with an @latest URL, then the icon no longer works. Therefore, I changed `@latest` to `@v2`, which resolves to the latest `2.x.x.` version available.

This behaviour is illustrated by the URLs for `@v1`:

- https://cdn.jsdelivr.net/npm/simple-icons@v1/
- https://unpkg.com/browse/simple-icons@v1/

#### The Unpkg URL

The Unpkg URL in the text linked to the Unpkg homepage but the JSDelivr URL in the text linked to simple-icons' page on JSDelivr. Now, both of them link to the simple-icons page.