### PR TITLE
Avoid to run svglint for icons/*.js files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "run-s our-lint jsonlint svglint wslint",
     "our-lint": "node scripts/lint.js",
     "jsonlint": "jsonlint _data/simple-icons.json -q -V .jsonlintschema",
-    "svglint": "svglint icons/* --ci",
+    "svglint": "svglint icons/*.svg --ci",
     "wslint": "editorconfig-checker -exclude \\.svg$",
     "prepublishOnly": "npm run build",
     "postpublish": "npm run clean",


### PR DESCRIPTION
Only run `svglint` for SVG files inside `icons/` folder, so you can build the library and lint SVG files after. It's just for comfort.
