### PR TITLE
Update LinkedIn Colour

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -4343,7 +4343,7 @@
         },
         {
             "title": "LinkedIn",
-            "hex": "0077B5",
+            "hex": "0A66C2",
             "source": "https://brand.linkedin.com"
         },
         {


### PR DESCRIPTION
**Issue:** Closes #4938
**Alexa rank:** [~53](http://alexa.com/siteinfo/linkedin.com)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
LinkedIn icon colour is updated.