### PR TITLE
Improve TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,18 @@ jobs:
       name: "Lint"
       language: node_js
       node_js: 10
+      git:
+        depth: 1
       script:
         - npm run jsonlint
         - npm run svglint
         - npm run wslint
         - npm run our-lint
-      git:
-        depth: 1
     - name: "Build website"
       language: ruby
       rvm: 2.5.3
+      git:
+        depth: 1
       cache:
         directories:
           - /home/travis/.rvm/
@@ -23,15 +25,13 @@ jobs:
         - gem install jekyll
       script:
         - jekyll build
-      git:
-        depth: 1
     - name: "Test package"
       language: node_js
       node_js: 10
-      script:
-        - npm run test
       git:
         depth: 1
+      script:
+        - npm run test
 
     - stage: "Deploy"
       name: "Git tag"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 os: linux
-language: node_js
 
 jobs:
   include:
@@ -12,20 +11,29 @@ jobs:
         - npm run svglint
         - npm run wslint
         - npm run our-lint
+      git:
+        depth: 1
     - name: "Build website"
       language: ruby
-      rvm: 2.4.1
+      rvm: 2.5.3
+      cache:
+        directories:
+          - /home/travis/.rvm/
       install:
         - gem install jekyll
       script:
         - jekyll build
+      git:
+        depth: 1
     - name: "Test package"
       language: node_js
       node_js: 10
       script:
         - npm run test
+      git:
+        depth: 1
 
-    - stage: deploy
+    - stage: "Deploy"
       name: "Git tag"
       language: shell
       if: branch = master
@@ -38,9 +46,12 @@ jobs:
       deploy:
         provider: releases
         token: "$GITHUB_TOKEN"
+        skip_cleanup: true
     - name: "NPM Package"
       language: node_js
       node_js: 10
+      git:
+        depth: 1
       if: branch = master
 
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ jobs:
     - stage: "Deploy"
       name: "Git tag"
       language: shell
+      git:
+        depth: 1
       if: branch = master
 
       before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
       deploy:
         provider: releases
         token: "$GITHUB_TOKEN"
-        skip_cleanup: true
+        cleanup: false
     - name: "NPM Package"
       language: node_js
       node_js: 10
@@ -59,6 +59,7 @@ jobs:
         provider: npm
         email: "$NPM_EMAIL"
         api_token: "$NPM_KEY"
+        cleanup: false
         on:
           branch: master
 


### PR DESCRIPTION
This pull optimize all the TravisCI jobs, especially the "Build website":

1. Removed root `language` because is explicitly declared in jobs.
2. Unify stage names, both Capitalized.
3. Add `git.depth: 1` to reduce `git clone` command time for all jobs ~~except "Git tag" (I'm not sure if there could be risky)~~.
4. Add ~~`deploy.skip_cleanup: true`~~ `deploy.cleanup: false` for "Git tag" job because there is nothing to clean (or I'm missing something? :thinking:). I couldn't tested this. EDIT: Added it also for "NPM package".
5. Upgrade Ruby version with preinstalled TravisCI `2.5.3` in "Build website" job.
6. Cache Ruby installation in "Build website" job as [recommended by TravisCI](https://docs.travis-ci.com/user/caching/#cache-rvm-ruby-version-for-non-ruby-projects). The cache [will expire in 45 days](https://docs.travis-ci.com/user/caching/#caches-expiration). Since we are not freezing gem versions in a Gemfile, this is perfect for our Jekyll use case. This is the greatest optimization in this pull, as you can see in [this job](https://travis-ci.com/github/mondeja/simple-icons/jobs/432363573), taking about the same time as the other jobs.
