### PR TITLE
Add PlayCanvas

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -5957,7 +5957,7 @@
         },
         {
             "title": "PlayCanvas",
-            "hex": "e05f2c",
+            "hex": "E05F2C",
             "source": "https://playcanvas.com/"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -5956,6 +5956,11 @@
             "source": "https://github.com/PlatziDev/oss/blob/932bd83d43e061e1c38fbc116db31aa6d0145be6/static/logo.svg"
         },
         {
+            "title": "PlayCanvas",
+            "hex": "e05f2c",
+            "source": "https://playcanvas.com/"
+        },
+        {
             "title": "Player FM",
             "hex": "C8122A",
             "source": "https://player.fm/"

--- a/icons/playcanvas.svg
+++ b/icons/playcanvas.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>PlayCanvas icon</title><path d="M6.07 0l-.002 3.414 5.823 3.41-5.82 3.414-.003 3.412 11.774-6.826L6.07 0zm11.77 10.35L6.068 17.174 17.842 24l-.002-3.414-5.82-3.412 5.822-3.412-.002-3.412z" fill-rule="evenodd"/></svg>

--- a/icons/playcanvas.svg
+++ b/icons/playcanvas.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>PlayCanvas icon</title><path d="M6.07 0l-.002 3.414 5.823 3.41-5.82 3.414-.003 3.412 11.774-6.826L6.07 0zm11.77 10.35L6.068 17.174 17.842 24l-.002-3.414-5.82-3.412 5.822-3.412-.002-3.412z" fill-rule="evenodd"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>PlayCanvas icon</title><path d="M6.115 0l-.002 3.414 5.823 3.41-5.82 3.414-.003 3.412 11.774-6.826zm11.77 10.35L6.113 17.174 17.887 24l-.002-3.414-5.82-3.412 5.822-3.412z"/></svg>


### PR DESCRIPTION
![PlayCanvas icon preview](https://user-images.githubusercontent.com/6013871/108783494-98158700-753b-11eb-99e9-cc51295983c8.png)

**Issue:** Closes #5094 
**Alexa rank:** [162,130](https://www.alexa.com/siteinfo/playcanvas.com)
**GitHub stars:** [6.1K](https://github.com/playcanvas/engine)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
No press page - used the navbar graphic. SVG icon grabbed from [original SVG graphic](https://playcanvas.com/assets/images/logo/PlayCanvas-Logo-White.svg) on [playcanvas.com](https://PlayCanvas.com). Text was removed and the icon was sized into a 24x24 viewbox. Hex value pulled from the original SVG graphic. Semi-transparent drop shadows were removed.

