### PR TITLE
Add VirusTotal icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -6233,7 +6233,7 @@
         {
             "title": "VirusTotal",
             "hex": "394EFF",
-            "source": "https://www.virustotal.com/gui/user//comments"
+            "source": "https://www.virustotal.com/"
         },
         {
             "title": "Visa",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -6231,6 +6231,11 @@
             "source": "http://virb.com/about"
         },
         {
+            "title": "VirusTotal",
+            "hex": "394EFF",
+            "source": "https://www.virustotal.com/gui/user//comments"
+        },
+        {
             "title": "Visa",
             "hex": "142787",
             "source": "https://commons.wikimedia.org/wiki/File:Visa_2014_logo_detail.svg"

--- a/icons/virustotal.svg
+++ b/icons/virustotal.svg
@@ -1,0 +1,1 @@
+<svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>VirusTotal icon</title><path d="M10.87 12L0 22.68h24V1.32H0zm10.73 8.52H5.28l8.637-8.448L5.28 3.48H21.6z"/></svg>


### PR DESCRIPTION
**Issue:** Closes #3171

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
- The hex value was from @PeterShaggyNoble 
- It was already a vector, I used a combination of a text editor, Inkscape, and SVGOMG to make it ready.
- I used the one with only the icon.
- More info is available in #3171, and in [simple-icons.json](https://github.com/simple-icons/simple-icons/compare/develop...KTibow:develop#diff-df9e95716b46f7061fee6b9225b7bc98)

![virustotal](https://user-images.githubusercontent.com/10727862/83888136-4a7f9280-a6fe-11ea-8852-1603f87e1f2f.png)