### PR TITLE
fix broken link to react-simple-icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Icons are also available on Kirby through a simple plugin created by [@runxel](h
 
 ### React
 
-Icons are also available on React through a simple package created by [@wootsbot](https://github.com/wootsbot), which you can find [here](https://github.com/mamut-dev/icons-pack/tree/master/packages/react-simple-icons).
+Icons are also available on React through a simple package created by [@wootsbot](https://github.com/wootsbot), which you can find [here](https://github.com/icons-pack/react-simple-icons).
 
 ### Svelte
 


### PR DESCRIPTION
### Description

The link to the [react-simple-icons](https://github.com/icons-pack/react-simple-icons) package was updated due to the fact that you moved from the organization.