### PR TITLE
Fix data for "Transport for ..." icons

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -8912,13 +8912,13 @@
         },
         {
             "title": "Transport for Ireland",
-            "hex": "113B92",
-            "source": "https://tfl.gov.uk/"
+            "hex": "00B274",
+            "source": "https://www.transportforireland.ie/"
         },
         {
             "title": "Transport for London",
-            "hex": "00B274",
-            "source": "https://www.transportforireland.ie/"
+            "hex": "113B92",
+            "source": "https://tfl.gov.uk/"
         },
         {
             "title": "Travis CI",


### PR DESCRIPTION
**Issue:** n/a
**Alexa rank:** n/a

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
So, somehow in #2742 _somebody_ 🙄 managed to mix up the JSON data for Transport for Ireland & Transport for London and not only did it pass review but it went unnoticed for over a year!