### PR TITLE
Update setup Ruby step in build job of verification workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -27,9 +27,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Use Ruby 2.5
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.5
+        ruby-version: 2.7
     - name: Setup cache for gems
       uses: actions/cache@v2
       with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Use Ruby 2.5
+    - name: Use Ruby 2.7
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7


### PR DESCRIPTION
As you can see in [this run](https://github.com/simple-icons/simple-icons/pull/4210/checks?check_run_id=1484519338#step:5:6), the `bundle` command does not exists in the instance for ruby which executes the "Build Website" job. This is happening in all new pull requests because Github Actions now uses Ubuntu 20.04 specifying `ubuntu-latest`. I've been investigating this and seems that the action [actions/setup-ruby](https://github.com/actions/setup-ruby) is not maintained, with [bugs in Ubuntu 20.04](https://github.com/actions/setup-ruby/issues/70), and do not explicitly specify Bundler availability, so I've changed by [ruby/setup-ruby](https://github.com/ruby/setup-ruby) action that seems better maintained, supports a lot of versions and [explicitly declares Bundler availability](https://github.com/ruby/setup-ruby#bundler).

Also, I've updated the Ruby version to 2.7 because [Ruby v2.5 will reach their EOL](https://www.ruby-lang.org/en/downloads/branches/) at 2021-03-31. 