### PR TITLE
F Brand Review

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2860,7 +2860,7 @@
         {
             "title": "FileZilla",
             "hex": "BF0000",
-            "source": "https://upload.wikimedia.org/wikipedia/commons/0/01/FileZilla_logo.svg"
+            "source": "https://commons.wikimedia.org/wiki/File:FileZilla_logo.svg"
         },
         {
             "title": "Fing",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2749,7 +2749,7 @@
             "source": "https://fandomdesignsystem.com/identity/assets"
         },
         {
-            "title": "Farfetch",
+            "title": "FARFETCH",
             "hex": "000000",
             "source": "https://www.farfetch.com/"
         },

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2806,7 +2806,7 @@
         {
             "title": "Feedly",
             "hex": "2BB24C",
-            "source": "https://blog.feedly.com/wp-content/themes/feedly-2017-v1.19.3/assets/images/logos/logo.svg"
+            "source": "https://blog.feedly.com/"
         },
         {
             "title": "Ferrari",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2907,7 +2907,11 @@
         {
             "title": "Flask",
             "hex": "000000",
-            "source": "http://flask.pocoo.org/community/logos/"
+            "source": "https://github.com/pallets/flask/blob/e6e75e55470a0682ee8370e6d68062e515a248b9/artwork/logo-full.svg",
+            "license": {
+                "type": "custom",
+                "url": "https://github.com/pallets/flask/blob/master/artwork/LICENSE.rst"
+            }
         },
         {
             "title": "Flathub",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2827,10 +2827,7 @@
             "title": "Fido Alliance",
             "hex": "FFBF3B",
             "source": "https://fidoalliance.org/overview/legal/logo-usage/",
-            "license": {
-                "type": "custom",
-                "url": "https://fidoalliance.org/overview/legal/fido-trademark-and-service-mark-usage-agreement-for-websites/"
-            }
+            "guidelines": "https://fidoalliance.org/overview/legal/fido-trademark-and-service-mark-usage-agreement-for-websites/"
         },
         {
             "title": "FIFA",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2826,7 +2826,11 @@
         {
             "title": "Fido Alliance",
             "hex": "FFBF3B",
-            "source": "https://fidoalliance.org/overview/legal/logo-usage/"
+            "source": "https://fidoalliance.org/overview/legal/logo-usage/",
+            "license": {
+                "type": "custom",
+                "url": "https://fidoalliance.org/overview/legal/fido-trademark-and-service-mark-usage-agreement-for-websites/"
+            }
         },
         {
             "title": "FIFA",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2926,7 +2926,7 @@
         {
             "title": "Flickr",
             "hex": "0063DC",
-            "source": "https://worldvectorlogo.com/logo/flickr-1"
+            "source": "https://www.flickr.com/"
         },
         {
             "title": "Flipboard",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2951,12 +2951,16 @@
         {
             "title": "Fluentd",
             "hex": "0E83C8",
-            "source": "https://docs.fluentd.org/quickstart/logo"
+            "source": "https://docs.fluentd.org/quickstart/logo",
+            "license": {
+                "type": "Apache-2.0"
+            }
         },
         {
             "title": "Flutter",
             "hex": "02569B",
-            "source": "https://flutter.dev/brand"
+            "source": "https://flutter.dev/brand",
+            "guidelines": "https://flutter.dev/brand"
         },
         {
             "title": "Fnac",

--- a/icons/farfetch.svg
+++ b/icons/farfetch.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Farfetch icon</title><path d="M9.635 0L4.883 4.811V24h4.752v-9.593h7.119V9.6H9.635V4.811h9.482V0Z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>FARFETCH icon</title><path d="M24 10.248V6.749H13.586c-3.062 0-4.737 1.837-4.737 4.488v2.231H4.321V8.599c0-3.425.332-5.074 4.212-5.074H24V0H6.259C2.336 0 0 2.589 0 6.386V24h4.321v-7.033h4.527V24h4.339v-7.033H24v-3.499H13.188v-1.155c0-1.461.232-2.064 2.257-2.064H24z"/></svg>


### PR DESCRIPTION
## Updated
- FARFETCH (New SVG, and uppercase brand name).
- Feedly (Change source to blog homepage, as opposed to specific file).
- Fido Alliance - Added Legal Page to `license` entry.
- FileZilla - Updated source to Wiki Commons _page_ instead of directly to file. Allows for us to see changes.
- Flickr - SVG now available on the homepage.
- Fluentd - Note at source saying available under Apache 2.0.
- Flutter - Added Guidelines Entry

### Notes
- We need to change Fedora to use the wordmark, as mentioned [here](https://fedoraproject.org/wiki/Logo/UsageGuidelines#One-color_logo).
- Our `First` logo should be updated to the 'Vertical One Colour' version found [here](https://www.firstinspires.org/sites/default/files/uploads/resource_library/brand/first-brand-guidelines-2020.pdf).
- Flickr's icon is different to the previous (WorldVectorIcon) version. Will need updating.
- Ford - Most instances I'm seeing online include a flat-coloured inner ellipse. Should we look to update ours? (No source SVG found of new icon yet!).
- FreeBSD - We need to include the ® - as detailed [here](https://freebsdfoundation.org/legal/trademark-usage-terms-and-conditions/).