### PR TITLE
Update Kotlin hex color and guideline

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -4945,7 +4945,7 @@
         },
         {
             "title": "Kotlin",
-            "hex": "0095D5",
+            "hex": "7F52FF",
             "source": "https://resources.jetbrains.com/storage/products/kotlin/docs/kotlin_logos.zip",
             "guidelines": "https://www.jetbrains.com/company/brand/"
         },

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -4947,7 +4947,7 @@
             "title": "Kotlin",
             "hex": "7F52FF",
             "source": "https://resources.jetbrains.com/storage/products/kotlin/docs/kotlin_logos.zip",
-            "guidelines": "https://www.jetbrains.com/company/brand/"
+            "guidelines": "https://blog.jetbrains.com/kotlin/2021/07/adding-volume-to-the-kotlin-identity/"
         },
         {
             "title": "Krita",


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/SI-Sandbox/preview/
-->
![kotlin](https://user-images.githubusercontent.com/26060382/128807962-118f8740-91c3-48ff-9cad-22f42e063bcc.png)

**Issue: #6235**

### Description
I pick this hex value according to `Kotlin One Color Logo Mark RGB` file included in the source.
The new guideline is from their [blog post](https://blog.jetbrains.com/kotlin/2021/07/adding-volume-to-the-kotlin-identity/).

### Additional Context
I can not update the logo therefore i just can help with hex color and guideline url.