### PR TITLE
Add Alitalia

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -301,6 +301,11 @@
             "source": "https://gw.alipayobjects.com/os/rmsportal/trUJZfSrlnRCcFgfZGjD.ai"
         },
         {
+            "title": "Alitalia",
+            "hex": "006643",
+            "source": "https://www.alitalia.com/it_it/fly-alitalia/in-flight/ulisse-magazine.html"
+        },
+        {
             "title": "AlliedModders",
             "hex": "1578D3",
             "source": "https://forums.alliedmods.net/index.php"

--- a/icons/alitalia.svg
+++ b/icons/alitalia.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Alitalia icon</title><path d="M5.429 20.551H0l14.257-14.87c1.622-1.765 2.878-2.232 4.686-2.232H24L21.602 20.55h-4.17L19.49 5.907M15.7 20.551l1.384-9.842-9.457 9.842Z"/></svg>


### PR DESCRIPTION
![Alitalia](https://user-images.githubusercontent.com/15157491/105032937-5e8ac100-5a4f-11eb-9b18-01801bae96df.png)

**Issue:** #2587
**Alexa rank:** [~46k](https://www.alexa.com/siteinfo/alitalia.com)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Icon from vector in bottom-right of first page in [this PDF](https://www.alitalia.com/content/dam/alitalia/files/IT/volare/in-volo/ulisse-magazine/Ulisse-marzo-2020.pdf); colour from [website](https://www.alitalia.com/) stylesheet.