### PR TITLE
Updated VSCO Source

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -8800,7 +8800,7 @@
         {
             "title": "VSCO",
             "hex": "000000",
-            "source": "https://vsco.co/about/press/vsco-releases-redesigned-mobile-app"
+            "source": "https://vscopress.co/"
         },
         {
             "title": "Vue.js",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -8800,7 +8800,7 @@
         {
             "title": "VSCO",
             "hex": "000000",
-            "source": "https://vscopress.co/"
+            "source": "https://vscopress.co/media-kit"
         },
         {
             "title": "Vue.js",


### PR DESCRIPTION
Our current source URL leads to a 404 page. Updated to their new (?) press portal.