### PR TITLE
Escape 'Get commit message' step output in 'Publish' workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,10 +47,10 @@ jobs:
     - name: Get release title and body
       id: release
       run: |
-        COMMIT_MSG="$(printf "${{ steps.commit.outputs.git-message }}")"
-        RELEASE_TITLE="$(printf "$COMMIT_MSG" | head -n 1)"
+        COMMIT_MSG="$(echo "${{ steps.commit.outputs.git-message }}")"
+        RELEASE_TITLE="$(echo "$COMMIT_MSG" | head -n 1)"
         echo "::set-output name=title::$RELEASE_TITLE"
-        RELEASE_BODY="$(printf "$COMMIT_MSG" | tail -n +3)"
+        RELEASE_BODY="$(echo "$COMMIT_MSG" | tail -n +3)"
         echo "::set-output name=body::$RELEASE_BODY"
     - name: Get release version
       id: get-version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,9 +47,10 @@ jobs:
     - name: Get release title and body
       id: release
       run: |
-        RELEASE_TITLE=$(echo '${{ steps.commit.outputs.git-message }}' | head -n 1)
+        COMMIT_MSG="$(printf "${{ steps.commit.outputs.git-message }}")"
+        RELEASE_TITLE="$(printf "$COMMIT_MSG" | head -n 1)"
         echo "::set-output name=title::$RELEASE_TITLE"
-        RELEASE_BODY=$(echo '${{ steps.commit.outputs.git-message }}' | tail -n $(expr $(echo '${{ steps.commit.outputs.git-message }}' | wc -l) - 1))
+        RELEASE_BODY="$(printf "$COMMIT_MSG" | tail -n +3)"
         echo "::set-output name=body::$RELEASE_BODY"
     - name: Get release version
       id: get-version


### PR DESCRIPTION
If a brand name has the character `'` the release will fail because is not properly escaped in Publish workflow, as [has been happended in latest release](https://github.com/simple-icons/simple-icons/runs/1676956577?check_suite_focus=true#step:8:463) publication due to "De'Longhi" brand name.

- This is solved by using `printf` with `"` wrapped string to prevent string termination. This works for brand names with `'` character, but not if brand names have characters `"` (I've opened [an issue in the kceb/git-message-action](https://github.com/kceb/git-message-action/issues/7), but other suggestions are welcome). Anyways, there is no brands with `"` character in their name, but this does not mean that they cannot appear in the future.
- Additionally, the `wc` + expression computation of release body has changed by `tail` command, easier and not redundant.

You can check the reproducible error with a test of these new commands [here](https://github.com/mondeja/test-escape-step-output/blob/main/.github/workflows/test.yml), executed [here](https://github.com/mondeja/test-escape-step-output/runs/1677376113?check_suite_focus=true). 