### PR TITLE
Update release.yml to allow for automated release merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
     - uses: simple-icons/release-action@master
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Following [the discussion on the latest `release` PR](https://github.com/simple-icons/simple-icons/pull/4150#issuecomment-735380711), this changes the [Automated releases workflow](https://github.com/simple-icons/simple-icons/actions?query=workflow%3A%22Automated+releases%22) to use a Personal Access Token (stored as `RELEASE_TOKEN` in the repository secrets) instead of the standard `GITHUB_TOKEN`.

As per the discussion, the usage of the `GITHUB_TOKEN` prevents the merge commit on `master` created by the workflow from having any GitHub Actions workflows being run on it. As per [the documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token) (thanks @mondeja!) using a Personal Access Token instead will resolve this issue. For now, I added a Personal Access Token of my own to the secrets of this repository.

Since the workflow where we use `RELEASE_TOKEN` isn't triggered by commits, we are pretty safe with respect to infinite CI loops. But it does mean that we should be careful with any changes to how this workflow is configured in the future!

I tested this on my own fork of this repository (apologies for the mess). I created [a "random" PR](https://github.com/ericcornelissen/simple-icons/pull/48) to merge `develop` into `master` labelled as a `release`. I than had this PR merged by the GitHub Actions workflow, resulting in [the commit with hash f13cccfe134703253f602ac8eb04f5b13095dc44](https://github.com/ericcornelissen/simple-icons/commit/f13cccfe134703253f602ac8eb04f5b13095dc44). And, as you can see in the GitHub UI, all the expected workflows were triggered on this commit.

 * * *

Also as per the discussion mentioned earlier. An alternative would be to do the deployments to GitHub Releases and NPM via a separate CI vendor (e.g. Travis CI as we used before). I did not yet test whether commits created by a workflow using `GITHUB_TOKEN` trigger Travis CI (or other CI) builds. If there is interest in this alternative I could test this.