### PR TITLE
Update Preview Generator URL in PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Before opening your pull request, have a quick look at our contribution guidelin
 https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
 
 Consider adding a preview image of your submission using:
-https://petershaggynoble.github.io/MDI-Sandbox/simpleicons/preview/
+https://petershaggynoble.github.io/SI-Sandbox/preview/
 -->
 
 **Issue:**


### PR DESCRIPTION
Now that I have a [dedicated sandbox site](https://petershaggynoble.github.io/SI-Sandbox/) for Simple Icons, this PR simply updates the preview generator URL in our PR template to point to [the version there](https://petershaggynoble.github.io/SI-Sandbox/preview/) rather than linking to a sandbox site for another icon library.