### PR TITLE
Updated Bentley Source

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1046,7 +1046,7 @@
         {
             "title": "Bentley",
             "hex": "333333",
-            "source": "https://en.wikipedia.org/wiki/File:Bentley_logo.svg"
+            "source": "https://en.wikipedia.org/wiki/File:Bentley_logo_2.svg"
         },
         {
             "title": "Big Cartel",


### PR DESCRIPTION
Updated source for Bentley logo. Original source now points to a school logo.