### PR TITLE
Add Material Design Icons license

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -4825,7 +4825,10 @@
         {
             "title": "Material Design Icons",
             "hex": "2196F3",
-            "source": "https://materialdesignicons.com/icon/vector-square"
+            "source": "https://materialdesignicons.com/icon/vector-square",
+            "license": {
+                "type": "Apache-2.0"
+            }
         },
         {
             "title": "Material-UI",


### PR DESCRIPTION
**Issue:** n/a
**Alexa rank:** [~30.3k](https://www.alexa.com/siteinfo/materialdesignicons.com)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
Source: https://github.com/Templarian/MaterialDesign/blob/master/LICENSE