### PR TITLE
Added curl call to auto-release.yml to be created in simple-icons-pdf

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           curl -X POST \
             -H "Authorization: Bearer ${{ secrets.REMOTE_DISPATCH_TOKEN }}" \
-            -d '{"ref":"develop"}' \
+            -d '{"ref":"master"}' \
             https://api.github.com/repos/simple-icons/simple-icons-pdf/actions/workflows/auto-release.yml/dispatches
   website:
     name: Trigger simple-icons-website update

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,7 +103,7 @@ jobs:
             https://api.github.com/repos/simple-icons/simple-icons-font/actions/workflows/auto-release.yml/dispatches
   pdf:
     name: Trigger simple-icons-pdf release
-    needs: npm
+    needs: sanity-check
     runs-on: ubuntu-latest
     steps:
       - name: Trigger simple-icons-pdf release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,6 +101,17 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.REMOTE_DISPATCH_TOKEN }}" \
             -d '{"ref":"develop"}' \
             https://api.github.com/repos/simple-icons/simple-icons-font/actions/workflows/auto-release.yml/dispatches
+  pdf:
+    name: Trigger simple-icons-pdf release
+    needs: npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger simple-icons-pdf release
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.REMOTE_DISPATCH_TOKEN }}" \
+            -d '{"ref":"develop"}' \
+            https://api.github.com/repos/simple-icons/simple-icons-pdf/actions/workflows/auto-release.yml/dispatches
   website:
     name: Trigger simple-icons-website update
     needs: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,7 +114,7 @@ jobs:
             https://api.github.com/repos/simple-icons/simple-icons-pdf/actions/workflows/auto-release.yml/dispatches
   website:
     name: Trigger simple-icons-website update
-    needs: npm
+    needs: [npm, pdf]
     runs-on: ubuntu-latest
     steps:
       - name: Trigger simple-icons-website update


### PR DESCRIPTION
Partial solution for the automatic release of the PDF repo.
This has been mentioned in several issues in several repos.
**Issues:**: 
#5804 

This depends on https://github.com/simple-icons/simple-icons-pdf/pull/2