### PR TITLE
Update Adobe Illustrator & InDesign colours

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -122,13 +122,13 @@
         },
         {
             "title": "Adobe Illustrator",
-            "hex": "FF7C00",
-            "source": "https://wwwimages2.adobe.com/etc/clientlibs/beagle/ace/source/font/aceui-fonts.svg"
+            "hex": "F37021",
+            "source": "https://www.adobe.com/products/illustrator.html"
         },
         {
             "title": "Adobe InDesign",
-            "hex": "FD3F93",
-            "source": "https://wwwimages2.adobe.com/etc/clientlibs/beagle/ace/source/font/aceui-fonts.svg"
+            "hex": "EE3D8F",
+            "source": "https://www.adobe.com/products/indesign.html"
         },
         {
             "title": "Adobe Lightroom CC",


### PR DESCRIPTION
![Adobe Illustrator](https://user-images.githubusercontent.com/15157491/81168253-9075f900-8f8e-11ea-8d01-578d1c6fb664.png)
![Adobe InDesign](https://user-images.githubusercontent.com/15157491/81168288-9ff54200-8f8e-11ea-803a-9bf6b6ee64fa.png)

**Issue:** #2734 and separated out of #2769

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
Colours from SVGs found in headers of respective new source URLs