### PR TITLE
Add Packagist README badge icon and place badges before 'Usage'

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 Over 1500 Free SVG icons for popular brands. See them all on one page at <a href="https://simpleicons.org">SimpleIcons.org</a>. Contributions, corrections & requests can be made on GitHub. Started by <a href="https://twitter.com/bathtype">Dan Leech</a>.</p>
 </p>
 
+<p align="center">
+<a href="https://github.com/simple-icons/simple-icons/actions?query=workflow%3AVerify+branch%3Adevelop"><img src="https://img.shields.io/github/workflow/status/simple-icons/simple-icons/Verify/develop?logo=github" alt="Build status" /></a>
+<a href="https://www.npmjs.com/package/simple-icons"><img src="https://img.shields.io/npm/v/simple-icons.svg?logo=npm" alt="NPM version" /></a>
+<a href="https://packagist.org/packages/simple-icons/simple-icons"><img src="https://img.shields.io/packagist/v/simple-icons/simple-icons?logo=packagist&logoColor=white" alt="Build status" /></a>
+</p>
+
 ## Usage
 
 ### General Usage
@@ -138,9 +144,3 @@ Icons are also available as a [Vue package](https://github.com/mainvest/vue-simp
 ### WordPress
 
 Icons are also available as a [WordPress plugin](https://wordpress.org/plugins/simple-icons/) created by  [@tjtaylo](https://github.com/tjtaylo).
-
-## Status
-
-[![Build status](https://img.shields.io/github/workflow/status/simple-icons/simple-icons/Verify/develop?logo=github)](https://github.com/simple-icons/simple-icons/actions?query=workflow%3AVerify+branch%3Adevelop)
-[![npm version](https://img.shields.io/npm/v/simple-icons.svg?logo=npm)](https://www.npmjs.com/package/simple-icons)
-[![Packagist version](https://img.shields.io/packagist/v/simple-icons/simple-icons?logo=packagist&logoColor=white)](https://packagist.org/packages/simple-icons/simple-icons)

--- a/README.md
+++ b/README.md
@@ -143,4 +143,4 @@ Icons are also available as a [WordPress plugin](https://wordpress.org/plugins/s
 
 [![Build status](https://img.shields.io/github/workflow/status/simple-icons/simple-icons/Verify/develop?logo=github)](https://github.com/simple-icons/simple-icons/actions?query=workflow%3AVerify+branch%3Adevelop)
 [![npm version](https://img.shields.io/npm/v/simple-icons.svg?logo=npm)](https://www.npmjs.com/package/simple-icons)
-[![Packagist version](https://img.shields.io/packagist/v/simple-icons/simple-icons)](https://packagist.org/packages/simple-icons/simple-icons)
+[![Packagist version](https://img.shields.io/packagist/v/simple-icons/simple-icons?logo=packagist&logoColor=white)](https://packagist.org/packages/simple-icons/simple-icons)


### PR DESCRIPTION
It doesn't look quite right due to the number of lines the icon has, but IMHO seems to be enough, and since simple-icons is the icon provider, I think it is useful to add it. You can see the rendered result [here](https://github.com/mondeja/simple-icons/tree/packagist-icon-readme-badge#status).