### PR TITLE
Allow exponential notation with E uppercase inside icon paths.

### DIFF
--- a/tests/icons.test.js
+++ b/tests/icons.test.js
@@ -24,7 +24,7 @@ icons.forEach(icon => {
 
   test(`${icon.title} has a "path"`, () => {
     expect(typeof subject.path).toBe('string');
-    expect(subject.path).toMatch(/[MmZzLlHhVvCcSsQqTtAae0-9-,.\s]/g);
+    expect(subject.path).toMatch(/[MmZzLlHhVvCcSsQqTtAaEe0-9-,.\s]/g);
   });
 
   test(`${icon.title} has a "slug"`, () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -24,7 +24,7 @@ icons.forEach(icon => {
 
   test(`${icon.title} has a "path"`, () => {
     expect(typeof subject.path).toBe('string');
-    expect(subject.path).toMatch(/^[MmZzLlHhVvCcSsQqTtAae0-9-,.\s]+$/g);
+    expect(subject.path).toMatch(/^[MmZzLlHhVvCcSsQqTtAaEe0-9-,.\s]+$/g);
   });
 
   test(`${icon.title} has a "slug"`, () => {


### PR DESCRIPTION
I just realized that [SVG 1.1 Specification](https://www.w3.org/TR/SVG11/paths.html#PathData) allows exponential notation using `E` uppercase inside paths, so we can allow it extending #2946.