### PR TITLE
feat(clickhouse): add clickhouse icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -1628,6 +1628,11 @@
             "source": "https://www.claris.com/"
         },
         {
+            "title": "ClickHouse",
+            "hex": "FFCC01",
+            "source": "https://clickhouse.tech/"
+        },
+        {
             "title": "ClickUp",
             "hex": "7B68EE",
             "source": "https://clickup.com/brand"

--- a/icons/clickhouse.svg
+++ b/icons/clickhouse.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>ClickHouse icon</title><path d="M0 20h2.7v2.7H0V20zM0 1.3h2.7V20H0V1.3zm5.3 0H8v21.3H5.3V1.3zm5.4 0h2.7v21.3h-2.7V1.3zm5.3 0h2.7v21.3H16V1.3zm5.3 8.7H24v4h-2.7v-4z"/></svg>


### PR DESCRIPTION
![clickhouse](https://user-images.githubusercontent.com/28356381/119014458-e6e28980-b98f-11eb-945f-cf9ef36caf23.png)

**Issue: n/a**
**Alexa rank: ~86.5k**

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Icon from SVG in website through [svg-grabber](https://chrome.google.com/webstore/detail/svg-grabber-get-all-the-s/ndakggdliegnegeclmfgodmgemdokdmg), colour is the background colour of the logo itself `#FFCC01` 
Used [inkscape](https://inkscape.org/) to vectorize the icon as it was suggested in the [CONTRIBUTING.md](https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md) file