### PR TITLE
Updated AMD Source

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -413,7 +413,7 @@
         {
             "title": "AMD",
             "hex": "ED1C24",
-            "source": "https://subscriptions.amd.com/greatpower/img/amd-logo-black.svg"
+            "source": "https://www.amd.com/"
         },
         {
             "title": "American Airlines",


### PR DESCRIPTION
**Issue:** Contributes to #5251.
**Alexa rank:** [2,442](https://www.alexa.com/siteinfo/amd.com)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
AMD Source in `_data.json` is outdated, and no longer available. Updated to homepage, as SVG available in header.
