### PR TITLE
Clarify we don't want overlapping paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,9 @@ There are many different tools for editing SVG files, some options include:
 
 Using your preferred tool you should:
 
-1. Isolate the icon from any text or extraneous items. Please also make sure that there are no overlapping paths by merging them.
+1. Isolate the icon from any text or extraneous items.
+1. Merge any overlapping paths.
+1. Compound all paths into one.
 1. Change the icon's viewbox/canvas/page size to 24x24.
 1. Scale the icon to fit the viewbox, while preserving the icon's original proportions. This means the icon should be touching at least two sides of the viewbox.
 1. Center the icon horizontally and vertically.


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/MDI-Sandbox/simpleicons/preview/
-->

**Issue:** n/a

### Description

Following the discussion on 69ae2c829b1c33708e77c02998224d038802d980 this updates the Contributing Guidelines _"Extract the Icon from the Logo"_ section based on @runxel's suggestion.

An alternative (almost equal) solution to consider is:

```diff
  1. Isolate the icon from any text or extraneous items.
+ 1. Merge any overlapping paths and compound all paths into one.
  1. Change the icon's viewbox/canvas/page size to 24x24.
```

---

<sup>Went with a PR rather than a direct commit because I wasn't 100% sure if the discussion was finished. Also, maybe, some input from the contributing community</sup>
