### PR TITLE
Fix redirection when returning from new website

### DIFF
--- a/site_script.js
+++ b/site_script.js
@@ -200,6 +200,7 @@
       $hideAlways = document.getElementById('hide-feedback-request');
 
   var redesignUrl = 'https://simple-icons.github.io/simple-icons-website/',
+      redesignRootDomain = 'simple-icons.github.io',
       hideBannerAlwaysIdentifier = 'hide-banner',
       redirectAutomaticallyIdentifier = 'redirect-to-redesign';
 
@@ -235,7 +236,7 @@
     var redirect = localStorage.getItem(redirectAutomaticallyIdentifier);
     if (redirect === 'true') {
       $redirectAutomatically.innerHTML = "Disable redirect";
-      if (document.referrer !== redesignUrl) {
+      if (document.referrer.split('/')[2] !== redesignRootDomain) {
         window.location.replace(redesignUrl);
       }
     }


### PR DESCRIPTION
The current problem is: if an user comes from the new website (clicking in "Go to the old design" link) and has the automatic redirection active (saved at storage), will be redirected to the new website again. This happens because `document.referrer` [does not return the full URL of the page from the user comes](https://stackoverflow.com/q/23682718/9167585), the path is omitted, so the referrer comparation should be against the root domain.