### PR TITLE
Add Naver

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -5023,6 +5023,11 @@
             "source": "https://docs.nativescript.org/"
         },
         {
+            "title": "Naver",
+            "hex": "03C75A",
+            "source": "https://www.navercorp.com/investment/annualReport"
+        },
+        {
             "title": "NBA",
             "hex": "253B73",
             "source": "https://nba.com/"

--- a/icons/naver.svg
+++ b/icons/naver.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Naver icon</title><path d="M1.6 0S0 0 0 1.6v20.8S0 24 1.6 24h20.8s1.6 0 1.6-1.6V1.6S24 0 22.4 0zm3.415 5.6h4.78l4.425 6.458V5.6h4.765v12.8h-4.78L9.78 11.943V18.4H5.015Z"/></svg>


### PR DESCRIPTION
![Naver](https://user-images.githubusercontent.com/15157491/107761965-27dd5900-6d24-11eb-84a5-5c17c16069ea.png)

**Issue:** Closes #4415
**Alexa rank:** [39](https://www.alexa.com/siteinfo/naver.com)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Well, that took some digging! Icon from page 32 of [this PDF](https://www.navercorp.com/navercorp_/ir/annualReport/2020/NAVER_2019AR_Design_TCG0604_ENG.pdf), colour from [website](https://www.naver.com/) stylesheet - there were a few options available, I went with the one used in the menu.