### PR TITLE
Allow exponential notation inside icons paths.

### DIFF
--- a/tests/icons.test.js
+++ b/tests/icons.test.js
@@ -24,7 +24,7 @@ icons.forEach(icon => {
 
   test(`${icon.title} has a "path"`, () => {
     expect(typeof subject.path).toBe('string');
-    expect(subject.path).toMatch(/[MmZzLlHhVvCcSsQqTtAa0-9-,.\s]/g);
+    expect(subject.path).toMatch(/[MmZzLlHhVvCcSsQqTtAae0-9-,.\s]/g);
   });
 
   test(`${icon.title} has a "slug"`, () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -24,7 +24,7 @@ icons.forEach(icon => {
 
   test(`${icon.title} has a "path"`, () => {
     expect(typeof subject.path).toBe('string');
-    expect(subject.path).toMatch(/^[MmZzLlHhVvCcSsQqTtAa0-9-,.\s]+$/g);
+    expect(subject.path).toMatch(/^[MmZzLlHhVvCcSsQqTtAae0-9-,.\s]+$/g);
   });
 
   test(`${icon.title} has a "slug"`, () => {


### PR DESCRIPTION
Maybe we need to allow `e` characters inside icons paths to prevent [this](https://travis-ci.com/github/simple-icons/simple-icons/jobs/320569782)? The last version of `uploaded.svg` has the number `5e-3z` and it's breaking tests. See #2921.
