### PR TITLE
Add Blender simple-icons add-on to Third-Party Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ echo file_get_contents('path/to/package/icons/simpleicons.svg');
 
 | Extension | Author |
 | :--- | :--- |
+| [Blender add-on](https://github.com/mondeja/simple-icons-blender) | [@mondeja](https://github.com/mondeja) |
 | [Drawio library](https://github.com/mondeja/simple-icons-drawio) | [@mondeja](https://github.com/mondeja) |
 | [Drupal module](https://www.drupal.org/project/simple_icons) | [Phil Wolstenholme](https://www.drupal.org/u/phil-wolstenholme) |
 | [Flutter package](https://pub.dev/packages/simple_icons) | [@jlnrrg](https://jlnrrg.github.io/) |


### PR DESCRIPTION
See [simple-icons-blender](https://github.com/mondeja/simple-icons-blender)