### PR TITLE
Add GoToWebinar alias to GoToMeeting

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3634,7 +3634,16 @@
         {
             "title": "GoToMeeting",
             "hex": "F68D2E",
-            "source": "https://www.gotomeeting.com/"
+            "source": "https://www.gotomeeting.com/",
+            "aliases": {
+                "dup": [
+                    {
+                        "title": "GoToWebinar",
+                        "hex": "00C0F3",
+                        "source": "https://www.gotomeeting.com/en-ie/webinar"
+                    }
+                ]
+            }
         },
         {
             "title": "GOV.UK",


### PR DESCRIPTION
![GoToWebinar](https://user-images.githubusercontent.com/15157491/117854811-bf9a0700-b281-11eb-88ea-ee51092c24f0.png)

**Issue:** Closes #3394
**Alexa rank:** [781](https://www.alexa.com/siteinfo/gotowebinar.com)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Colour from SVG in [source](https://www.gotomeeting.com/en-ie/webinar) header.