### PR TITLE
Update Hashicorp Data

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1881,8 +1881,9 @@
         },
         {
             "title": "Consul",
-            "hex": "CA2171",
-            "source": "https://www.hashicorp.com/brand"
+            "hex": "F24C53",
+            "source": "https://www.hashicorp.com/brand",
+            "guidelines": "https://www.hashicorp.com/brand"
         },
         {
             "title": "Contactless Payment",
@@ -8712,8 +8713,9 @@
         },
         {
             "title": "Terraform",
-            "hex": "623CE4",
-            "source": "https://www.hashicorp.com/brand#terraform"
+            "hex": "7B42BC",
+            "source": "https://www.hashicorp.com/brand",
+            "guidelines": "https://www.hashicorp.com/brand"
         },
         {
             "title": "Tesla",
@@ -9263,8 +9265,9 @@
         },
         {
             "title": "Vagrant",
-            "hex": "1563FF",
-            "source": "https://www.hashicorp.com/brand#vagrant"
+            "hex": "1868F2",
+            "source": "https://www.hashicorp.com/brand",
+            "guidelines": "https://www.hashicorp.com/brand"
         },
         {
             "title": "Valve",
@@ -9279,7 +9282,8 @@
         {
             "title": "Vault",
             "hex": "000000",
-            "source": "https://www.hashicorp.com/brand"
+            "source": "https://www.hashicorp.com/brand",
+            "guidelines": "https://www.hashicorp.com/brand"
         },
         {
             "title": "Vauxhall",


### PR DESCRIPTION
**Issue:** n/a
**Alexa rank:** n/a

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
Updates the hex values for all our Hashicorp icons to the newest Print/Logomark colours available at [source](https://www.hashicorp.com/brand) and duplicates the `source` entry for each as the `guidelines`.