### PR TITLE
Add teratail

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -7462,6 +7462,11 @@
             "source": "https://github.com/Teradata/teradata.github.io/"
         },
         {
+            "title": "teratail",
+            "hex": "F4C51C",
+            "source": "https://teratail.com/"
+        },
+        {
             "title": "Terraform",
             "hex": "623CE4",
             "source": "https://www.hashicorp.com/brand#terraform"

--- a/icons/teratail.svg
+++ b/icons/teratail.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>teratail icon</title><path d="M9.81.968h4.375L24 23.032h-5.107L12.121 6.605h-.198L5.148 23.03H0Z"/></svg>


### PR DESCRIPTION
![teratail](https://user-images.githubusercontent.com/15157491/106300151-04a7a980-624e-11eb-8ce2-b26c5c33ef1c.png)

**Issue:** Closes #3713
**Alexa rank:** [~3.6k](https://www.alexa.com/siteinfo/teratail.com)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Icon & colour from [SVG](https://teratail-v2.storage.googleapis.com/assets/img/common/logo_white.svg?1611826191518470) in website footer, using the same treatment as seen in their [`mask-icon`](https://teratail.com/img/favicon/safari-pinned-tab.svg) whose `meta` tag also uses the same yellow.