### PR TITLE
Update Beijing Subway Source

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1041,7 +1041,7 @@
         {
             "title": "Beijing Subway",
             "hex": "004A9D",
-            "source": "https://commons.wikimedia.org/wiki/File:Beijing_Subway_logo.svg"
+            "source": "https://zh.wikipedia.org/wiki/File:Beijing_Subway_Logo.svg"
         },
         {
             "title": "Bentley",


### PR DESCRIPTION
Original source removed from Wikipedia due to the [Threshold of Originality](https://commons.wikimedia.org/wiki/Commons:Copyright_rules_by_territory/China#Threshold_of_originality) in China. Updated to Chinese source.