### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,10 @@ jobs:
             ${{ runner.os }}-node-
       - name: Install dependencies
         run: npm i
-      - name: Build NodeJS package
-        run: npm run build
       - name: Run linters
         run: npm run lint
+      - name: Build NodeJS package
+        run: npm run build
       - name: Run tests
         run: npm run test
   npm:

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,11 @@ _data/simple-icons.json
 
 # JavaScript templates are invalid JavaScript so cannot be formatted.
 scripts/build/templates/*.js
+
+# Generated JavaScript files don't need to be formatted
+icons/*.js
+icons/*.d.ts
+icons.d.ts
+icons.js
+icons.mjs
+index.js


### PR DESCRIPTION
The release on 2021-10-31 [failed due to Prettier complaining that generated files are not properly formatted](https://github.com/simple-icons/simple-icons/runs/4059502095?check_suite_focus=true#step:7:4167) (*). This fixes that in two ways:
1. It updates the publish workflow's `sanity-check` job such that it lints the code before it builds the package. This is to ensure that problems like this don't happen again in the future.
2. It updates `.prettierignore` to ignore the files generated by `npm run build` to prevent these warning from accidentally showing up.

---

(*): I opted to manually release [v5.21.0](https://github.com/simple-icons/simple-icons/releases/tag/5.21.0) ([npm](https://www.npmjs.com/package/simple-icons/v/5.21.0), [packagist](https://packagist.org/packages/simple-icons/simple-icons#5.21.0), [font](https://github.com/simple-icons/simple-icons-font/releases/tag/5.21.0)).