### PR TITLE
Correct Logstash icon

### DIFF
--- a/icons/logstash.svg
+++ b/icons/logstash.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Logstash icon</title><path d="M12.6 7.2V24c-5.2 0-10.8-4-10.8-9.3V0h3.6c3.8 0 7.2 3.4 7.2 7.2zm2.4 6V24h7.2V13.2z"/></svg>
+<svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Logstash icon</title><path d="M13.745 24h8.291v-9.164h-8.29zm-2.618 0h.437v-9.164h-9.6A9.163 9.163 0 0011.127 24m.438-9.164h-9.6V0h.873a8.727 8.727 0 018.727 8.727z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/MDI-Sandbox/simpleicons/preview/
-->
![image](https://user-images.githubusercontent.com/12817388/100523272-48623200-317d-11eb-8bd1-621d88d46b22.png)

**Issue:** #3169
**Alexa rank:**
  <!-- The Alexa rank can be retrieved at https://www.alexa.com/siteinfo/
       Please see our contributing guidelines for more details on how we
       assess a brand's popularity. -->

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
- I took the original logo from https://www.elastic.co/fr/brand since the current icon looks wrong.
- I used Inkscape to fix size and center
- I used https://jakearchibald.github.io/svgomg/ to optimize the resulting SVG

**_Note: I think the color needs to be updated, but not sure which one to use..._**
