### PR TITLE
Exclude unnecessary files and directories from website build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,11 @@
+exclude: [
+  'tests',
+  'scripts',
+  'composer.json',
+  'CONTRIBUTING.md',
+  'Dockerfile',
+  'LICENSE.md',
+  'package-lock.json',
+  'package.json',
+  'README.md'
+]

--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,10 @@
-exclude: [
-  'tests',
-  'scripts',
-  'composer.json',
-  'CONTRIBUTING.md',
-  'Dockerfile',
-  'index.js',
-  'LICENSE.md',
-  'package-lock.json',
-  'package.json',
-  'README.md'
-]
+exclude:
+- tests
+- scripts
+- composer.json
+- CONTRIBUTING.md
+- Dockerfile
+- index.js
+- package-lock.json
+- package.json
+- README.md

--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ exclude: [
   'composer.json',
   'CONTRIBUTING.md',
   'Dockerfile',
+  'index.js',
   'LICENSE.md',
   'package-lock.json',
   'package.json',


### PR DESCRIPTION
After build `_site` locally, if I run tests, next errors are raised:

<details>
<summary>Jest errors</summary>

```
FAIL  _site/tests/icons.test.js
 ● Test suite failed to run

   Cannot find module '../_data/simple-icons.json' from '_site/tests/icons.test.js'

   > 1 | const { icons } = require('../_data/simple-icons.json');
       |                   ^
     2 | const { titleToFilename } = require('../scripts/utils.js');
     3 | 
     4 | icons.forEach(icon => {

     at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:306:11)
     at Object.<anonymous> (_site/tests/icons.test.js:1:19)

FAIL  _site/tests/index.test.js
 ● Test suite failed to run

   Cannot find module '../_data/simple-icons.json' from '_site/tests/index.test.js'

   > 1 | const { icons } = require('../_data/simple-icons.json');
       |                   ^
     2 | const simpleIcons = require('../index.js');
     3 | const { titleToFilename } = require("../scripts/utils.js");
     4 | 

     at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:306:11)
     at Object.<anonymous> (_site/tests/index.test.js:1:19)
```

</details>

The problem is that jest discover the directory `_site/tests` and run it along with `tests`. But, we don't need the next files inside website `_site` directory:

- `tests/` -> http://simpleicons.org/tests/icons.test.js
- `scripts/` -> http://simpleicons.org/scripts/build-package.js
- `composer.json` -> http://simpleicons.org/composer.json
- `CONTRIBUTING.md` -> http://simpleicons.org/CONTRIBUTING.md
- `Dockerfile` -> http://simpleicons.org/Dockerfile
- `index.js`
- `LICENSE.md` -> http://simpleicons.org/LICENSE.md
- `package-lock.json` -> http://simpleicons.org/package-lock.json
- `package.json` -> http://simpleicons.org/package.json
- `README.md` -> http://simpleicons.org/README.md

So the solution is not to include them from website build using a [Jekyll configuration file](https://jekyllrb.com/docs/configuration/). The new `_site` tree would be:

```
_site
├── CNAME
├── icons
├── images
├── index.html
├── site_script.js
└── stylesheet.css
```

## Steps to reproduce

```bash
gem install jekyll bundler
jekyll build
npm install
npm run test
```