### PR TITLE
Add the use of icons to svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Icons are also available on Kirby through a simple plugin created by [@runxel](h
 
 Icons are also available on React through a simple package created by [@wootsbot](https://github.com/wootsbot), which you can find [here](https://github.com/mamut-dev/icons-pack/tree/master/packages/react-simple-icons).
 
+### Svelte
+
+Icons are also available on Svelte through a simple package created by [@wootsbot](https://github.com/wootsbot), which you can find [here](https://github.com/icons-pack/svelte-simple-icons).
+
 ## Status
 
 [![Build Status](https://travis-ci.com/simple-icons/simple-icons.svg?branch=develop)](https://travis-ci.com/simple-icons/simple-icons)


### PR DESCRIPTION
### Description

Add in the `README.md` the use of the [@icons-pack/svelte-simple-icons](https://github.com/icons-pack/svelte-simple-icons) package to be able to expand the uses of the icons as components in `Svelte`.

