### PR TITLE
Add Meta icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -5833,6 +5833,11 @@
             "guidelines": "https://en.facebookbrand.com/facebookapp/assets/messenger/"
         },
         {
+            "title": "Meta",
+            "hex": "0064E0",
+            "source": "https://www.meta.com/"
+        },
+        {
             "title": "Metabase",
             "hex": "509EE3",
             "source": "https://www.metabase.com/"


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/SI-Sandbox/preview/
-->
![meta](https://user-images.githubusercontent.com/39214723/139912737-c311f484-7a2c-494b-a246-69aea0f41b7e.png)

**Issue:** Closes #6791
**Alexa rank:** [7](https://www.alexa.com/siteinfo/facebook.com)
  <!-- The Alexa rank can be retrieved at https://www.alexa.com/siteinfo/
       Please see our contributing guidelines for more details on how we
       assess a brand's popularity. -->

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description

Meta is Facebook Company's new brand name. Alexa rank is from Facebook, because meta.com url is redirecting to about.facebook.com.
Meta logo is most with #0064E0 hex color.

<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->