### PR TITLE
Add Drawio simple-icons library to Third-Party Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ echo file_get_contents('path/to/package/icons/simpleicons.svg');
 
 | Extension | Author |
 | :--- | :--- |
+| [Drawio library](https://github.com/mondeja/simple-icons-drawio) | [@mondeja](https://github.com/mondeja) |
 | [Drupal module](https://www.drupal.org/project/simple_icons) | [Phil Wolstenholme](https://www.drupal.org/u/phil-wolstenholme) |
 | [Flutter package](https://pub.dev/packages/simple_icons) | [@jlnrrg](https://jlnrrg.github.io/) |
 | [Hexo plugin](https://github.com/nidbCN/hexo-simpleIcons) | [@nidbCN](https://github.com/nidbCN/) |


### PR DESCRIPTION
See [simple-icons-drawio](https://github.com/mondeja/simple-icons-drawio).