### PR TITLE
Request: Suckless Icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -7253,7 +7253,7 @@
         },
         {
             "title": "suckless",
-            "hex": "006699",
+            "hex": "1177AA",
             "source": "https://suckless.org"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -7252,6 +7252,11 @@
             "source": "http://subversion.apache.org/logo"
         },
         {
+            "title": "Suckless",
+            "hex": "006699",
+            "source": "https://suckless.org/logo.svg"
+        },
+        {
             "title": "Sumo Logic",
             "hex": "000099",
             "source": "https://sites.google.com/sumologic.com/sumo-logic-brand/home"

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -7252,9 +7252,9 @@
             "source": "http://subversion.apache.org/logo"
         },
         {
-            "title": "Suckless",
+            "title": "suckless",
             "hex": "006699",
-            "source": "https://suckless.org/logo.svg"
+            "source": "https://suckless.org"
         },
         {
             "title": "Sumo Logic",

--- a/icons/suckless.svg
+++ b/icons/suckless.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Suckless icon</title><path d="M0 2h24v4H4v4h20v12H0v-4h20v-4H0z"/></svg>

--- a/icons/suckless.svg
+++ b/icons/suckless.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>suckless icon</title><path d="M0 2h24v4H4v4h20v12H0v-4h20v-4H0z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>suckless icon</title><path d="M0 4h24v4H4v2h20v10H0v-4h20v-2H0z"/></svg>

--- a/icons/suckless.svg
+++ b/icons/suckless.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Suckless icon</title><path d="M0 2h24v4H4v4h20v12H0v-4h20v-4H0z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>suckless icon</title><path d="M0 2h24v4H4v4h20v12H0v-4h20v-4H0z"/></svg>


### PR DESCRIPTION
## Details
![suckless](https://user-images.githubusercontent.com/76186754/106314472-a53dae00-62ce-11eb-8f86-80633890b3bc.png)

**Issue:** Closes #4883 - Add Icon for Suckless (and possibly dwm)
**Alexa rank:** [412,962](https://www.alexa.com/siteinfo/suckless.org)

**Why did you pick the hex value?**
The suckless tools all have a very consistent aesthetic, based on the 6 colours listed in my issue, however, the website and it's logo used `#069` (nice) and since most people customize the colours of the tools, this seems to be the best fitting. Both in terms of recognizability, and brand consistency.

**Did you manually vectorize the logo?**
Yes, I manually wrote the `path="..."` to get it to fit 24x24.

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`