### PR TITLE
Fix broken npm link

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "simple-icons",
   "version": "4.14.0",
   "description": "SVG icons for popular brands https://simpleicons.org",
-  "homepage": "https://www.simpleicons.org",
+  "homepage": "https://simpleicons.org",
   "keywords": [
     "svg",
     "icons"


### PR DESCRIPTION
Hiya :)

Clicking on the "homepage" field [on npm](https://www.npmjs.com/package/simple-icons) returns a privacy error for https://www.simpleicons.org/

Removing the www subdomain from that link sends you to https://simpleicons.org/ which works just fine.

You may also want to look into why the www cert doesn't work, here's a quick fix though.

<img width="1000" alt="Screen Shot 2021-03-08 at 8 44 27 AM" src="https://user-images.githubusercontent.com/231851/110329381-811a6e80-7fea-11eb-9441-311309a440f6.png">