### PR TITLE
Add TV Time

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -7511,6 +7511,11 @@
             "source": "https://github.com/tutao/tutanota/blob/8ff5f0e7d78834ac8fcb0f2357c394b757ea4793/resources/images/logo-solo-red.svg"
         },
         {
+            "title": "TV Time",
+            "hex": "FFD400",
+            "source": "https://github.com/simple-icons/simple-icons/issues/2952"
+        },
+        {
             "title": "Twilio",
             "hex": "F22F46",
             "source": "https://www.twilio.com/company/brand"

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -7513,7 +7513,7 @@
         {
             "title": "TV Time",
             "hex": "FFD400",
-            "source": "https://github.com/simple-icons/simple-icons/issues/2952"
+            "source": "https://www.tvtime.com/"
         },
         {
             "title": "Twilio",

--- a/icons/tvtime.svg
+++ b/icons/tvtime.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>TV Time icon</title><path d="M0 0v24h24V0zm4.8 4.8h14.4v4.8h-4.8v9.6H9.6V9.6H4.8Z"/></svg>


### PR DESCRIPTION
![TV Time](https://user-images.githubusercontent.com/15157491/104589255-7a622180-5661-11eb-91fe-400bcf82f2df.png)


**Issue:** Closes #2952
**Alexa rank:** [~23.2k](https://www.alexa.com/siteinfo/tvtime.com)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
~I'm not _entirely_ sure what to use for the source here, as the only source we currently have for an official vector image is one of our own issues. Should we go with [their website](https://www.tvtime.com/), despite the absence of a vector logo?~

Possible alternative treatment & colour (or maybe one of the other greys from their website):
![](https://user-images.githubusercontent.com/15157491/104589524-e5abf380-5661-11eb-8073-8b69bd55a9f4.png)