### PR TITLE
Fix the release body of GitHub releases created by publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,6 +78,9 @@ jobs:
           RELEASE_TITLE=$(echo "${{ steps.commit.outputs.git-message }}" | head -n 1)
           echo "::set-output name=title::$RELEASE_TITLE"
           RELEASE_BODY=$(echo "${{ steps.commit.outputs.git-message }}" | tail -n $(expr $(echo "${{ steps.commit.outputs.git-message }}" | wc -l) - 1))
+          RELEASE_BODY="${RELEASE_BODY//'%'/'%25'}"
+          RELEASE_BODY="${RELEASE_BODY//$'\n'/'%0A'}"
+          RELEASE_BODY="${RELEASE_BODY//$'\r'/'%0D'}"
           echo "::set-output name=body::$RELEASE_BODY"
       - name: Get release version
         id: get-version


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/SI-Sandbox/preview/
-->

**Issue:** #5767
**Alexa rank:** n/a
  <!-- The Alexa rank can be retrieved at https://www.alexa.com/siteinfo/
       Please see our contributing guidelines for more details on how we
       assess a brand's popularity. -->

### Checklist
  - [n/a] I updated the JSON data in `_data/simple-icons.json`
  - [n/a] I optimized the icon with SVGO or SVGOMG
  - [n/a] The SVG `viewbox` is `0 0 24 24`

### Description

This fixes a bug in the CI/CD workflow as it relates to publishing GitHub releases. It turns out that currently releases are created without a proper body, and GitHub just shows the commit message of the corresponding commit. This is fine-ish in the UI, but it doesn't look great and it doesn't work if the release is emailed to someone (ref. #5767).

This Pull Request fixes the bug based on the solution provided in [this thread](https://github.community/t/set-output-truncates-multiline-strings/16852). Namely, the bug is due to the following line:

https://github.com/simple-icons/simple-icons/blob/a95ad430a3b5f2902393fbac67c63f3c81c8d8de/.github/workflows/publish.yml#L81

where `$RELEASE_BODY` is a mutli-line string. As it is a multi-line string, this command may look something like the following (taken from #6035):

```
echo "::set-output name=body::

# New Icons

- Adidas (#5917)
- AEW (#5971)
- App Annie (#5353)
- Cytoscape.js (#5968)
- ExpressVPN (#6001)
- Frontend Mentor (#5746)
- Jordan (#5920)
- KFC (#6025)
- Konva (#5797)
- Nette (#5821)
- Nike (#5916)
- NordVPN (#5908)
- Protractor (#5999)
- Puma (#5919)
- PyScaffold (#5866)
- React Table (#5979)
- Reebok (#5921)
- Sequelize (#4539)
- Spond (#5995)
- Starbucks (#5910)
"
```

which evaluates to:

```
::set-output name=body::''
[...]
```

hence, an empty body.

The fix is to escape newlines (`\n` and `\r`), as per lines 82 and 83. Line 81 just ensures the release body will be fine if there's ever a `%` in the release body.

I verified the behaviour in a private repository using the following GitHub Actions workflow and an appropriate commit message:

```yaml
name: test github release action
on: push

jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v2
      - name: Get commit message (for release title and body)
        id: commit
        uses: kceb/git-message-action@v1
      - name: Get release title and body
        id: release
        run: |
          RELEASE_TITLE=$(echo "${{ steps.commit.outputs.git-message }}" | head -n 1)
          echo ::set-output name=title::$RELEASE_TITLE
          RELEASE_BODY=$(echo "${{ steps.commit.outputs.git-message }}" | tail -n $(expr $(echo "${{ steps.commit.outputs.git-message }}" | wc -l) - 1))
          RELEASE_BODY="${RELEASE_BODY//'%'/'%25'}"
          RELEASE_BODY="${RELEASE_BODY//$'\n'/'%0A'}"
          RELEASE_BODY="${RELEASE_BODY//$'\r'/'%0D'}"
          echo ::set-output name=body::$RELEASE_BODY
      - name: Release
        uses: actions/create-release@v1
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        with:
          tag_name: v3.1.4
          release_name: ${{ steps.release.outputs.title }}
          body: ${{ steps.release.outputs.body }}
```