### PR TITLE
Fully escape parameter before use in Regexp

### DIFF
--- a/site_script.js
+++ b/site_script.js
@@ -54,12 +54,12 @@
     };
   }
 
-  // Get any parameter from the URL's search section (location.search).
-  // see
+  // Get a parameter from the URL's search section (location.search). Based on:
   //   - https://davidwalsh.name/query-string-javascript
   //   - https://github.com/WebReflection/url-search-params
+  //   - https://stackoverflow.com/a/6969486
   function getUrlParameter(parameter) {
-    var name = parameter.replace(/[\[]/g, '\\[').replace(/[\]]/g, '\\]');
+    var name = parameter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
     var results = regex.exec(location.search);
     return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));

--- a/site_script.js
+++ b/site_script.js
@@ -57,7 +57,7 @@
   // Get a parameter from the URL's search section (location.search). Based on:
   //   - https://davidwalsh.name/query-string-javascript
   //   - https://github.com/WebReflection/url-search-params
-  //   - https://stackoverflow.com/a/6969486
+  //   - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
   function getUrlParameter(parameter) {
     var name = parameter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');


### PR DESCRIPTION
Following up on #3342, this improve the `site_script.js` based on [this LGTM alert](https://lgtm.com/projects/g/simple-icons/simple-icons/snapshot/b54065727825cac829f6c602c7be0a708ddbc3ad/files/site_script.js?sort=name&dir=ASC&mode=heatmap#V62) further by escaping all special characters in the string that is used to match a specific parameter in `location.search` using a Regular Expression in [`getUrlParameter`](https://github.com/simple-icons/simple-icons/blob/809b5f0cc5ab898e9a5238134af65c4e46771000/site_script.js#L61-L66).