### PR TITLE
Remove Degree Symbol in Filenames

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     {% assign filename = filename | replace: "+", "plus" %}
     {% assign filename = filename | replace: ".", "-dot-" %}
     {% assign filename = filename | replace: "&", "-and-" %}
-    {% assign filename = filename | replace: " ", "" | replace: "!", "" | replace: ":", "" | replace: "’", "" | replace: "'", "" %}
+    {% assign filename = filename | replace: " ", "" | replace: "!", "" | replace: ":", "" | replace: "’", "" | replace: "'", "" | replace: "°", "" %}
 
     {% assign hex = icon.hex %}
     {% assign hexCharacter1 = hex | slice: 0, 1 %}

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -12,7 +12,7 @@ module.exports = {
             .replace(/^&/, "and-")
             .replace(/&$/, "-and")
             .replace(/&/g, "-and-")
-            .replace(/[ !:’']/g, "")
+            .replace(/[ !:’'°]/g, "")
             .replace(/à|á|â|ã|ä/g, "a")
             .replace(/ç|č|ć/g, "c")
             .replace(/è|é|ê|ë/g, "e")


### PR DESCRIPTION
**Issue:** #4637
**Alexa rank:** n/a

### Checklist
  - [ ] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
Removes the `°` symbol when normalising filenames.