### PR TITLE
Added Betfair icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1096,7 +1096,7 @@
         {
             "title": "Betfair",
             "hex": "FFB80B",
-            "source": "https://ro.wikipedia.org/wiki/Betfair#/media/Fi%C8%99ier:Betfair_logo.svg"
+            "source": "https://partnerships.betfair.com/"
         },
         {
             "title": "Big Cartel",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1094,6 +1094,11 @@
             "source": "https://en.wikipedia.org/wiki/File:Bentley_logo_2.svg"
         },
         {
+            "title": "Betfair",
+            "hex": "FFB80B",
+            "source": "https://partnerships.betfair.com/"
+        },
+        {
             "title": "Big Cartel",
             "hex": "222222",
             "source": "https://www.bigcartel.com"

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1096,7 +1096,7 @@
         {
             "title": "Betfair",
             "hex": "FFB80B",
-            "source": "https://partnerships.betfair.com/"
+            "source": "https://ro.wikipedia.org/wiki/Betfair#/media/Fi%C8%99ier:Betfair_logo.svg"
         },
         {
             "title": "Big Cartel",

--- a/icons/betfair.svg
+++ b/icons/betfair.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Betfair icon</title><path d="M20 0h-7v5H9l8 11 7-11h-4V0zM0 19h4v5h7v-5h4L7 8 0 19z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Betfair icon</title><path d="M20.25 0H13.2v4.76H9.3l7.35 11.703L24 4.959h-3.75zM0 19.24h3.75V24h7.05v-4.76h3.75L7.35 7.537z"/></svg>

--- a/icons/betfair.svg
+++ b/icons/betfair.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Betfair icon</title><path d="M20 0h-7v5H9l8 11 7-11h-4V0zM0 19h4v5h7v-5h4L7 8 0 19z"/></svg>

--- a/icons/betfair.svg
+++ b/icons/betfair.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Betfair icon</title><path d="M20.2178 3H13.1347V6.59934H9.35243L16.7106 15.1824L24 6.53012H20.2178V3ZM0 17.1205H3.78223V20.7198H10.8653V17.1205H14.6476L7.35817 8.53745L0 17.1205Z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Betfair icon</title><path d="M20.218 3h-7.083v3.6H9.352l7.359 8.582L24 6.53h-3.782V3zM0 17.12h3.782v3.6h7.083v-3.6h3.783l-7.29-8.583L0 17.12z"/></svg>

--- a/icons/betfair.svg
+++ b/icons/betfair.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Betfair icon</title><path d="M20.25 0H13.2v4.76H9.3l7.35 11.703L24 4.959h-3.75zM0 19.24h3.75V24h7.05v-4.76h3.75L7.35 7.537z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Betfair icon</title><path d="M20.2178 3H13.1347V6.59934H9.35243L16.7106 15.1824L24 6.53012H20.2178V3ZM0 17.1205H3.78223V20.7198H10.8653V17.1205H14.6476L7.35817 8.53745L0 17.1205Z"/></svg>

--- a/icons/betfair.svg
+++ b/icons/betfair.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Betfair icon</title><path d="M20.218 3h-7.083v3.6H9.352l7.359 8.582L24 6.53h-3.782V3zM0 17.12h3.782v3.6h7.083v-3.6h3.783l-7.29-8.583L0 17.12z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Betfair icon</title><path d="M20.218 3.14h-7.083v3.6H9.352l7.359 8.582L24 6.67h-3.782zM0 17.26h3.782v3.6h7.083v-3.6h3.783l-7.29-8.583z"/></svg>


### PR DESCRIPTION

![betfair (4)](https://user-images.githubusercontent.com/28590126/118769675-19558f00-b889-11eb-8c6c-7862ad86dc14.png)

**Issue:** https://github.com/simple-icons/simple-icons/issues/5714
**Alexa rank:** 10,460
  <!-- The Alexa rank can be retrieved at https://www.alexa.com/siteinfo/
       Please see our contributing guidelines for more details on how we
       assess a brand's popularity. -->

### Checklist
  - [X] I updated the JSON data in `_data/simple-icons.json`
  - [X] I optimized the icon with SVGO or SVGOMG
  - [X] The SVG `viewbox` is `0 0 24 24`

### Description

I picked the #FFB80B color from the logo itself using colour picker. I think it represents the betfair brand well, the logo looks really well on that color.

