### PR TITLE
Add Google Fonts

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3309,6 +3309,11 @@
             "source": "https://partnermarketinghub.withgoogle.com/"
         },
         {
+            "title": "Google Fonts",
+            "hex": "4285F4",
+            "source": "https://fonts.google.com/"
+        },
+        {
             "title": "Google Hangouts",
             "hex": "0C9D58",
             "source": "https://material.google.com/resources/sticker-sheets-icons.html#sticker-sheets-icons-components"

--- a/icons/googlefonts.svg
+++ b/icons/googlefonts.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Google Fonts icon</title><path d="M4 2.8A3.6 3.6 0 1 0 4 10a3.6 3.6 0 0 0 0-7.2zm7.6 0v18.4h7.2a5.2 5.2 0 1 1 0-10.4 4 4 0 1 1 0-8zm7.2 0v8a4 4 0 1 0 0-8zm0 8v10.4A5.2 5.2 0 0 0 24 16a5.2 5.2 0 0 0-5.2-5.2zm-7.7-7.206L0 21.199h8.8l2.3-3.64Z"/></svg>


### PR DESCRIPTION
![Google Fonts](https://user-images.githubusercontent.com/15157491/110359647-a385a980-8035-11eb-87d5-0e1847ad299b.png)

**Issue:** n/a
**Alexa rank:** n/a

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Icon from SVG in [source](https://fonts.google.com/) header, colour is just Google blue. Tried everything I could to get rid of the overlapping points running down the middle of the circles but to no avail.