### PR TITLE
Add Eclipse Che

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2359,6 +2359,11 @@
             "source": "https://go.developer.ebay.com/logos"
         },
         {
+            "title": "Eclipse Che",
+            "hex": "525C86",
+            "source": "https://www.eclipse.org/che/"
+        },
+        {
             "title": "Eclipse IDE",
             "hex": "2C2255",
             "source": "https://www.eclipse.org/artwork/"

--- a/icons/eclipseche.svg
+++ b/icons/eclipseche.svg
@@ -1,0 +1,1 @@
+<svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Eclipse Che icon</title><path d="M12 0L1.604 6.021v7.452L12 7.494l3.941 2.254 6.455-3.727zm10.396 10.527L12 16.506l-7.334-4.217-3.062 1.76v3.93L12 24l10.396-6.021z"/></svg>


### PR DESCRIPTION
Fixes #5161

![image](https://user-images.githubusercontent.com/54133/110213937-ff5b0180-7e80-11eb-9550-a1cd52d48e86.png)


**Issue:** #5161

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->

Although the logo has 2 colors, I picked the hex value for the top color. Icon from https://www.eclipse.org/che/images/logo-eclipseche.svg