### PR TITLE
Update GNOME color

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3394,7 +3394,7 @@
         },
         {
             "title": "GNOME",
-            "hex": "4A86CF",
+            "hex": "000000",
             "source": "https://wiki.gnome.org/Engagement/BrandGuidelines"
         },
         {


### PR DESCRIPTION
![gnome](https://user-images.githubusercontent.com/86081003/123682864-91fd2300-d819-11eb-8a48-f558c7016da6.png)

**Issue:** fixes #6041
**Alexa rank:** 19,062

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - I picked the current color `#000000`, made with a GNOME logo. Taken in the GNOME's footer.
-->