### PR TITLE
Get labels at runtime in `assign-to-project` workflow

### DIFF
--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -18,16 +18,22 @@ jobs:
     env:
       MY_GITHUB_TOKEN: ${{ secrets.AUTO_ASSIGN_WORKFLOW_TOKEN }}
     steps:
+    - id: get-labels
+      name: Get labels
+      run: |
+        labels="$(curl --retry 5 -s https://api.github.com/repos/simple-icons/simple-icons/pulls/${{ github.event.pull_request.number }} | jq '.labels[].name' | tr '\n' ',' | sed 's/"//g' | sed 's/,$//')"
+        echo "::set-output name=labels::$labels"
+
     - name: Assign pull requests to "Unprioritised"
       uses: srggrs/assign-one-project-github-action@1.2.1
-      if: contains(github.event.pull_request.labels.*.name, 'icon outdated') == false
+      if: contains(steps.get-labels.outputs.labels, 'icon outdated') == false
       with:
         project: https://github.com/orgs/simple-icons/projects/2
         column_name: Unprioritised
 
     - name: Assign `icon outdated` pull requests to "Priority 1"
       uses: srggrs/assign-one-project-github-action@1.2.1
-      if: contains(github.event.pull_request.labels.*.name, 'icon outdated')
+      if: contains(steps.get-labels.outputs.labels, 'icon outdated')
       with:
         project: https://github.com/orgs/simple-icons/projects/2
         column_name: Priority 1


### PR DESCRIPTION
The labels in `github.event.pull_request.labels.*.name` are defined at PR open time, so the `contains(github.event.pull_request.labels.*.name, 'icon outdated') == false` conditional is always executed, even if the previous step has added a new `icon outdated` label.

This pull introduces a step to get the updated labels from the PR with cURL, using them in conditionals. [See it working here](https://github.com/mondeja/simple-icons/pull/9/checks?check_run_id=3723663912#step:3:10).