### PR TITLE
Added "-D" for dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ for (const iconSlug in simpleIcons) {
 There are also TypeScript type definitions for the Node package. To use them, simply run:
 
 ```shell
-npm install -D @types/simple-icons
+npm install --save-dev @types/simple-icons
 ```
 
 ### PHP Usage

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ for (const iconSlug in simpleIcons) {
 There are also TypeScript type definitions for the Node package. To use them, simply run:
 
 ```shell
-npm install @types/simple-icons
+npm install -D @types/simple-icons
 ```
 
 ### PHP Usage


### PR DESCRIPTION
Simple change in docs to mark type definitions as dev dependency as they should not be installed as a dependency