### PR TITLE
Focus the search input on load

### DIFF
--- a/site_script.js
+++ b/site_script.js
@@ -17,6 +17,7 @@
   // Remove the "disabled" attribute from the search input
   $searchInput.setAttribute('title', 'Search Simple Icons');
   $searchInput.removeAttribute('disabled');
+  $searchInput.focus();
 
   // include a modified debounce underscorejs helper function.
   // see


### PR DESCRIPTION
This updates the website source so that the search input is focused on load. (this cannot be achieved with [the HTML autofocus attribute](https://www.w3schools.com/tags/att_input_autofocus.asp) because the field is disabled by default in case JavaScript is disabled in the browser).

Closes  #1982