### PR TITLE
Update TypeScript metadata with official url and add guidelines

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -9600,7 +9600,8 @@
         {
             "title": "TypeScript",
             "hex": "3178C6",
-            "source": "https://www.staging-typescript.org/branding"
+            "source": "https://www.typescriptlang.org/branding",
+            "guidelines": "https://www.typescriptlang.org/branding"
         },
         {
             "title": "TYPO3",


### PR DESCRIPTION
### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`

### Description
Previous URL was for the staging website (https://www.staging-typescript.org/), new URL is the production website (https://www.typescriptlang.org/).
