### PR TITLE
Update Buzzfeed Source

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1307,7 +1307,7 @@
         {
             "title": "BuzzFeed",
             "hex": "EE3322",
-            "source": "http://www.buzzfeed.com/press/downloads"
+            "source": "https://www.buzzfeed.com/press/assets"
         },
         {
             "title": "byte",


### PR DESCRIPTION
Buzzfeed's source went to a blank page. Updated to the correct download page for their brand assets.