### PR TITLE
Update Fedora JSON

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2872,7 +2872,12 @@
         {
             "title": "Fedora",
             "hex": "294172",
-            "source": "https://fedoraproject.org/wiki/Logo/UsageGuidelines"
+            "source": "https://fedoraproject.org/wiki/Logo/UsageGuidelines",
+            "guidelines": "https://fedoraproject.org/wiki/Logo/UsageGuidelines",
+            "license": {
+                "type": "custom",
+                "url": "https://fedoraproject.org/wiki/Legal/TrademarkGuidelines"
+            }
         },
         {
             "title": "FedRAMP",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2876,7 +2876,7 @@
             "guidelines": "https://fedoraproject.org/wiki/Logo/UsageGuidelines",
             "license": {
                 "type": "custom",
-                "url": "https://fedoraproject.org/wiki/Legal/TrademarkGuidelines"
+                "url": "https://fedoraproject.org/wiki/Legal:Trademark_guidelines"
             }
         },
         {


### PR DESCRIPTION
### Notes
Following internal discussion with @mairin, we're allowed to continue using the current version of the Fedora icon for the time being, provided we link to the proper documents on their end. I've updated the JSON to include the guidelines and legal links for the existing icon. Awaiting feedback from the Fedora team as to whether we can rename this as 'Fedora Classic' once the new icon is in place. The question has been asked as to whether our users would _need_ a 'Fedora Classic' icon, or whether they can just use the new version. What are your thoughts @simple-icons/maintainers?

**Note:** This will not close the 'Update Fedora' issue, as the discussion around the new icon is still ongoing. This is just to update our JSON to be a bit more compliant until we're able to use the new icon.