### PR TITLE
Add New Japan Pro-Wrestling aliases

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -5813,7 +5813,22 @@
             "title": "New Japan Pro-Wrestling",
             "slug": "newjapanpro-wrestling",
             "hex": "FF160B",
-            "source": "https://en.wikipedia.org/wiki/File:NJPW_World_Logo.svg"
+            "source": "https://en.wikipedia.org/wiki/File:NJPW_World_Logo.svg",
+            "aliases": {
+                "aka": [
+                    "NJPW"
+                ],
+                "dup": [
+                    {
+                        "title": "NJPW World",
+                        "hex": "B79C65",
+                        "source": "https://njpwworld.com/"
+                    }
+                ],
+                "loc": {
+                    "ja-JP": "新日本プロレスリング"
+                }
+            }
         },
         {
             "title": "New Relic",


### PR DESCRIPTION
![NJPW World](https://user-images.githubusercontent.com/15157491/117313169-8f1b2d00-ae7d-11eb-8ac4-ea2a3c676564.png)

**Issue:** #4797
**Alexa rank:** [~35.5k](https://www.alexa.com/siteinfo/njpwworld.com)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
Taking aliases for a test drive 🙂
- You can see from [their English site](https://www.njpw1972.com/) and sub-sites that they refer to themselves as NJPW at times and it's even more prevelant when spoken (e.g., on commentary).
- NJPW World is their streaming service and the colour is taken from the "Live Schedule" link below the slideshow on [their website](https://njpwworld.com/). Ignore the unspaced "NJPWWorld" stylisation if you're viewing the site in English; they're using Google Translate 🙄
- Japanese name (Shin Nihon Puroresuringu) from `<title>` tag of [their Japanese site](https://www.njpw.co.jp/) and confirmed by [Wikipedia](https://en.wikipedia.org/wiki/New_Japan_Pro-Wrestling). Note that the "株式会社" (kabushiki gaisha) in the name on Wikipedia is simply the [type of company](https://en.wikipedia.org/wiki/Kabushiki_gaisha) they are and, in the same way we don't include the likes of "Ltd", "plc" or "GmbH" in brand names, I've omitted it from the title in the JSON.