### PR TITLE
Letter H review

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3664,7 +3664,7 @@
         {
             "title": "HackHands",
             "hex": "00ACBD",
-            "source": "https://hackhands.com/"
+            "source": "https://www.pluralsight.com/hackhands"
         },
         {
             "title": "Hackster",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3722,7 +3722,8 @@
         {
             "title": "Haxe",
             "hex": "EA8220",
-            "source": "https://haxe.org/foundation/branding.html"
+            "source": "https://haxe.org/foundation/branding.html",
+            "guidelines": "https://haxe.org/foundation/branding.html"
         },
         {
             "title": "HBO",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3841,7 +3841,7 @@
         {
             "title": "HomeAdvisor",
             "hex": "F68315",
-            "source": "https://www.abouthomeadvisor.com/media-room/press-resources/"
+            "source": "https://www.homeadvisor.com/"
         },
         {
             "title": "Homebrew",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3691,8 +3691,8 @@
         },
         {
             "title": "Harbor",
-            "hex": "4A00D8",
-            "source": "https://github.com/goharbor/harbor/blob/13686cbe83d22259216da7658612e86201070e94/src/portal/src/images/harbor-logo.svg"
+            "hex": "60B932",
+            "source": "https://branding.cncf.io/projects/harbor/"
         },
         {
             "title": "Hashnode",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3919,7 +3919,8 @@
         {
             "title": "HubSpot",
             "hex": "FF7A59",
-            "source": "https://www.hubspot.com/style-guide"
+            "source": "https://www.hubspot.com/style-guide",
+            "guidelines": "https://www.hubspot.com/style-guide"
         },
         {
             "title": "Hugo",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3966,7 +3966,7 @@
         {
             "title": "Hypothesis",
             "hex": "BD1C2B",
-            "source": "https://web.hypothes.is/"
+            "source": "https://web.hypothes.is/brand/"
         },
         {
             "title": "Hyundai",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3796,7 +3796,7 @@
         {
             "title": "Hilton",
             "hex": "124D97",
-            "source": "https://www.hilton.com/en/"
+            "source": "https://newsroom.hilton.com/hhr/page/logos"
         },
         {
             "title": "HipChat",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3971,7 +3971,8 @@
         {
             "title": "Hyundai",
             "hex": "002C5F",
-            "source": "https://en.wikipedia.org/wiki/File:Hyundai_Motor_Company_logo.svg"
+            "source": "https://en.wikipedia.org/wiki/File:Hyundai_Motor_Company_logo.svg",
+            "guidelines": "https://www.hyundai.pl/fileadmin/user_upload/media/logo/201607_HYU_Guideline_ENG_small.pdf"
         },
         {
             "title": "Iata",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3822,7 +3822,8 @@
         {
             "title": "HockeyApp",
             "hex": "009EE1",
-            "source": "https://hockeyapp.net/brand-guidelines/"
+            "source": "https://hockeyapp.net/brand-guidelines/",
+            "guidelines": "https://hockeyapp.net/brand-guidelines/"
         },
         {
             "title": "Home Assistant",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3892,7 +3892,8 @@
         {
             "title": "Houzz",
             "hex": "4DBC15",
-            "source": "https://www.houzz.com/logoGuidelines"
+            "source": "https://www.houzz.com/logoGuidelines",
+            "guidelines": "https://www.houzz.com/logoGuidelines"
         },
         {
             "title": "HP",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3702,7 +3702,7 @@
         {
             "title": "Haskell",
             "hex": "5D4F85",
-            "source": "https://commons.wikimedia.org/wiki/File:Haskell-Logo.svg"
+            "source": "https://wiki.haskell.org/Thompson-Wheeler_logo"
         },
         {
             "title": "Hasura",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3828,7 +3828,10 @@
         {
             "title": "Home Assistant",
             "hex": "41BDF5",
-            "source": "https://github.com/home-assistant/home-assistant-assets"
+            "source": "https://github.com/home-assistant/assets/blob/1e19f0dca208f0876b274c68345fcf989de7377a/logo/logo-small.png",
+            "license": {
+                "type": "CC-BY-NC-SA-4.0"
+            }
         },
         {
             "title": "Home Assistant Community Store",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3675,7 +3675,8 @@
         {
             "title": "Handshake",
             "hex": "FF2F1C",
-            "source": "https://learn.joinhandshake.com/marketing-toolkit/"
+            "source": "https://joinhandshake.com/career-centers/marketing-toolkit/",
+            "guidelines": "https://joinhandshake.com/career-centers/marketing-toolkit/"
         },
         {
             "title": "Handshake",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3765,7 +3765,7 @@
         {
             "title": "HERE",
             "hex": "00AFAA",
-            "source": "https://www.here.com"
+            "source": "https://www.here.com/company/media-assets"
         },
         {
             "title": "Heroku",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3929,8 +3929,9 @@
         },
         {
             "title": "Hulu",
-            "hex": "3DBB3D",
-            "source": "https://www.hulu.com/press/brand-assets/"
+            "hex": "1CE783",
+            "source": "https://press.hulu.com/branding/",
+            "guidelines": "https://press.hulu.com/branding/"
         },
         {
             "title": "Humble Bundle",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3865,8 +3865,9 @@
         },
         {
             "title": "Hootsuite",
-            "hex": "000000",
-            "source": "https://hootsuite.com/en-gb/about/media-kit"
+            "hex": "143059",
+            "source": "https://hootsuite.widencollective.com/portals/bafpk5oo/MediaKitAssets/c/b9e3a7bb-aca7-48d7-90ed-cff5898aafd0",
+            "guidelines": "https://hootsuite.widencollective.com/portals/bafpk5oo/MediaKitAssets"
         },
         {
             "title": "Hoppscotch",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3759,7 +3759,8 @@
         {
             "title": "HelpDesk",
             "hex": "FFD000",
-            "source": "https://helpdesk.design/"
+            "source": "https://helpdesk.design/",
+            "guidelines": "https://helpdesk.design/"
         },
         {
             "title": "HERE",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3733,7 +3733,8 @@
         {
             "title": "HCL",
             "hex": "006BB6",
-            "source": "https://www.hcl.com/brand-guidelines"
+            "source": "https://www.hcl.com/brand-guidelines",
+            "guidelines": "https://www.hcl.com/brand-guidelines"
         },
         {
             "title": "Headspace",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3770,7 +3770,8 @@
         {
             "title": "Heroku",
             "hex": "430098",
-            "source": "https://www.heroku.com"
+            "source": "https://brand.heroku.com/",
+            "guidelines": "https://brand.heroku.com/"
         },
         {
             "title": "Hexo",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3638,7 +3638,8 @@
         {
             "title": "Hack The Box",
             "hex": "9FEF00",
-            "source": "https://www.hackthebox.eu/docs/Hack_The_Box_Brand_Assets_Guide.pdf"
+            "source": "https://www.hackthebox.eu/docs/Hack_The_Box_Brand_Assets_Guide.pdf",
+            "guidelines": "https://www.hackthebox.eu/docs/Hack_The_Box_Brand_Assets_Guide.pdf"
         },
         {
             "title": "Hackaday",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3668,8 +3668,9 @@
         },
         {
             "title": "Hackster",
-            "hex": "1BACF7",
-            "source": "https://drive.google.com/file/d/0B3aqzR8LzoqdT1p4ZUlWVnJ1elk/view?usp=sharing"
+            "hex": "2E9FE6",
+            "source": "https://www.hackster.io/branding#logos",
+            "guidelines": "https://www.hackster.io/branding"
         },
         {
             "title": "Handshake",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3913,7 +3913,8 @@
         {
             "title": "Huawei",
             "hex": "FF0000",
-            "source": "https://en.wikipedia.org/wiki/File:Huawei.svg"
+            "source": "https://e.huawei.com/ph/material/partner/0a72728b864949c48b22106454352483",
+            "guidelines": "https://e.huawei.com/ph/material/partner/0a72728b864949c48b22106454352483"
         },
         {
             "title": "HubSpot",


### PR DESCRIPTION
**Issue:** #5251

### Notes

- [x] I think we might need to update https://habr.com/, no more use of a squared "h" can be found
- [x] We need to update https://www.hackerrank.com/, logo is now H🟩
- [ ] Was not able to find a better source for https://www.pluralsight.com/hackhands
- [x] Should we add the circle around https://www.hackster.io/branding?
- [x] I think we might need to add the ®️ for https://www.hellyhansen.com/
- [x] We need to remove Highly (https://techcrunch.com/2019/04/17/twitter-highly/) - #4243
- [x] We need to remove HipChat (https://en.wikipedia.org/wiki/HipChat) - #5556
- [ ] Was not able to find a better source for https://www.homeadvisor.com/
- [x] I think we might need to use the full wordmark for https://press.hulu.com/branding/
