### PR TITLE
Letter G review

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3167,7 +3167,8 @@
         {
             "title": "Geocaching",
             "hex": "00874D",
-            "source": "https://www.geocaching.com/about/logousage.aspx"
+            "source": "https://www.geocaching.com/about/logousage.aspx",
+            "guidelines": "https://www.geocaching.com/about/logousage.aspx"
         },
         {
             "title": "Gerrit",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3158,7 +3158,11 @@
         {
             "title": "Gentoo",
             "hex": "54487A",
-            "source": "https://wiki.gentoo.org/wiki/Project:Artwork/Artwork#Variations_of_the_.22g.22_logo"
+            "source": "https://wiki.gentoo.org/wiki/Project:Artwork/Artwork#Variations_of_the_.22g.22_logo",
+            "guidelines": "https://www.gentoo.org/inside-gentoo/foundation/name-logo-guidelines.html",
+            "license": {
+                "type": "CC-BY-SA-2.5"
+            }
         },
         {
             "title": "Geocaching",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3623,7 +3623,7 @@
         {
             "title": "Gridsome",
             "hex": "00A672",
-            "source": "https://gridsome.org/logos/only-logo.svg"
+            "source": "https://gridsome.org/logo/"
         },
         {
             "title": "Groupon",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3198,7 +3198,8 @@
         {
             "title": "GIPHY",
             "hex": "FF6666",
-            "source": "https://support.giphy.com/hc/en-us/articles/360022283772-GIPHY-Brand-Guidelines"
+            "source": "https://support.giphy.com/hc/en-us/articles/360022283772-GIPHY-Brand-Guidelines",
+            "guidelines": "https://support.giphy.com/hc/en-us/articles/360022283772-GIPHY-Brand-Guidelines"
         },
         {
             "title": "Git",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3183,8 +3183,9 @@
         },
         {
             "title": "Ghostery",
-            "hex": "00BAF2",
-            "source": "https://www.ghostery.com/"
+            "hex": "00AEF0",
+            "source": "https://www.ghostery.com/",
+            "guidelines": "https://www.ghostery.com/press/"
         },
         {
             "title": "GIMP",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3127,7 +3127,8 @@
         {
             "title": "Gatsby",
             "hex": "663399",
-            "source": "https://www.gatsbyjs.com/guidelines/logo"
+            "source": "https://www.gatsbyjs.com/guidelines/logo",
+            "guidelines": "https://www.gatsbyjs.com/guidelines/logo"
         },
         {
             "title": "Gauges",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3628,7 +3628,8 @@
         {
             "title": "Groupon",
             "hex": "53A318",
-            "source": "https://brandplaybook.groupon.com/guidelines/logo/"
+            "source": "https://about.groupon.com/press/",
+            "guidelines": "https://about.groupon.com/press/"
         },
         {
             "title": "Grubhub",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3222,7 +3222,7 @@
         {
             "title": "GitBook",
             "hex": "3884FF",
-            "source": "http://styleguide.gitbook.com/icons"
+            "source": "https://github.com/GitbookIO/styleguide/blob/c958388dab901defa3e22978ca01272295627e05/icons/Logo.svg"
         },
         {
             "title": "Gitea",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3105,12 +3105,13 @@
             "title": "G2A",
             "hex": "F05F00",
             "source": "https://www.g2a.co/documents/",
-            "Guidelines": "https://www.g2a.co/documents/"
+            "guidelines": "https://www.g2a.co/documents/"
         },
         {
             "title": "Game Jolt",
             "hex": "CCFF00",
-            "source": "https://gamejolt.com/about"
+            "source": "https://gamejolt.com/about",
+            "guidelines": "https://gamejolt.com/about"
         },
         {
             "title": "Garmin",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3341,7 +3341,8 @@
         {
             "title": "Go",
             "hex": "00ADD8",
-            "source": "https://blog.golang.org/go-brand"
+            "source": "https://blog.golang.org/go-brand",
+            "guidelines": "https://blog.golang.org/go-brand"
         },
         {
             "title": "Godot Engine",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3576,7 +3576,8 @@
         {
             "title": "Gradle",
             "hex": "02303A",
-            "source": "https://gradle.com/brand"
+            "source": "https://gradle.com/brand",
+            "guidelines": "https://gradle.com/brand"
         },
         {
             "title": "Grafana",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3596,8 +3596,9 @@
         },
         {
             "title": "GraphQL",
-            "hex": "E10098",
-            "source": "http://graphql.org/"
+            "hex": "E434AA",
+            "source": "https://github.com/graphql/artwork/blob/ac6ee2ac1cf31ba1be1b8fbc40910f0c70c98a1e/GraphQL/icon/GraphQL-mark-black.svg",
+            "guidelines": "https://github.com/graphql/artwork"
         },
         {
             "title": "Grav",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3303,6 +3303,7 @@
             "title": "GNU Bash",
             "hex": "4EAA25",
             "source": "https://github.com/odb/official-bash-logo",
+            "guidelines": "https://github.com/odb/official-bash-logo",
             "license": {
                 "type": "custom",
                 "url": "http://artlibre.org/licence/lal/en/"

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3190,7 +3190,10 @@
         {
             "title": "GIMP",
             "hex": "5C5543",
-            "source": "https://www.gimp.org/about/linking.html#wilber-the-gimp-mascot"
+            "source": "https://www.gimp.org/about/linking.html#wilber-the-gimp-mascot",
+            "license": {
+                "type": "CC-BY-SA-3.0"
+            }
         },
         {
             "title": "GIPHY",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3650,7 +3650,11 @@
         {
             "title": "gulp",
             "hex": "CF4647",
-            "source": "https://gulpjs.com/"
+            "source": "https://github.com/gulpjs/artwork/blob/4e14158817ac88e9a5c02b3b307e6f630fe222fb/gulp-white-text.svg",
+            "guidelines": "https://github.com/gulpjs/artwork",
+            "license": {
+                "type": "CC0-1.0"
+            }
         },
         {
             "title": "Gumroad",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3232,7 +3232,7 @@
         {
             "title": "Gitee",
             "hex": "C71D23",
-            "source": "https://gitee.com/"
+            "source": "https://gitee.com/about_us"
         },
         {
             "title": "GitHub",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3177,8 +3177,9 @@
         },
         {
             "title": "Ghost",
-            "hex": "738A94",
-            "source": "https://ghost.org/design"
+            "hex": "15171A",
+            "source": "https://ghost.org/docs/logos/",
+            "guidelines": "https://ghost.org/docs/logos/"
         },
         {
             "title": "Ghostery",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3382,7 +3382,7 @@
         {
             "title": "Google Ads",
             "hex": "4285F4",
-            "source": "https://ads.google.com/intl/en_GB/home/"
+            "source": "https://ads.google.com/home/"
         },
         {
             "title": "Google AdSense",
@@ -3412,7 +3412,7 @@
         {
             "title": "Google Cast",
             "hex": "1BB6F6",
-            "source": "https://partnermarketinghub.withgoogle.com/#/brands"
+            "source": "https://www.google.com/intl/en_us/chromecast/built-in/"
         },
         {
             "title": "Google Chat",
@@ -3422,7 +3422,7 @@
         {
             "title": "Google Chrome",
             "hex": "4285F4",
-            "source": "https://thepartnermarketinghub.withgoogle.com/brands/chromebook/visual-identity/visual-identity/logos-and-badges/"
+            "source": "https://www.google.com/chrome/"
         },
         {
             "title": "Google Classroom",
@@ -3457,12 +3457,12 @@
         {
             "title": "Google Fit",
             "hex": "4285F4",
-            "source": "https://partnermarketinghub.withgoogle.com/"
+            "source": "https://partnermarketinghub.withgoogle.com/brands/google-fit/"
         },
         {
             "title": "Google Hangouts",
             "hex": "0C9D58",
-            "source": "https://material.google.com/resources/sticker-sheets-icons.html#sticker-sheets-icons-components"
+            "source": "https://upload.wikimedia.org/wikipedia/commons/e/ee/Hangouts_icon.svg"
         },
         {
             "title": "Google Keep",
@@ -3472,7 +3472,7 @@
         {
             "title": "Google Lens",
             "hex": "4285F4",
-            "source": "https://partnermarketinghub.withgoogle.com/#/brands/"
+            "source": "https://lens.google.com/"
         },
         {
             "title": "Google Maps",
@@ -3502,7 +3502,8 @@
         {
             "title": "Google News",
             "hex": "174EA6",
-            "source": "https://thepartnermarketinghub.withgoogle.com/brands/google-news/"
+            "source": "https://partnermarketinghub.withgoogle.com/brands/google-news/",
+            "guidelines": "https://partnermarketinghub.withgoogle.com/brands/google-news/legal-and-trademarks/legal-requirements/"
         },
         {
             "title": "Google Optimize",
@@ -3512,17 +3513,19 @@
         {
             "title": "Google Pay",
             "hex": "4285F4",
-            "source": "https://partnermarketinghub.withgoogle.com/#/brands/"
+            "source": "https://pay.google.com/intl/en_us/about/"
         },
         {
             "title": "Google Photos",
             "hex": "4285F4",
-            "source": "https://partnermarketinghub.withgoogle.com/#/brands/"
+            "source": "https://partnermarketinghub.withgoogle.com/brands/google-photos/visual-identity/visual-identity/icon/",
+            "guidelines": "https://partnermarketinghub.withgoogle.com/brands/google-photos/visual-identity/visual-identity/icon/"
         },
         {
             "title": "Google Play",
             "hex": "414141",
-            "source": "https://thepartnermarketinghub.withgoogle.com/brands/google-play/"
+            "source": "https://partnermarketinghub.withgoogle.com/brands/google-play/visual-identity/primary-logos/",
+            "guidelines": "https://partnermarketinghub.withgoogle.com/brands/google-play/visual-identity/primary-logos/"
         },
         {
             "title": "Google Podcasts",
@@ -3547,7 +3550,8 @@
         {
             "title": "Google Street View",
             "hex": "FEC111",
-            "source": "https://developers.google.com/streetview/ready/branding"
+            "source": "https://developers.google.com/streetview/ready/branding",
+            "guidelines": "https://developers.google.com/streetview/ready/branding"
         },
         {
             "title": "Google Tag Manager",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3104,7 +3104,8 @@
         {
             "title": "G2A",
             "hex": "F05F00",
-            "source": "https://www.g2a.co/contact/brand_guidelines/"
+            "source": "https://www.g2a.co/documents/",
+            "Guidelines": "https://www.g2a.co/documents/"
         },
         {
             "title": "Game Jolt",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3347,7 +3347,11 @@
         {
             "title": "Godot Engine",
             "hex": "478CBF",
-            "source": "https://godotengine.org/themes/godotengine/assets/download/godot_logo.svg"
+            "source": "https://godotengine.org/press",
+            "guidelines": "https://godotengine.org/press",
+            "license": {
+                "type": "CC-BY-4.0"
+            }
         },
         {
             "title": "GoFundMe",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3273,7 +3273,8 @@
         {
             "title": "Glassdoor",
             "hex": "0CAA41",
-            "source": "https://www.glassdoor.com/press/images/"
+            "source": "https://www.glassdoor.com/about-us/press/media-assets/",
+            "guidelines": "https://www.glassdoor.com/about-us/press/media-assets/"
         },
         {
             "title": "Glitch",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3376,7 +3376,8 @@
         {
             "title": "Google",
             "hex": "4285F4",
-            "source": "https://partnermarketinghub.withgoogle.com/"
+            "source": "https://partnermarketinghub.withgoogle.com/",
+            "guidelines": "https://about.google/brand-resource-center/brand-elements/"
         },
         {
             "title": "Google Ads",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3608,7 +3608,7 @@
         {
             "title": "Gravatar",
             "hex": "1E8CBE",
-            "source": "https://automattic.com/press"
+            "source": "https://automattic.com/press/brand-materials/"
         },
         {
             "title": "Graylog",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3638,8 +3638,9 @@
         },
         {
             "title": "Grunt",
-            "hex": "FBA919",
-            "source": "https://github.com/gruntjs/gruntjs.com/tree/master/src/media"
+            "hex": "FAA918",
+            "source": "https://github.com/gruntjs/gruntjs.com/blob/70f43898d9ce8e6cc862ad72bf8a7aee5ca199a9/src/media/grunt-logo-no-wordmark.svg",
+            "guidelines": "https://github.com/gruntjs/grunt-docs/blob/main/Grunt-Brand-Guide.md"
         },
         {
             "title": "Guangzhou Metro",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3116,7 +3116,8 @@
         {
             "title": "Garmin",
             "hex": "000000",
-            "source": "https://creative.garmin.com/styleguide/brand/"
+            "source": "https://creative.garmin.com/styleguide/logo/",
+            "guidelines": "https://creative.garmin.com/styleguide/brand/"
         },
         {
             "title": "Gatling",


### PR DESCRIPTION
**Issue:** #5251

### Notes

- [ ] We need to update https://g2acowebproddata.blob.core.windows.net/g2acowebproddata/2020/06/G2A_Brand_Book_Basic_September_2019.pdf since the logo is slightly different
  - We might be able to remove the `.com` as stated in their guidelines: "You can omit “.com” with the G2A logo in very small sizes"
- [ ] I think we might need to update https://get.gaug.es/
- [ ] We need to update https://www.geeksforgeeks.org/
- [ ] I think we might need to add the ® for https://www.geocaching.com/about/logousage.aspx
- [ ] We need to update https://ghost.org/docs/logos/ (or remove since it is hard to do a monochrome version?)
- [ ] We need to remove https://support.giphy.com/hc/en-us/articles/360022283772-GIPHY-Brand-Guidelines (no monochrome version allowed)
- [ ] We need to update https://github.com/logos
- [ ] We need to remove https://www.graph.cool/
