### PR TITLE
Updated Google Scholar

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2958,7 +2958,7 @@
         {
             "title": "Google Scholar",
             "hex": "4285F4",
-            "source": "https://commons.wikimedia.org/wiki/File:Google_Scholar_logo.svg"
+            "source": "https://about.google/products/#all-products"
         },
         {
             "title": "Google Search Console",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2958,7 +2958,7 @@
         {
             "title": "Google Scholar",
             "hex": "4285F4",
-            "source": "https://about.google/products/#all-products"
+            "source": "https://commons.wikimedia.org/wiki/File:Google_Scholar_logo.svg"
         },
         {
             "title": "Google Search Console",

--- a/icons/googlescholar.svg
+++ b/icons/googlescholar.svg
@@ -1,1 +1,1 @@
-<svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Google Scholar icon</title><path d="M12 24a7 7 0 1 1 0-14 7 7 0 0 1 0 14zm0-24L0 9.5l4.838 3.94A8 8 0 0 1 12 9a8 8 0 0 1 7.162 4.44L24 9.5z"/></svg>
+<svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Google Scholar icon</title><path d="M5.242 13.769L0 9.5 12 0l12 9.5-5.242 4.269C17.548 11.249 14.978 9.5 12 9.5c-2.977 0-5.548 1.748-6.758 4.269zM12 10a7 7 0 1 0 0 14 7 7 0 0 0 0-14z"/></svg>


### PR DESCRIPTION
![googlescholar](https://user-images.githubusercontent.com/1830867/104010054-db8e7e80-51a3-11eb-8ecd-c4135963e91a.png)

**Issue:** Contributes to #4205
**Alexa rank:** N/A (Google Product)

### Checklist
  - ~[] I updated the JSON data in `_data/simple-icons.json`~ --> Not Necessary
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Rebuilt from Wikipedia source. Standardized gap of 0.5px between shapes.