### PR TITLE
Add GNU licenses

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3248,12 +3248,19 @@
         {
             "title": "GNU Bash",
             "hex": "4EAA25",
-            "source": "https://github.com/odb/official-bash-logo"
+            "source": "https://github.com/odb/official-bash-logo",
+            "license": {
+                "type": "custom",
+                "url": "http://artlibre.org/licence/lal/en/"
+            }
         },
         {
             "title": "GNU Emacs",
             "hex": "7F5AB6",
-            "source": "https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/images/icons/hicolor/scalable/apps/emacs.svg"
+            "source": "https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/images/icons/hicolor/scalable/apps/emacs.svg",
+            "license": {
+                "type": "GPL-2.0-or-later"
+            }
         },
         {
             "title": "GNU IceCat",
@@ -3263,7 +3270,10 @@
         {
             "title": "GNU Privacy Guard",
             "hex": "0093DD",
-            "source": "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=tree;f=artwork/icons"
+            "source": "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=tree;f=artwork/icons",
+            "license": {
+                "type": "GPL-3.0-or-later"
+            }
         },
         {
             "title": "GNU social",


### PR DESCRIPTION
**Issue:** Follow-up to #5396
**Alexa rank:** n/a

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
Adds license info for a number of our GNU icons.
Sources:
- [GNU Bash](https://github.com/odb/official-bash-logo)
- [GNU Emacs](https://ftp.gnu.org/old-gnu/Manuals/emacs-20.7/html_chapter/emacs_3.html) (confirmed by comments in [source](https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/images/icons/hicolor/scalable/apps/emacs.svg))
- [GNU Privacy Guard](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob;f=artwork/README;h=068bdea1df9f70b3e4faeef7f176096ff20a4bca;hb=HEAD)

GNU IceCat is released under the Mozilla Public License but I couldn't find anything explicitly confirming that that includes the logo.