### PR TITLE
Suggest using "Treeless clone" to contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,10 @@
 Simple Icons welcomes contributions and corrections. Before contributing, please make sure you have read the guidelines below. If you decide to contribute anything, please do the following:
 
 1. Fork this repository
+1. (Optional) Clone the fork
+   ```
+   git clone --filter=tree:0 git@github.com:simple-icons/simple-icons.git
+   ```
 1. Create a new branch from the latest `develop` (read more [here](https://guides.github.com/introduction/flow/))
 1. Start hacking on the new branch
 1. Commit and push to the new branch
@@ -31,11 +35,11 @@ We welcome icon requests. Before you submit a new issue please make sure the ico
        - Allowed: Space agencies
     - Symbols, including flags and banners
     - Sport clubs
-       - Allowed: Sport organizations 
+       - Allowed: Sport organizations
     - Yearly releases
     - Universities or other educational institutions
     - Any brands representing individuals rather than an organization, company or product. This includes musicians, bands, and social media personalities.
-    
+
 If you are in doubt, feel free to submit it and we'll have a look.
 
 When submitting a request for a new or updated icon include helpful information such as:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,9 @@ Simple Icons welcomes contributions and corrections. Before contributing, please
 
    # Using HTTPS
    git clone --filter=tree:0 https://github.com/simple-icons/simple-icons.git
+
+   # Using GitHub CLI
+   gh repo clone simple-icons/simple-icons -- --filter=tree:0
    ```
 1. Create a new branch from the latest `develop` (read more [here](https://guides.github.com/introduction/flow/))
 1. Start hacking on the new branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Simple Icons welcomes contributions and corrections. Before contributing, please
 1. (Optional) Clone the fork
    ```
    git clone --filter=tree:0 git@github.com:simple-icons/simple-icons.git
+   git clone --filter=tree:0 https://github.com/simple-icons/simple-icons.git
    ```
 1. Create a new branch from the latest `develop` (read more [here](https://guides.github.com/introduction/flow/))
 1. Start hacking on the new branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,11 @@ Simple Icons welcomes contributions and corrections. Before contributing, please
 
 1. Fork this repository
 1. (Optional) Clone the fork
-   ```
+   ```bash
+   # Using SSH
    git clone --filter=tree:0 git@github.com:simple-icons/simple-icons.git
+
+   # Using HTTPS
    git clone --filter=tree:0 https://github.com/simple-icons/simple-icons.git
    ```
 1. Create a new branch from the latest `develop` (read more [here](https://guides.github.com/introduction/flow/))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Simple Icons welcomes contributions and corrections. Before contributing, please
 
 1. Fork this repository
 1. (Optional) Clone the fork
+
    ```bash
    # Using SSH
    git clone --filter=tree:0 git@github.com:simple-icons/simple-icons.git
@@ -14,6 +15,7 @@ Simple Icons welcomes contributions and corrections. Before contributing, please
    # Using GitHub CLI
    gh repo clone simple-icons/simple-icons -- --filter=tree:0
    ```
+
 1. Create a new branch from the latest `develop` (read more [here](https://guides.github.com/introduction/flow/))
 1. Start hacking on the new branch
 1. Commit and push to the new branch


### PR DESCRIPTION
I recently had the _pleasure_ of cloning this repository, but with close to 3.500 commits in the project that is getting pretty slow. So, following a recent [GitHub blog post](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/), this Pull Request adds a suggestion to the Contributing Guidelines to use "Treeless clone" when cloning this repository. Put simply, this creates a clone that knows everything about the latest commit, as well as the existence of al other commits. However, the clone doesn't know anything about the content of other commits. Since the commit history is generally not super important to contributors of this project (I think!?), this can significantly speed up cloning without any real downside

I fear that many contributors won't see this (or only see it after they clone) and so still have to sit through the long cloning process for this repo. I'm not sure if we can put it in a place where more people can see it... Any suggestions?

For completeness, I compared normal cloning and all the cloning options from the blog past using the [`time` command](https://man7.org/linux/man-pages/man1/time.1.html). Note that this doesn't tell you the whole picture because, as the blog post explains, each method comes with different down and upsides.

| Method | Name | `time` |
| --- | --- | --- |
| - | Normal clone | 48.649 total |
| `--depth=1` | Shallow clone | 5.491 total |
| `--filter=tree:0` | Treeless clone | 9.915 total |
| `--filter=blob:none` | Blobless clone | 12.111 total |


<sup>Apologies about the unrelated changes (removal of whitespace at the end of a line)</sup>