### PR TITLE
Document enumerability of the simple-icons object

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ console.log(icon);
 */
 ```
 
+Lastly, the `simpleIcons` object is also enumerable.
+This is useful if you want to do a computation on every icon:
+
+```javascript
+const simpleIcons = require('simple-icons');
+
+for (const title in simpleIcons) {
+    const icon = simpleIcons.get(title);
+    // do stuff
+}
+```
+
 #### TypeScript Usage
 
 There are also TypeScript type definitions for the Node package. To use them, simply run:


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/MDI-Sandbox/simpleicons/preview/
-->

**Issue:** n/a
**Alexa rank:** n/a
  <!-- The Alexa rank can be retrieved at https://www.alexa.com/siteinfo/
       Please see our contributing guidelines for more details on how we
       assess a brand's popularity. -->

### Checklist
n/a

### Description

This updates [the documentation for the NPM package](https://github.com/simple-icons/simple-icons#node-usage) to include the fact that the `require('simple-icons')` value is **enumerable**. This is pretty useful information for anyone wanting to build a third-party plugin or just needs access to all icons for some reason.

Note that it is in fact not **iterable** (i.e. you can't do `for (const icon of simpleIcons) { }`), this could be a desired feature. If anyone thinks so they can open an issue for it :slightly_smiling_face: 