### PR TITLE
Adding Packer by HashiCorp

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -6529,7 +6529,7 @@
         },
         {
             "title": "Packer",
-            "hex": "02a8ef",
+            "hex": "02A8EF",
             "source": "https://packer.io",
             "guidelines": "https://www.hashicorp.com/brand"
         },

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -6528,6 +6528,12 @@
             }
         },
         {
+            "title": "Packer",
+            "hex": "02a8ef",
+            "source": "https://packer.io",
+            "guidelines": "https://www.hashicorp.com/brand"
+        },
+        {
             "title": "Paddy Power",
             "hex": "004833",
             "source": "https://www.paddypower.com/"

--- a/icons/packer.svg
+++ b/icons/packer.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Packer</title><path d="M4.2 21.8l8.2 2.2V5.9L4.2 3.7v18.1zM17.8 2.5L8.4 0v3.3l5.4 1.4v12.6l3.9 1.1c1.3.4 2.4-.6 2.4-2.2V6.1c.1-1.7-1-3.2-2.3-3.6"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Packer</title><path d="M4 21.8l8.2 2.2V5.9L4 3.7v18.1zM17.6 2.5L8.2 0v3.3l5.4 1.4v12.6l3.9 1.1c1.3.4 2.4-.6 2.4-2.2V6.1c.1-1.7-1-3.2-2.3-3.6"/></svg>

--- a/icons/packer.svg
+++ b/icons/packer.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Packer</title><path d="M4.2 21.8l8.2 2.2V5.9L4.2 3.7v18.1zM17.8 2.5L8.4 0v3.3l5.4 1.4v12.6l3.9 1.1c1.3.4 2.4-.6 2.4-2.2V6.1c.1-1.7-1-3.2-2.3-3.6"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/SI-Sandbox/preview/
-->

**Issue:** https://github.com/simple-icons/simple-icons/issues/6111-
**Alexa rank:** #381861
  <!-- The Alexa rank can be retrieved at https://www.alexa.com/siteinfo/
       Please see our contributing guidelines for more details on how we
       assess a brand's popularity. -->

### Checklist
  - [X] I updated the JSON data in `_data/simple-icons.json`
  - [X] I optimized the icon with SVGO or SVGOMG
  - [X] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->

The hex value is based on the SVG from https://www.hashicorp.com/brand for Packer.
