### PR TITLE
Avoid truthy check for strings in package index

### DIFF
--- a/scripts/templates/index.js
+++ b/scripts/templates/index.js
@@ -5,14 +5,12 @@ Object.defineProperty(icons, "get", {
   value: function(targetName) {
     if (icons[targetName]) {
       return icons[targetName];
-    } else {
-      var normalizedName = targetName.toLowerCase();
-      for (var iconName in icons) {
-        var icon = icons[iconName];
-        if ((icon.title && icon.title.toLowerCase() === normalizedName)
-         || (icon.slug && icon.slug === normalizedName)) {
-           return icon;
-        }
+    }
+    var normalizedName = targetName.toLowerCase();
+    for (var iconName in icons) {
+      var icon = icons[iconName];
+      if (icon.title.toLowerCase() === normalizedName || icon.slug === normalizedName) {
+         return icon;
       }
     }
   }


### PR DESCRIPTION
Since `slug` and `title` properties of all icons are filled (not empty), we can avoid the truthy check for both strings. This increments the execution speed of the getter. The `else` branch removal does not have effect in minified built file, because this is done yet by the minifier,  so I've removed.