### PR TITLE
Auto Assign PRs to priorisation project

### DIFF
--- a/.github/workflows/auto-assign-to-project.yml
+++ b/.github/workflows/auto-assign-to-project.yml
@@ -7,7 +7,7 @@ env:
   MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  assign_one_project:
+  assign-to-project:
     runs-on: ubuntu-latest
     name: Assign to Project
     steps:

--- a/.github/workflows/auto-assign-to-project.yml
+++ b/.github/workflows/auto-assign-to-project.yml
@@ -1,0 +1,26 @@
+name: Auto Assign to Project(s)
+
+on:
+  pull_request:
+    types: [opened, labeled]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to One Project
+    steps:
+    - name: Assign NEW pull requests to "Unprioritised" column
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/orgs/simple-icons/projects/2'
+        column_name: 'Unprioritised'
+
+    - name: Assign pull requests with `icon outdated` label to "Priority 1" column
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      if: contains(github.event.pull_request.labels.*.name, 'icon outdated')
+      with:
+        project: 'https://github.com/orgs/simple-icons/projects/2'
+        column_name: 'Priority 1'

--- a/.github/workflows/auto-assign-to-project.yml
+++ b/.github/workflows/auto-assign-to-project.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, labeled]
 env:
-  MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  MY_GITHUB_TOKEN: ${{ secrets.AUTO_ASSIGN_WORKFLOW_TOKEN }}
 
 jobs:
   assign-to-project:

--- a/.github/workflows/auto-assign-to-project.yml
+++ b/.github/workflows/auto-assign-to-project.yml
@@ -4,23 +4,23 @@ on:
   pull_request:
     types: [opened, labeled]
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   assign_one_project:
     runs-on: ubuntu-latest
-    name: Assign to One Project
+    name: Assign to Project
     steps:
-    - name: Assign NEW pull requests to "Unprioritised" column
+    - name: Assign pull requests to "Unprioritised"
       uses: srggrs/assign-one-project-github-action@1.2.0
       if: github.event.action == 'opened'
       with:
-        project: 'https://github.com/orgs/simple-icons/projects/2'
-        column_name: 'Unprioritised'
+        project: https://github.com/orgs/simple-icons/projects/2
+        column_name: Unprioritised
 
-    - name: Assign pull requests with `icon outdated` label to "Priority 1" column
+    - name: Assign `icon outdated` pull requests to "Priority 1"
       uses: srggrs/assign-one-project-github-action@1.2.0
       if: contains(github.event.pull_request.labels.*.name, 'icon outdated')
       with:
-        project: 'https://github.com/orgs/simple-icons/projects/2'
-        column_name: 'Priority 1'
+        project: https://github.com/orgs/simple-icons/projects/2
+        column_name: Priority 1


### PR DESCRIPTION
As discussed internally before, we use a priorisation project. This workflow would help us auto assign PRs to this project.

- New PRs to Unprioritised column
- PRs labeled as `icon outdated` to Priority 1

### Missing

I'm not able to generate an Organization token to add as Secrets:
https://github.com/srggrs/assign-one-project-github-action#organisation-or-user-project