### PR TITLE
Change "Name" to "Brand Name" in Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/icon_request.md
+++ b/.github/ISSUE_TEMPLATE/icon_request.md
@@ -14,7 +14,7 @@ labels: new icon
 
   When requesting a new icon please provide the following information:
 -->
-**Name:**
+**Brand Name:**
 **Website:**
 **Alexa rank:**
   <!-- The Alexa rank can be retrieved at https://www.alexa.com/siteinfo/

--- a/.github/ISSUE_TEMPLATE/icon_update.md
+++ b/.github/ISSUE_TEMPLATE/icon_update.md
@@ -8,6 +8,6 @@ labels: icon outdated
 
 
 <!-- When reporting an update to an icon we need information such as: -->
-**Name:**
+**Brand Name:**
 **Official resources for icon and color:**
   <!-- for example media kits, brand guidelines, SVG files, ...) -->


### PR DESCRIPTION
I've noticed, on occasion, people entering their own names in the `Name` filed of our issue templates so this PR updates them to rename that field `Brand Name` for clarity.