### PR TITLE
Update Adobe After Effects & Dreamweaver sources

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -98,7 +98,7 @@
         {
             "title": "Adobe After Effects",
             "hex": "D291FF",
-            "source": "https://wwwimages2.adobe.com/etc/clientlibs/beagle/ace/source/font/aceui-fonts.svg"
+            "source": "https://www.adobe.com/products/aftereffects.html"
         },
         {
             "title": "Adobe Audition",
@@ -113,7 +113,7 @@
         {
             "title": "Adobe Dreamweaver",
             "hex": "35FA00",
-            "source": "https://wwwimages2.adobe.com/etc/clientlibs/beagle/ace/source/font/aceui-fonts.svg"
+            "source": "https://www.adobe.com/products/dreamweaver.html"
         },
         {
             "title": "Adobe Fonts",


### PR DESCRIPTION
**Issue:** #2734 and separated out of #2769

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
Not a biggie; our [existing source URL](https://wwwimages2.adobe.com/etc/clientlibs/beagle/ace/source/font/aceui-fonts.svg) for both brands is dead but our icons and colours still match up with the SVGs found in the headers of both new source URLs.