### PR TITLE
Add Lospec

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3606,6 +3606,11 @@
             "source": "https://loop.frontiersin.org/"
         },
         {
+            "title": "Lospec",
+            "hex": "EAEAEA",
+            "source": "https://lospec.com/brand"
+        },
+        {
             "title": "Lua",
             "hex": "2C2D72",
             "source": "https://www.lua.org/docs.html"

--- a/icons/lospec.svg
+++ b/icons/lospec.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Lospec icon</title><path d="M4.23 0v24h15.541v-8.4h-7.172v3.6h-1.197V0z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Lospec icon</title><path d="M4.23 0v24h15.541v-8.4004h-7.1719v3.5996H11.402V0z"/></svg>

--- a/icons/lospec.svg
+++ b/icons/lospec.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Lospec icon</title><path d="M4.7 0v24h15.541v-8.4h-7.172v3.6h-1.197V0z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Lospec icon</title><path d="M4.23 0v24h15.541v-8.4h-7.172v3.6h-1.197V0z"/></svg>

--- a/icons/lospec.svg
+++ b/icons/lospec.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Lospec icon</title><path d="M4.7 0v24h15.541v-8.4h-7.172v3.6h-1.197V0z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/MDI-Sandbox/simpleicons/preview/
--> 
![lospec](https://user-images.githubusercontent.com/53346722/93008691-1dcce980-f53d-11ea-8ce0-b1921a9d666f.png)

**Name:** Lospec
**Website:** https://lospec.com/
**Alexa rank:** [318,564](https://www.alexa.com/siteinfo/lospec.com)
  <!-- The Alexa rank can be retrieved at https://www.alexa.com/siteinfo/
       Please see our contributing guidelines for more details on how we
       assess a brand's popularity. -->

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
--> The hex value is the logo color from the branding page. The background color is (332F35). The logo was from the branding page as svg format. The usage section of the branding page says,

> The Logo and logomark should be placed on a dark background, preferably our background color, but can be reversed if needed. As the logo is essentially pixel art, it's best if it's resized to an exact multiple of 100% using a nearest-neighbor algorithm to prevent blurring.
