### PR TITLE
update color of SAP logo

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -5283,7 +5283,7 @@
         {
             "title": "SAP",
             "hex": "0FAAFF",
-            "source": "https://support.sap.com/content/dam/support/sap-logo.svg"
+            "source": "https://www.sap.com/"
         },
         {
             "title": "Sass",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -5282,7 +5282,7 @@
         },
         {
             "title": "SAP",
-            "hex": "008FD3",
+            "hex": "0FAAFF",
             "source": "https://support.sap.com/content/dam/support/sap-logo.svg"
         },
         {


### PR DESCRIPTION
Title: SAP
Hex: 0FAAFF
Source: https://support.sap.com/content/dam/support/sap-logo.svg
Brand guidelines: https://www.sapbrandtools.com/logo#sap-logo_alternative-logos

![Simple Icons Preview: SAP](https://user-images.githubusercontent.com/10072099/89126511-5b723780-d4e6-11ea-9499-c0a5a276c700.png)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
I am an SAP employee and was confused by the color of the SAP logo when I saw it on simple icons. The information which color to use it not really obvious because the SAP logo is a gradient logo. I saw that some styleguide has been found when creating the SAP logo here on simple icons. There was lists of colors we use, but we do not use this blue for our logo (`#008fd3`) but only for text/graphs/...

We have a website regarding branding which should also be available for externals after registering. To avoid you this step, I just added a screenshot of https://www.sapbrandtools.com/logo#sap-logo_alternative-logos which displays the solid color logo:
![image](https://user-images.githubusercontent.com/10072099/89126546-a8eea480-d4e6-11ea-878f-5590178f4f0e.png)

Source for the graphic on the left side: https://d.dam.sap.com/a/AJUOAK (should be available without registering/login)

As you can see, the color used for the logo is another one (`#0faaff`). I also asked someone from our branding team at SAP and they confirmed that this color should work better than the one before (even though the solid color version of the logo is mostly/only used for printing and should be avoided when using it digitally). But I am aware that only one color is possible here, so this one should be the closest you can get.

I just updated the color to `#0faaff` in `_data/simple-icons.json` and did not touch the svg.
