### PR TITLE
Website: add banner asking visitors to check out the redesign

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,6 +205,7 @@
             <li class="navbar__nav-item"><a href="https://www.npmjs.com/package/simple-icons">NPM</a></li>
             <li class="navbar__nav-item"><a href="https://packagist.org/packages/simple-icons/simple-icons">Packagist</a></li>
         </ul>
+        <p class="redesign-banner">We're redesigning the website! Please <a href="https://simple-icons.github.io/simple-icons-website/">Check it out</a> and <a href="https://github.com/simple-icons/simple-icons/discussions/4865">Share you feedback</a>.</p>
     </header>
     <main role="main">
         <p class="hero">{{ iconCount }} Free <abbr title="Scalable Vector Graphic">SVG</abbr> icons for popular&nbsp;brands</p>

--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
             <li class="navbar__nav-item"><a href="https://www.npmjs.com/package/simple-icons">NPM</a></li>
             <li class="navbar__nav-item"><a href="https://packagist.org/packages/simple-icons/simple-icons">Packagist</a></li>
         </ul>
-        <p class="redesign-banner">We're redesigning the website! Please <a href="https://simple-icons.github.io/simple-icons-website/">Check it out</a> and <a href="https://github.com/simple-icons/simple-icons/discussions/4865">Share you feedback</a>.</p>
+        <p class="redesign-banner">We're redesigning the website! Please <a href="https://simple-icons.github.io/simple-icons-website/">Check it out</a> and <a href="https://github.com/simple-icons/simple-icons/discussions/4865">Share you feedback</a>. <span>Hide this message <button id="hide-feedback-request-once">Once</button> or <button id="hide-feedback-request">Always</button> | <button id="redirect-to-redesign">Redirect automatically</button></span></p>
     </header>
     <main role="main">
         <p class="hero">{{ iconCount }} Free <abbr title="Scalable Vector Graphic">SVG</abbr> icons for popular&nbsp;brands</p>

