### PR TITLE
Add prepare script to initialize husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "jsonlint": "node scripts/lint/jsonlint.js",
     "svglint": "svglint icons/*.svg --ci",
     "wslint": "editorconfig-checker -exclude \\.svg$",
+    "prepare": "is-ci || husky install",
     "prepublishOnly": "npm run build",
     "postpublish": "npm run clean",
     "test": "jest",


### PR DESCRIPTION
I removed the `postinstall` script intializing husky in cc9ee3f853064a69adfa10382d05fede2b1e6901 to [hotpatch](https://github.com/simple-icons/simple-icons/pull/6804) the broken [v5.21.0](https://github.com/simple-icons/simple-icons/releases/tag/5.21.0) release. This Pull Request adds back husky initialization through the `prepare` script, following [the lead of the `simple-icons-font`](https://github.com/simple-icons/simple-icons-font/blob/494bed695412a279d2ceec0aff15959fff69f629/package.json#L29).