### PR TITLE
Add `Douban`, `Douban Read` license

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2434,13 +2434,19 @@
             "title": "Douban",
             "hex": "007722",
             "source": "https://zh.wikipedia.org/wiki/Douban",
-            "guidelines": "https://www.douban.com/about/legal#info_data"
+            "license": {
+                "type": "custom",
+                "url": "https://www.douban.com/about/legal#info_data"
+            }
         },
         {
             "title": "Douban Read",
             "hex": "389EAC",
             "source": "https://read.douban.com",
-            "guidelines": "https://www.douban.com/about/legal#info_data"
+            "license": {
+                "type": "custom",
+                "url": "https://www.douban.com/about/legal#info_data"
+            }
         },
         {
             "title": "Draugiem.lv",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -2433,12 +2433,14 @@
         {
             "title": "Douban",
             "hex": "007722",
-            "source": "https://zh.wikipedia.org/wiki/Douban"
+            "source": "https://zh.wikipedia.org/wiki/Douban",
+            "guidelines": "https://www.douban.com/about/legal#info_data"
         },
         {
             "title": "Douban Read",
             "hex": "389EAC",
-            "source": "https://read.douban.com"
+            "source": "https://read.douban.com",
+            "guidelines": "https://www.douban.com/about/legal#info_data"
         },
         {
             "title": "Draugiem.lv",


### PR DESCRIPTION
### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`

### Description

Add `license` field according to https://github.com/simple-icons/simple-icons/pull/6084#pullrequestreview-708965455.

I also added the license for the Douban icon.
