### PR TITLE
Unpin kceb/git-message-action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get commit message (for release title and body)
         id: commit
-        uses: kceb/git-message-action@v1.2.0
+        uses: kceb/git-message-action@v1
       - name: Get release version
         id: get-version
         run: |


### PR DESCRIPTION
Following up on #6424, this unpins the [kceb/git-message-action](https://github.com/kceb/git-message-action) action used in the [publish workflow](https://github.com/simple-icons/simple-icons/blob/af3df419a2ae0455f5d026f22238db17de77d1a2/.github/workflows/publish.yml#L74) again now that [the version tags have been updated](https://github.com/kceb/git-message-action/issues/9).