### PR TITLE
Format  Third Party Extensions using Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,52 +154,19 @@ echo file_get_contents('path/to/package/icons/simpleicons.svg');
 
 ## Third Party Extensions
 
-### Drupal
-
-Icons are also available as a [Drupal module](https://www.drupal.org/project/simple_icons) created by [Phil Wolstenholme](https://www.drupal.org/u/phil-wolstenholme).
-
-### Flutter
-
-Icons are also available as a [Flutter package](https://pub.dev/packages/simple_icons) created by [@jlnrrg](https://jlnrrg.github.io/).
-
-### Hexo
-
-Icons are also available as a [Hexo plugin](https://github.com/nidbCN/hexo-simpleIcons) created by [@nidbCN](https://github.com/nidbCN/).
-
-### Home Assistant
-
-Icons are also available as a [Home Assistant plugin](https://github.com/vigonotion/hass-simpleicons) created by [@vigonotion](https://github.com/vigonotion/).
-
-### Jetpack Compose
-
-Icons are also available as a [Jetpack Compose library](https://github.com/DevSrSouza/compose-icons) created by [@devsrsouza](https://github.com/devsrsouza/).
-
-### Kirby
-
-Icons are also available as a [Kirby plugin](https://github.com/runxel/kirby3-simpleicons) created by [@runxel](https://github.com/runxel).
-
-### Laravel
-
-Icons are also available as a [Laravel Package](https://github.com/ublabs/blade-simple-icons) created by [@adrian-ub](https://github.com/adrian-ub)
-
-### Python
-
-Icons are also available as a [Python package](https://github.com/xCloudzx/simpleicons) created by [@xCloudzx](https://github.com/xCloudzx).
-
-### React
-
-Icons are also available as a [React package](https://github.com/icons-pack/react-simple-icons) created by [@wootsbot](https://github.com/wootsbot).
-
-### Svelte
-
-Icons are also available as a [Svelte package](https://github.com/icons-pack/svelte-simple-icons) created by [@wootsbot](https://github.com/wootsbot).
-
-### Vue
-
-Icons are also available as a [Vue package](https://github.com/mainvest/vue-simple-icons) created by [@noahlitvin](https://github.com/noahlitvin).
-
-### WordPress
-
-Icons are also available as a [WordPress plugin](https://wordpress.org/plugins/simple-icons/) created by [@tjtaylo](https://github.com/tjtaylo).
+| Extension | Author |
+| :--- | :--- |
+| [Drupal module](https://www.drupal.org/project/simple_icons) | [Phil Wolstenholme](https://www.drupal.org/u/phil-wolstenholme) |
+| [Flutter package](https://pub.dev/packages/simple_icons) | [@jlnrrg](https://jlnrrg.github.io/) |
+| [Hexo plugin](https://github.com/nidbCN/hexo-simpleIcons) | [@nidbCN](https://github.com/nidbCN/) |
+| [Home Assistant plugin](https://github.com/vigonotion/hass-simpleicons) | [@vigonotion](https://github.com/vigonotion/) |
+| [Jetpack Compose library](https://github.com/DevSrSouza/compose-icons) | [@devsrsouza](https://github.com/devsrsouza/) |
+| [Kirby plugin](https://github.com/runxel/kirby3-simpleicons) | [@runxel](https://github.com/runxel) |
+| [Laravel Package](https://github.com/ublabs/blade-simple-icons) | [@adrian-ub](https://github.com/adrian-ub) |
+| [Python package](https://github.com/xCloudzx/simpleicons) | [@xCloudzx](https://github.com/xCloudzx) |
+| [React package](https://github.com/icons-pack/react-simple-icons) | [@wootsbot](https://github.com/wootsbot) |
+| [Svelte package](https://github.com/icons-pack/svelte-simple-icons) | [@wootsbot](https://github.com/wootsbot) |
+| [Vue package](https://github.com/mainvest/vue-simple-icons) | [@noahlitvin](https://github.com/noahlitvin) |
+| [WordPress plugin](https://wordpress.org/plugins/simple-icons/) | [@tjtaylo](https://github.com/tjtaylo) |
 
 [slug]: ./slugs.md


### PR DESCRIPTION
Proposal to simplify the way we list  Third Party Extensions in the `README.md`.

This was a proposal made by @adamrusted in https://github.com/simple-icons/simple-icons/pull/4816#issuecomment-826301405.

You can see the results [here](https://github.com/service-paradis/simple-icons/blob/readme-extensions-in-table/README.md)
![image](https://user-images.githubusercontent.com/12817388/116412634-e168a800-a804-11eb-9a16-3597518c70c9.png)
