### PR TITLE
Set up automated labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+new icon:
+- any: [icons/*.svg]
+  status: 'added'
+icon outdated:
+- any: [icons/*.svg]
+  status: 'modified'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+  pull_request_target:
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: ericcornelissen/labeler@label-based-on-status
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This will add automated labelling for Pull Requests. More specifically, this adds a GitHub Actions Workflow file that utilizes [the labeler Action](https://github.com/actions/labeler) to automatically assign the labels [`new icon`](https://github.com/simple-icons/simple-icons/pulls?q=label%3A%22new+icon%22) and [`icon outdated`](https://github.com/simple-icons/simple-icons/pulls?q=label%3A%22icon+outdated%22) based on whether or not an SVG was added or edited in [the `icons/` folder](https://github.com/simple-icons/simple-icons/tree/develop/icons).

Even more specific, this PR is using [my fork of the labeler Action](https://github.com/ericcornelissen/labeler) because the functionality used (namely: labeling based on whether a file was "added", "modified", or "removed") is [not yet part of the official labeler Action](https://github.com/actions/labeler/pull/79).

This PR is different from #2420 in that it uses the `pull_request_target` event instead of `pull_request` (which runs the Action in the context of this repository rather than that of the fork), which has been added after we removed automated labeling in #2449. I'm pretty sure it will actually work this time, as evidenced by [this PR](https://github.com/ericcornelissen/simple-icons/pull/47) opened from @runxel's fork of this repository into my own fork of this repository.