### PR TITLE
Auto assign pull requests to 'Priority 2' column

### DIFF
--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -33,7 +33,9 @@ jobs:
 
       - id: get-linked-issues
         name: Get linked issue numbers
-        uses: mondeja/pr-linked-issues-action@v1
+        uses: mondeja/pr-linked-issues-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - id: priority-1
         name: Assign `icon outdated` pull requests to "Priority 1"

--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -18,22 +18,49 @@ jobs:
     env:
       MY_GITHUB_TOKEN: ${{ secrets.AUTO_ASSIGN_WORKFLOW_TOKEN }}
     steps:
-    - id: get-labels
-      name: Get labels
-      run: |
-        labels="$(curl --retry 5 -s https://api.github.com/repos/simple-icons/simple-icons/pulls/${{ github.event.pull_request.number }} | jq '.labels[].name' | tr '\n' ',' | sed 's/"//g' | sed 's/,$//')"
-        echo "::set-output name=labels::$labels"
+    steps:
+      - id: get-labels
+        name: Get labels
+        run: |
+          labels="$(curl --retry 5 -s https://api.github.com/repos/simple-icons/simple-icons/pulls/${{ github.event.pull_request.number }} | jq '.labels[].name' | tr '\n' ',' | sed -e 's/"//g' -e 's/,$//')"
+          echo "::set-output name=labels::$labels"
 
-    - name: Assign pull requests to "Unprioritised"
-      uses: srggrs/assign-one-project-github-action@1.2.1
-      if: contains(steps.get-labels.outputs.labels, 'icon outdated') == false
-      with:
-        project: https://github.com/orgs/simple-icons/projects/2
-        column_name: Unprioritised
+      - id: get-si-members
+        name: Get simple-icons members
+        run: |
+          members="$(curl --retry 5 -s https://api.github.com/orgs/simple-icons/members | jq .[].login | tr '\n' ',' | sed -e 's/"//g' -e 's/,$//')"
+          echo "::set-output name=members::$members"
 
-    - name: Assign `icon outdated` pull requests to "Priority 1"
-      uses: srggrs/assign-one-project-github-action@1.2.1
-      if: contains(steps.get-labels.outputs.labels, 'icon outdated')
-      with:
-        project: https://github.com/orgs/simple-icons/projects/2
-        column_name: Priority 1
+      - id: get-linked-issues
+        name: Get linked issue numbers
+        uses: mondeja/pr-linked-issues-action@v1
+
+      - id: priority-1
+        name: Assign `icon outdated` pull requests to "Priority 1"
+        uses: srggrs/assign-one-project-github-action@1.2.1
+        if: contains(steps.get-labels.outputs.labels, 'icon outdated')
+        with:
+          project: https://github.com/orgs/simple-icons/projects/2
+          column_name: Priority 1
+
+      - id: priority-2
+        name: Assign `new icon` pull requests to "Priority 2"
+        uses: srggrs/assign-one-project-github-action@1.2.1
+        # the PR has the `new icon` label along with a linked issue and
+        # the opener is not a member of simple-icons organization
+        if: |
+          contains(steps.get-labels.outputs.labels, 'new icon') &&
+          join(steps.get-linked-issues.outputs.issues) != '' &&
+          contains(steps.get-si-members.outputs.members, github.event.actor.login) == false
+        with:
+          project: https://github.com/orgs/simple-icons/projects/2
+          column_name: Priority 2
+
+      - name: Assign pull requests to "Unprioritised"
+        uses: srggrs/assign-one-project-github-action@1.2.1
+        if: |
+          steps.priority-1.conclusion == 'skipped' &&
+          steps.priority-2.conclusion == 'skipped'
+        with:
+          project: https://github.com/orgs/simple-icons/projects/2
+          column_name: Unprioritised


### PR DESCRIPTION
This is the next step for automatic priorization of pull requests. Implements the Priority 2 [group of rules for priorization](https://github.com/orgs/simple-icons/teams/maintainers/discussions/9) (si maintainers link only):

> ## Priority 2
>
> This is for all "[new icon](https://github.com/simple-icons/simple-icons/pulls?q=is%3Aopen+is%3Apr+label%3A%22new+icon%22)" PRs submitted by outside contributors that fulfil a request. If a new member joins the team then any PRs they submitted prior to accepting the invitation should remain at this priority and not be re-priortised.

The implementation follows that. The `if` conditional for `Priority 2` means "if the pull request has a 'new icon' label, has a linked issue and the user which has opened the pull request is not a member of simple-icons organization":

```
contains(steps.get-labels.outputs.labels, 'new icon') &&
join(steps.get-linked-issues.outputs.issues) != '' &&
contains(steps.get-si-members.outputs.members, github.event.actor.login) == false
```

The "Unprioritised" conditional has been changed by "if priority conditionals has not been executed", so it works like an else for previous rules (see `conclusion` in [`steps` context](https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context)):

```
steps.priority-1.conclusion == 'skipped' &&
steps.priority-2.conclusion == 'skipped'
```

To get the linked issues for pull requests I'm using [mondeja/pr-linked-issues-action](https://github.com/mondeja/pr-linked-issues-action). ~~This action works parsing the HTML of the pull request page because I've not found a way to get them using Github APIs. I'm testing this every month in [a CI workflow](https://github.com/mondeja/pr-linked-issues-action/blob/fa2264e6d9e447315ab5ef608e754fd3817971a5/.github/workflows/ci.yml) without mocking, so I think it will not be difficult to debug if an error starts to occur.~~

I've tested it in [mondeja/simple-icons#10](https://github.com/mondeja/simple-icons/pull/10) all the 3 possible strategies and works as expected. 