### PR TITLE
Request: dwm Icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2130,7 +2130,7 @@
         },
         {
             "title": "dwm",
-            "hex": "1177aa",
+            "hex": "1177AA",
             "source": "https://dwm.suckless.org/dwm.svg"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2129,6 +2129,11 @@
             "source": "https://www.duolingo.com/"
         },
         {
+            "title": "dwm",
+            "hex": "006699",
+            "source": "https://dwm.suckless.org/dwm.svg"
+        },
+        {
             "title": "Dynamics 365",
             "hex": "002050",
             "source": "http://thepartnerchannel.com/wp-content/uploads/Dynamics365_styleguide_092816.pdf"

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2130,7 +2130,7 @@
         },
         {
             "title": "dwm",
-            "hex": "006699",
+            "hex": "1177aa",
             "source": "https://dwm.suckless.org/dwm.svg"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2131,7 +2131,7 @@
         {
             "title": "dwm",
             "hex": "1177AA",
-            "source": "https://dwm.suckless.org/dwm.svg"
+            "source": "https://dwm.suckless.org"
         },
         {
             "title": "Dynamics 365",

--- a/icons/dwm.svg
+++ b/icons/dwm.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>dwm icon</title><path d="M0 11h6V8h2v8h2v-4h2v4h2v-4h10v6h-2v-4h-2v4h-2v-4h-2v4H2v-2h4v-2H2v4H0z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>dwm icon</title><path d="M0 11h6V7h2v8h2v-4h2v4h2v-4h10v6h-2v-4h-2v4h-2v-4h-2v4H2v-2h4v-2H2v4H0z"/></svg>

--- a/icons/dwm.svg
+++ b/icons/dwm.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>dwm icon</title><path d="M0 12h6V8h2v8h2v-4h2v4h2v-4h10v6h-2v-4h-2v4h-2v-4h-2v4H2v-2h4v-2H2v4H0z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>dwm icon</title><path d="M0 11h6V8h2v8h2v-4h2v4h2v-4h10v6h-2v-4h-2v4h-2v-4h-2v4H2v-2h4v-2H2v4H0z"/></svg>

--- a/icons/dwm.svg
+++ b/icons/dwm.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>dwm icon</title><path d="M0 12h6V6h2v10h2v-4h2v4h2v-4h10v6h-2v-4h-2v4h-2v-4h-2v4H2v-2h4v-2H2v4H0z"/></svg>

--- a/icons/dwm.svg
+++ b/icons/dwm.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>dwm icon</title><path d="M0 12h6V6h2v10h2v-4h2v4h2v-4h10v6h-2v-4h-2v4h-2v-4h-2v4H2v-2h4v-2H2v4H0z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>dwm icon</title><path d="M0 12h6V8h2v8h2v-4h2v4h2v-4h10v6h-2v-4h-2v4h-2v-4h-2v4H2v-2h4v-2H2v4H0z"/></svg>


### PR DESCRIPTION
## Details
![preview](https://user-images.githubusercontent.com/76186754/106542536-e3ee9500-6568-11eb-9e46-8ca390a48e54.png)

**Issue:** Closes #4883 - Add Icon for Suckless (and possibly dwm)
**Alexa rank:** [412,962](https://www.alexa.com/siteinfo/dwm.suckless.org)

**Why did you pick the hex value?**
The suckless tools all have a very consistent aesthetic, based on the 6 colours listed in my issue, however, the website and it's logo used `#069` (nice) and since most people customize the colours of the tools, this seems to be the best fitting. Both in terms of recognizability, and brand consistency.

**Did you manually vectorize the logo?**
Yes, I manually wrote the `path="..."` to get it to fit 24x24.

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

**Edit:** Updated colour in preview.