### PR TITLE
Add remote trigger for updating simple-icons in simple-icons-website

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,6 +78,17 @@ jobs:
       - name: Trigger simple-icons-font release
         run: |
           curl -X POST \
-            -H "Authorization: Bearer ${{ secrets.SIMPLE_ICONS_FONT_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.REMOTE_DISPATCH_TOKEN }}" \
             -d '{"ref":"develop"}' \
             https://api.github.com/repos/simple-icons/simple-icons-font/actions/workflows/auto-release.yml/dispatches
+  website:
+    name: Trigger simple-icons-website update
+    needs: npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger simple-icons-website update
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.REMOTE_DISPATCH_TOKEN }}" \
+            -d '{"ref":"master"}' \
+            https://api.github.com/repos/simple-icons/simple-icons-website/actions/workflows/auto-release.yml/dispatches


### PR DESCRIPTION
Following https://github.com/simple-icons/simple-icons/pull/4533, this adds a job/step to the [Publishing workflow](https://github.com/simple-icons/simple-icons/blob/develop/.github/workflows/publish.yml) which will trigger [a workflow in the simple-icons-website repository](https://github.com/simple-icons/simple-icons-website/blob/master/.github/workflows/auto-release.yml). This workflow will attempt to update [the simple-icons dependency](https://github.com/simple-icons/simple-icons-website/blob/9a1116bb95d37d98db940e21805385a782e520f9/package.json#L28) of the website and push this update to the repository. This way the website will always be generated with the latest version of [the simple-icons NPM package](https://www.npmjs.com/package/simple-icons).

I updated the name of the token used for this trigger as well as the trigger for [the font](). I already added a new secret with a Personal Access Token belonging to me to this repository with that name (`REMOTE_DISPATCH_TOKEN`).

---

<sup>See https://github.com/simple-icons/simple-icons/issues/980 for more context</sup>