### PR TITLE
Update Bitwarden color

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -817,7 +817,7 @@
         },
         {
             "title": "Bitwarden",
-            "hex": "3C8DBC",
+            "hex": "175DDC",
             "source": "https://github.com/bitwarden/brand/blob/f2d666eda756e2aba26f1463f102bc24ba179df2/icons/icon.svg"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -818,7 +818,7 @@
         {
             "title": "Bitwarden",
             "hex": "175DDC",
-            "source": "https://github.com/bitwarden/brand/blob/f2d666eda756e2aba26f1463f102bc24ba179df2/icons/icon.svg"
+            "source": "https://github.com/bitwarden/brand/blob/6182cd64321d810c6f6255db08c2a17804d2b724/icons/icon.svg"
         },
         {
             "title": "Blackberry",


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/MDI-Sandbox/simpleicons/preview/
-->


![bitwarden](https://user-images.githubusercontent.com/1506970/83409609-06964000-a415-11ea-974c-0f16776a49b5.png)


**Issue:**

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->

Bitwarden changed their brand color to `#175DDC`.
You can see the new color in use here: https://bitwarden.com/ (color has been extracted from their css).