--- a/site_script.js
+++ b/site_script.js
@@ -204,19 +204,26 @@
       redirectAutomaticallyIdentifier = 'redirect-to-redesign';
 
   $redirectAutomatically.addEventListener('click', function() {
-    console.log('redirect button');
+    var redirect = true;
     if (localStorage) {
-      localStorage.setItem(redirectAutomaticallyIdentifier, true);
+      var currentVal = localStorage.getItem(redirectAutomaticallyIdentifier);
+      if (currentVal === 'true') {
+        redirect = false;
+      }
+
+      localStorage.setItem(redirectAutomaticallyIdentifier, redirect);
     }
 
-    window.location.replace(redesignUrl);
+    if (redirect) {
+      window.location.replace(redesignUrl);
+    } else {
+      $redirectAutomatically.innerHTML = "Redirect automatically";
+    }
   });
   $hideOnce.addEventListener('click', function () {
-    console.log('hide once button');
     $banner.classList.add('hidden');
   });
   $hideAlways.addEventListener('click', function () {
-    console.log('hide always button');
     if (localStorage) {
       localStorage.setItem(hideBannerAlwaysIdentifier, true);
     }
@@ -226,9 +233,11 @@
 
   if (localStorage) {
     var redirect = localStorage.getItem(redirectAutomaticallyIdentifier);
-    console.log('should redirect', redirect, document.referrer);
-    if (redirect && !(document.referrer === redesignUrl)) {
-      window.location.replace(redesignUrl);
+    if (redirect === 'true') {
+      $redirectAutomatically.innerHTML = "Disable redirect";
+      if (document.referrer !== redesignUrl) {
+        window.location.replace(redesignUrl);
+      }
     }
 
     var hide = localStorage.getItem(hideBannerAlwaysIdentifier);

--- a/site_script.js
+++ b/site_script.js
@@ -191,4 +191,49 @@
   $orderByRelevance.addEventListener('click', function() {
     selectOrdering($orderByRelevance);
   });
+
+  /* Redesign */
+
+  var $banner = document.querySelector('.redesign-banner'),
+      $redirectAutomatically = document.getElementById('redirect-to-redesign'),
+      $hideOnce = document.getElementById('hide-feedback-request-once'),
+      $hideAlways = document.getElementById('hide-feedback-request');
+
+  var redesignUrl = 'https://simple-icons.github.io/simple-icons-website/',
+      hideBannerAlwaysIdentifier = 'hide-banner',
+      redirectAutomaticallyIdentifier = 'redirect-to-redesign';
+
+  $redirectAutomatically.addEventListener('click', function() {
+    console.log('redirect button');
+    if (localStorage) {
+      localStorage.setItem(redirectAutomaticallyIdentifier, true);
+    }
+
+    window.location.replace(redesignUrl);
+  });
+  $hideOnce.addEventListener('click', function () {
+    console.log('hide once button');
+    $banner.classList.add('hidden');
+  });
+  $hideAlways.addEventListener('click', function () {
+    console.log('hide always button');
+    if (localStorage) {
+      localStorage.setItem(hideBannerAlwaysIdentifier, true);
+    }
+
+    $banner.classList.add('hidden');
+  });
+
+  if (localStorage) {
+    var redirect = localStorage.getItem(redirectAutomaticallyIdentifier);
+    console.log('should redirect', redirect, document.referrer);
+    if (redirect && !(document.referrer === redesignUrl)) {
+      window.location.replace(redesignUrl);
+    }
+
+    var hide = localStorage.getItem(hideBannerAlwaysIdentifier);
+    if (hide) {
+      $banner.classList.add('hidden');
+    }
+  }
 })( document );

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -360,10 +360,21 @@ a.share-button {
 .redesign-banner a {
   color: #0096ee;
 }
-.redesign-banner a:hover {
+.redesign-banner a:focus, .redesign-banner a:hover,
+.redesign-banner button:focus, .redesign-banner button:hover {
   text-decoration: underline;
 }
-
+.redesign-banner span {
+  float: right
+}
+.redesign-banner button {
+  border: none;
+  background-color: transparent;
+  color: #0096ee;
+  cursor: pointer;
+  margin: 0;
+  padding: 0;
+}
 
 .hidden {
   display: none;

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -351,6 +351,20 @@ a.share-button {
   padding: 1.5rem 0 1.5rem 1.5rem;
 }
 
+.redesign-banner {
+  background-color: #565f63;
+  color: #FFF;
+  margin: 0;
+  padding: 0.5rem 1.5rem;
+}
+.redesign-banner a {
+  color: #0096ee;
+}
+.redesign-banner a:hover {
+  text-decoration: underline;
+}
+
+
 .hidden {
   display: none;
 }


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/MDI-Sandbox/simpleicons/preview/
-->

**Issue:** #980, https://github.com/simple-icons/simple-icons-website/pull/26
**Alexa rank:** n/a

### Checklist
  - [x] (n/a) I updated the JSON data in `_data/simple-icons.json`
  - [x] (n/a) I optimized the icon with SVGO or SVGOMG
  - [x] (n/a) The SVG `viewbox` is `0 0 24 24`

### Description

This adds a banner to the website asking visitors to check out the redesign and to provide feedback. Additionally, it provides users to option to hide the banner (once or permanently) or to redirect to the redesign automatically.

In https://github.com/simple-icons/simple-icons-website/pull/26 I add a similar banner to the redesigned website, allowing visitors to easily go back to the original design. Crucially, I (hope I) implemented it such that when automatic redirecting is enabled but you navigate back to the original design from the redesign, you are not redirected again, allowing you to disable the redirect.

Here is a preview of the banner:

![image](https://user-images.githubusercontent.com/3742559/105884817-a8077d00-6008-11eb-9d54-0177558c5b92.png)


Regarding the implementation, it is a bit quick and dirty, but I tried to implement it such that 1) it is easy to remove (i.e. the changes are grouped) and 2) it does not conflict with other changes to the website.