### PR TITLE
Add Home Assistant to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ echo file_get_contents('path/to/package/icons/simple-icons.svg');
 
 ## Third Party Extensions
 
-### WordPress
-
-Icons are also available on WordPress through a simple plugin created by [@tjtaylo](https://github.com/tjtaylo), which you can find [here](https://wordpress.org/plugins/simple-icons/).
-
 ### Drupal
 
-Icons are also availabe on Drupal through a module created by [Phil Wolstenholme](https://www.drupal.org/u/phil-wolstenholme), which you can find [here](https://www.drupal.org/project/simple_icons).
+Icons are also availabe on Drupal through a simple module created by [Phil Wolstenholme](https://www.drupal.org/u/phil-wolstenholme), which you can find [here](https://www.drupal.org/project/simple_icons).
+
+### Home Assistant
+
+Icons are also available for Home Assistant through a simple plugin created by [@vignotion](https://github.com/vigonotion/), which you can find [here](https://github.com/vigonotion/hass-simpleicons).
 
 ### Kirby
 
@@ -122,6 +122,10 @@ Icons are also available on Kirby through a simple plugin created by [@runxel](h
 ### React
 
 Icons are also available on React through a simple package created by [@wootsbot](https://github.com/wootsbot), which you can find [here](https://github.com/mamut-dev/icons-pack/tree/master/packages/react-simple-icons).
+
+### WordPress
+
+Icons are also available on WordPress through a simple plugin created by [@tjtaylo](https://github.com/tjtaylo), which you can find [here](https://wordpress.org/plugins/simple-icons/).
 
 ## Status
 


### PR DESCRIPTION
This PR adds @vigonotion's [hass-simpleicons](https://github.com/vigonotion/hass-simpleicons) plugin for [Home Assistant](https://www.home-assistant.io/) to the list of third party extensions in `README.md` and also moves the Wordpress plugin to the end of the list so that it is sorted alphabetically.