### PR TITLE
Update branding color of Umbraco

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -7687,7 +7687,7 @@
         },
         {
             "title": "Umbraco",
-            "hex": "00BEC1",
+            "hex": "3544B1",
             "source": "https://umbraco.com/"
         },
         {


### PR DESCRIPTION
### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
Previous a turquoise color was used in the Umbraco branding and included in this PR https://github.com/simple-icons/simple-icons/pull/428, but it has now changed to a blue color.
So I have updated the hex code to `#3544B1` which is the official color.