### PR TITLE
Add minimum NodeJS version requirement to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "get-filename": "node scripts/get-filename.js"
   },
   "engine": {
-    "node": ">=>=0.12.18"
+    "node": ">=0.12.18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "posttest": "npm run postpublish",
     "svgo": "svgo --config=./.svgo.yml",
     "get-filename": "node scripts/get-filename.js"
+  },
+  "engine": {
+    "node": ">=>=0.12.18"
   }
 }


### PR DESCRIPTION
**Issue:** #3959

Minimum version of NodeJS required to install simple-icons will be 0.12.18 after this pull.