### PR TITLE
Add Netlify CMS alias

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -5807,7 +5807,16 @@
             "title": "Netlify",
             "hex": "00C7B7",
             "source": "https://www.netlify.com/press/",
-            "guidelines": "https://www.netlify.com/press/"
+            "guidelines": "https://www.netlify.com/press/",
+            "aliases": {
+                "dup": [
+                    {
+                        "title": "Netlify CMS",
+                        "hex": "C9FA4B",
+                        "source": "https://www.netlifycms.org/"
+                    }
+                ]
+            }
         },
         {
             "title": "New Japan Pro-Wrestling",


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/SI-Sandbox/preview/
-->
![image](https://user-images.githubusercontent.com/12817388/117317712-c24ac580-ae57-11eb-9da4-01cae541d7e1.png)


**Issue:** N/A
**Alexa rank:** [~120k](https://www.alexa.com/siteinfo/netlifycms.org)
  <!-- The Alexa rank can be retrieved at https://www.alexa.com/siteinfo/
       Please see our contributing guidelines for more details on how we
       assess a brand's popularity. -->

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description

- We have aliases now, so wanted to give it a try :)
