### PR TITLE
Skip release job in non-release pull request review

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request_review' && contains(github.event.pull_request.labels.*.name, 'release')) || github.event_name == 'schedule'
     steps:
     - uses: simple-icons/release-action@master
       with:


### PR DESCRIPTION
I've seen a lot of times that the `release` job is executed when a pull request is reviewed, even if is not a pull with `release` label. This spend minutes of Github Actions (now free) which can be saved, time reviewing pulls and can generate confusion.

In order to accomplish this, I'm skipping the job if the event triggered is `pull_request_review` but the pull request does not [contains](https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#contains) the label `release`.

You can see this behaviour tested at https://github.com/mondeja/test-si-release/pulls