### PR TITLE
feat(laravel-sail): add laravel sail icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -4962,6 +4962,11 @@
             "source": "https://nova.laravel.com/"
         },
         {
+            "title": "Laravel Sail",
+            "hex": "0C4A6E",
+            "source": "https://github.com/laravel/sail/blob/1.x/art/logo.svg"
+        },
+        {
             "title": "Last.fm",
             "slug": "last-dot-fm",
             "hex": "D51007",

--- a/icons/laravelsail.svg
+++ b/icons/laravelsail.svg
@@ -1,0 +1,1 @@
+<svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>Laravel Sail icon</title><path d="M3.9 19.9c1.8 2.05 4.2 3.4 7.1 3.7V9.5L3.9 19.9zM12 0C5.35 0 0 5.35 0 12s5.35 12 12 12 12-5.35 12-12S18.65 0 12 0zM2 12C2 6.5 6.5 2 12 2s10 4.5 10 10c0 2.15-.7 4.15-1.9 5.8L12 5.5V22C6.5 22 2 17.5 2 12z"/></svg>


### PR DESCRIPTION
![laravelsail](https://user-images.githubusercontent.com/28356381/119061859-3d21ed80-b9cd-11eb-9c07-a4a694ec7485.png)


**Issue:** n/a
**Alexa rank:** [~5.5k](https://www.alexa.com/siteinfo/laravel.com)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Icon from SVG in website through [svg-grabber](https://chrome.google.com/webstore/detail/svg-grabber-get-all-the-s/ndakggdliegnegeclmfgodmgemdokdmg).
The logo has 3 colors `#38BDF7`, `#0F1416` and `#E0F2FE` i decided to go with the blue color.
Used [inkscape](https://inkscape.org/) to vectorize the icon as it was suggested in the [CONTRIBUTING.md](https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md) file
