### PR TITLE
Update Xbox source

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -9148,7 +9148,7 @@
         {
             "title": "Xbox",
             "hex": "107C10",
-            "source": "http://mspartner-public.sharepoint.com/XBOX%20Games/Xbox%20logo's%20+%20Guidelines/Xbox%20Live/Xbox_Live_Guidelines_10-4-13.pdf"
+            "source": "https://www.xbox.com/en-US/consoles"
         },
         {
             "title": "Xcode",


### PR DESCRIPTION
**Issue:** Contributes to #5251.
**Alexa rank:** [1,034](https://www.alexa.com/siteinfo/xbox.com)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
Source URL results in 404. Updated to console page on Xbox website, where the `Game Pass` graphic is an SVG including the logo.
