### PR TITLE
Add FutureLearn

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2656,6 +2656,11 @@
             "source": "https://furrynetwork.com"
         },
         {
+            "title": "FutureLearn",
+            "hex": "DE00A5",
+            "source": "https://www.futurelearn.com/"
+        },
+        {
             "title": "G2A",
             "hex": "F05F00",
             "source": "https://www.g2a.co/contact/brand_guidelines/"

--- a/icons/futurelearn.svg
+++ b/icons/futurelearn.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>FutureLearn icon</title><path d="M22.081.61v7.566h-7.223v6.661H7.566v6.634H0v1.92h9.471v-6.649h7.306v-6.66H24V.61Z"/></svg>


### PR DESCRIPTION
![FutureLearn](https://user-images.githubusercontent.com/15157491/104626447-d6429f80-568d-11eb-8e8d-c8f110032628.png)

**Issue:** Closes #3565
**Alexa rank:** [~4.4k](https://www.alexa.com/siteinfo/futurelearn.com)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Icon & colour from [SVG](https://assets.futurelearn.com/packs/app/assets/images/fl_logo-f9d7f37a61915a2fbf8a26cbb285fed0.svg) in website header.