### PR TITLE
wrap yes and no in quotes in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -41,7 +41,7 @@ body:
         This is an open source project and we welcome contributions. Do you want to
         work on this issue?
       options:
-        - Yes
-        - No
+        - 'Yes'
+        - 'No'
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/icon_request.yml
+++ b/.github/ISSUE_TEMPLATE/icon_request.yml
@@ -83,7 +83,7 @@ body:
         This is an open source project and we welcome contributions. Do you want to
         add this icon?
       options:
-        - Yes
-        - No
+        - 'Yes'
+        - 'No'
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/icon_update.yml
+++ b/.github/ISSUE_TEMPLATE/icon_update.yml
@@ -50,7 +50,7 @@ body:
         This is an open source project and we welcome contributions. Do you want to
         update this icon?
       options:
-        - Yes
-        - No
+        - 'Yes'
+        - 'No'
     validations:
       required: true


### PR DESCRIPTION
Not sure how but the quotes in issue templates were removed. YAML interprets `Yes` and `No` as boolean values, so the quotes are necessary for them to be treated as strings.