### PR TITLE
Disable Renovate dependency dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,9 @@
     "group:all",
   ],
 
+  // Disable dependency dashboard
+  dependencyDashboard: false,
+
   // Use our labelling system
   labels: ["dependencies"],
 


### PR DESCRIPTION
Disable the new [Renovate's Dependency Dashboard feature](https://docs.renovatebot.com/key-concepts/dashboard/).

**Issue:** #6440 (will be closed automatically by Renovate bot)
