### PR TITLE
Require Sorting by Slug

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3466,14 +3466,14 @@
         },
         {
             "title": "Handshake",
-            "slug": "handshake_protocol",
-            "hex": "000000",
-            "source": "https://handshake.org/"
+            "hex": "FF2F1C",
+            "source": "https://learn.joinhandshake.com/marketing-toolkit/"
         },
         {
             "title": "Handshake",
-            "hex": "FF2F1C",
-            "source": "https://learn.joinhandshake.com/marketing-toolkit/"
+            "slug": "handshake_protocol",
+            "hex": "000000",
+            "source": "https://handshake.org/"
         },
         {
             "title": "HappyCow",

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -28,11 +28,9 @@ const TESTS = {
         const compare = icon.title.localeCompare(prev.title);
         if (compare < 0) {
           invalidEntries.push(icon);
-        }else if(compare === 0){
-          if(prev.slug){
-            if(!icon.slug){
-              invalidEntries.push(icon);
-            }else if(icon.slug.localeCompare(prev.slug) < 0){
+        } else if (compare === 0) {
+          if (prev.slug) {
+            if (!icon.slug || icon.slug.localeCompare(prev.slug) < 0) {
               invalidEntries.push(icon);
             }
           }

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -39,10 +39,10 @@ const TESTS = {
       return invalidEntries;
     };
     const format = icon => {
-            if (icon.slug) {
-                return `${icon.title} (${icon.slug})`;
-            }
-            return icon.title;
+      if (icon.slug) {
+        return `${icon.title} (${icon.slug})`;
+      }
+      return icon.title;
     };
 
     const invalids = data.icons.reduce(collector, []);

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -25,8 +25,17 @@ const TESTS = {
     const collector = (invalidEntries, icon, index, array) => {
       if (index > 0) {
         const prev = array[index - 1];
-        if (icon.title.localeCompare(prev.title) < 0) {
+        const compare = icon.title.localeCompare(prev.title);
+        if (compare < 0) {
           invalidEntries.push(icon);
+        }else if(compare === 0){
+          if(prev.slug){
+            if(!icon.slug){
+              invalidEntries.push(icon);
+            }else if(icon.slug.localeCompare(prev.slug) < 0){
+              invalidEntries.push(icon);
+            }
+          }
         }
       }
       return invalidEntries;

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -38,11 +38,17 @@ const TESTS = {
       }
       return invalidEntries;
     };
+    const format = icon => {
+            if (icon.slug) {
+                return `${icon.title} (${icon.slug})`;
+            }
+            return icon.title;
+    };
 
     const invalids = data.icons.reduce(collector, []);
     if (invalids.length) {
       return `Some icons aren't in alphabetical order:
-        ${invalids.map(icon => icon.title).join(", ")}`;
+        ${invalids.map(icon => format(icon)).join(", ")}`;
     }
   },
 


### PR DESCRIPTION
**Issue:** Fixes #5098
**Alexa rank:** n/a

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
This PR adds a step to our linting that requires icons in our JSON with the same `title` to be sorted by their `slug` entry with the one without a `slug` coming first and the rest sorted alphabetically. If I've done this right, then the initial commit should fail on the 2 "Handshake" icons but, as I don't have a local setup to properly test with, I could really do with someone else throwing an eye over it.

Also, do we think it's enough to just log the `title` when icons aren't sorted by `slug` or should we somehow display the `slug` as well? One way we could do it would be to replace the whole `alphabetical` function with the following:
```
  alphabetical: function() {
    const collector = (invalidEntries, icon, index, array) => {
      if (index > 0) {
        const prev = array[index - 1];
        const compare = icon.title.localeCompare(prev.title);
        if (compare < 0) {
          invalidEntries.push(icon.title);
        }else if(compare === 0){
          if(prev.slug){
            if(!icon.slug){
              invalidEntries.push(icon.title);
            }else if(icon.slug.localeCompare(prev.slug) < 0){
              invalidEntries.push(icon.title+` (${icon.slug})`);
            }
          }
        }
      }
      return invalidEntries;
    };

    const invalids = data.icons.reduce(collector, []);
    if (invalids.length) {
      return `Some icons aren't in alphabetical order:
        ${invalids.join(", ")}`;
    }
  }
```