### PR TITLE
Improve release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,5 +1,7 @@
 name: Create Release Pull Request
 on:
+  # THIS WORKFLOW SHOULD NEVER BE TRIGGERED ON A PUSH EVENT. IF TRIGGERED ON A
+  # PUSH EVENT IT MAY CREATE AN ENDLESS STREAM OF 'version bump' COMMITS.
   workflow_dispatch:
   schedule:
     # "At 00:00 on Sunday" (https://crontab.guru/once-a-week)

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          # Ensure the commit can be pushed regardless of branch protections (must belong to an admin of this repo)
+          token: ${{ secrets.RELEASE_TOKEN }}
           # Ensure we are checked out on the develop branch
           ref: develop
       - name: Bump version


### PR DESCRIPTION
Following [the documentation for `stefanzweifel/git-auto-commit-action`](https://github.com/stefanzweifel/git-auto-commit-action#push-to-protected-branches) (the action we use to create the `version bump` commits), this updates the [`create-release.yml`](https://github.com/simple-icons/simple-icons/blob/eceb37ae967424008cf8e2692583543cb0131461/.github/workflows/create-release.yml) such that it can run without having to disable branch protections for `develop`.

The trick is to use a Personal Access Token (PAT) of an admin, and to allow admins to push regardless of branch protections. I.e., the following setting must be disabled for `develop`:

![image](https://user-images.githubusercontent.com/3742559/135750382-fe7dc676-2f46-42b7-93db-e6469757e2c6.png)

I re-used [the PAT used to merge the release](https://github.com/simple-icons/simple-icons/blob/eceb37ae967424008cf8e2692583543cb0131461/.github/workflows/merge-release.yml#L13).

---

The documentation linked above also mentions that you can use `--force` pushes. However, the first problem is that this requires allowing force pushes which I would argue is less secure than allowing admins to push regardless of CI checks; the second problem is that it did not appear to work for me, and some discussion over at `stefanzweifel/git-auto-commit-action` suggests I'm not alone in that.