### PR TITLE
Update the `hex` for Apple Music to pink

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -697,7 +697,7 @@
         },
         {
             "title": "Apple Music",
-            "hex": "000000",
+            "hex": "fa243c",
             "source": "https://www.apple.com/itunes/marketing-on-music/identity-guidelines.html#apple-music-icon"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -697,7 +697,7 @@
         },
         {
             "title": "Apple Music",
-            "hex": "fa243c",
+            "hex": "FA243C",
             "source": "https://www.apple.com/itunes/marketing-on-music/identity-guidelines.html#apple-music-icon"
         },
         {


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/SI-Sandbox/preview/
-->
![applemusic](https://user-images.githubusercontent.com/16580576/117861159-c0955d80-b2ae-11eb-9131-60176fd89610.png)


**Issue:** Resolves #5633
**Alexa rank:**
  <!-- The Alexa rank can be retrieved at https://www.alexa.com/siteinfo/
       Please see our contributing guidelines for more details on how we
       assess a brand's popularity. -->

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
This is the color used most extensively on the Apple Music site.