### PR TITLE
Avoid CRLF in SVG

### DIFF
--- a/.svglintrc.js
+++ b/.svglintrc.js
@@ -8,7 +8,7 @@ const svgPathBbox = require('svg-path-bbox');
 const parsePath = require('svg-path-segments');
 
 const svgRegexp =
-  /^<svg( [^\s]*=".*"){3}><title>.*<\/title><path d=".*"\/><\/svg>\r?\n?$/;
+  /^<svg( [^\s]*=".*"){3}><title>.*<\/title><path d=".*"\/><\/svg>\n?$/;
 const negativeZerosRegexp = /-0(?=[^\.]|[\s\d\w]|$)/g;
 
 const iconSize = 24;

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "jslint": "prettier --check .",
     "jsonlint": "node scripts/lint/jsonlint.js",
     "svglint": "svglint icons/*.svg --ci",
-    "wslint": "editorconfig-checker -exclude \\.svg$",
+    "wslint": "editorconfig-checker",
     "prepare": "is-ci || husky install",
     "prepublishOnly": "npm run build",
     "postpublish": "npm run clean",


### PR DESCRIPTION
**Issue:** Fix #6869 

### Description

FYI: https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreeol

We should always use LF instead of CRLF in our code. Otherwise some developers will get a unstaged change when they pull the latest code.

<img width="507" alt="image" src="https://user-images.githubusercontent.com/8186898/142682193-9b487d8d-d9d7-48af-a359-44417050b268.png">

### Changes

- ~~Added `end_of_line = lf` in our `.editorconfig`.~~
- ~~Changed our `wslint` to `editorconfig-checker -ignore-defaults` for linting SVG files.~~
- ~~Add `eol=lf` to `.gitattributes` to make sure developers are using the correct configuration with Git~~
- Updated regex pattern for `svglint`
- Removed unnecessary args from `wslint`

cc @ericcornelissen 