### PR TITLE
Fix run lint, Trailing whitespace

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -4809,7 +4809,7 @@
             "title": "Razer",
             "hex": "00FF00",
             "source": "https://en.wikipedia.org/wiki/File:Razer_snake_logo.svg"
-        },        
+        },
         {
             "title": "React",
             "hex": "61DAFB",


### PR DESCRIPTION
### Description

In line `4812` of the file `_data/simple-icons.json` there was a blank space at the end

- fix run lint Trailing whitespace
