### PR TITLE
Remove '.html' extension for SPDX license urls

### DIFF
--- a/scripts/build-package.js
+++ b/scripts/build-package.js
@@ -45,7 +45,7 @@ function licenseToObject(license) {
   }
 
   if (license.url === undefined) {
-    license.url = `https://spdx.org/licenses/${license.type}.html`;
+    license.url = `https://spdx.org/licenses/${license.type}`;
   }
   return license;
 }


### PR DESCRIPTION
SPDX license pages can be accesed without `.html` extensions as you can see in [their repository `website/` folder](https://github.com/spdx/license-list-data/tree/master/website), so we can remove the extension building the URL.