### PR TITLE
Correct Textpattern hex colour

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -7574,7 +7574,7 @@
         },
         {
             "title": "Textpattern",
-            "hex": "FFD942",
+            "hex": "FFDA44",
             "source": "https://textpattern.com/"
         },
         {


### PR DESCRIPTION
My bad - now corrected the hex colour reference. Cheers!

<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/MDI-Sandbox/simpleicons/preview/
-->

**Issue:**
**Alexa rank:**
  <!-- The Alexa rank can be retrieved at https://www.alexa.com/siteinfo/
       Please see our contributing guidelines for more details on how we
       assess a brand's popularity. -->

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
