### PR TITLE
Add Guidelines for Stack Exchange icons

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -7071,7 +7071,8 @@
         {
             "title": "Server Fault",
             "hex": "E7282D",
-            "source": "http://stackoverflow.com/company/logos"
+            "source": "http://stackoverflow.com/company/logos",
+            "guidelines": "https://stackoverflow.com/legal/trademark-guidance"
         },
         {
             "title": "Serverless",
@@ -7511,12 +7512,14 @@
         {
             "title": "Stack Exchange",
             "hex": "1E5397",
-            "source": "http://stackoverflow.com/company/logos"
+            "source": "http://stackoverflow.com/company/logos",
+            "guidelines": "https://stackoverflow.com/legal/trademark-guidance"
         },
         {
             "title": "Stack Overflow",
             "hex": "FE7A16",
-            "source": "http://stackoverflow.com"
+            "source": "http://stackoverflow.com",
+            "guidelines": "https://stackoverflow.com/legal/trademark-guidance"
         },
         {
             "title": "Stackbit",
@@ -7731,7 +7734,8 @@
         {
             "title": "Super User",
             "hex": "38A1CE",
-            "source": "https://superuser.com"
+            "source": "https://superuser.com",
+            "guidelines": "https://stackoverflow.com/legal/trademark-guidance"
         },
         {
             "title": "SurveyMonkey",


### PR DESCRIPTION
**Issue:** n/a
**Alexa rank:** n/a

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
Adds https://stackoverflow.com/legal/trademark-guidance as the `guidelines` entry for:
- Server Fault,
- Stack Exchange,
- Stack Overflow, and,
- Super User