### PR TITLE
Add pnpm icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -6540,8 +6540,7 @@
         {
             "title": "PostgreSQL",
             "hex": "336791",
-            "source": "https://wiki.postgresql.org/wiki/Logo",
-            "guidelines": "https://www.postgresql.org/about/policies/trademarks/"
+            "source": "https://wiki.postgresql.org/wiki/Logo"
         },
         {
             "title": "Postman",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -6477,6 +6477,11 @@
             "source": "https://pm2.keymetrics.io/"
         },
         {
+            "title": "pnpm",
+            "hex": "F69220",
+            "source": "https://pnpm.io/logos"
+        },
+        {
             "title": "Pocket",
             "hex": "EF3F56",
             "source": "https://getpocket.com/blog/press/"
@@ -6535,7 +6540,8 @@
         {
             "title": "PostgreSQL",
             "hex": "336791",
-            "source": "https://wiki.postgresql.org/wiki/Logo"
+            "source": "https://wiki.postgresql.org/wiki/Logo",
+            "guidelines": "https://www.postgresql.org/about/policies/trademarks/"
         },
         {
             "title": "Postman",

--- a/icons/pnpm.svg
+++ b/icons/pnpm.svg
@@ -1,0 +1,1 @@
+<svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>pnpm icon</title><path d="M0 0v7.5h7.5V0zm8.25 0v7.5h7.498V0zm8.25 0v7.5H24V0zM8.25 8.25v7.5h7.498v-7.5zm8.25 0v7.5H24v-7.5zM0 16.5V24h7.5v-7.5zm8.25 0V24h7.498v-7.5zm8.25 0V24H24v-7.5z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/SI-Sandbox/preview/
-->
![image](https://user-images.githubusercontent.com/12817388/115156718-ab346700-a053-11eb-9db1-d8ba6cd310c6.png)


**Issue:** N/A
**Alexa rank:** [10.9k Github ⭐](https://github.com/pnpm/pnpm)
  <!-- The Alexa rank can be retrieved at https://www.alexa.com/siteinfo/
       Please see our contributing guidelines for more details on how we
       assess a brand's popularity. -->

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description

- I took the Standard Logo with no text SVG from https://pnpm.io/logos#standard-logo-with-no-text
- I used Inkscape to scale
- I used https://jakearchibald.github.io/svgomg/ to optimize
- I took the primary color define in the website stylesheet
  - `#f9ad00` from the logo might be another color option
