### PR TITLE
add jsdoc preview images

### DIFF
--- a/scripts/build/package.js
+++ b/scripts/build/package.js
@@ -100,24 +100,26 @@ data.icons.forEach((icon) => {
   writeJs(jsFilepath, `module.exports=${iconObject};`);
 
   const dtsFilepath = path.resolve(iconsDir, `${filename}.d.ts`);
+
+  writeTs(
+    dtsFilepath,
+    'declare const i:import("../alias").I;export default i;',
+  );
+
+  // jsdoc preview image (encoded in base64)
   const base64IconPath = Buffer.from(
     `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="50" height="50"><path d="${icon.path}" /></svg>`,
   ).toString('base64');
-  // console.log(
-  //   `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="${icon.path}" /></svg>`,
-  // );
 
   const previewImage = `![${icon.title}](data:image/svg+xml;base64,${base64IconPath})`;
-  writeTs(
-    dtsFilepath,
-    `/**${previewImage}*/declare const i:import("../alias").I;export default i;`,
-  );
 
   // add object to the barrel file
   const iconExportName = slugToVariableName(icon.slug);
   iconsBarrelJs.push(`${iconExportName}:${iconObject},`);
   iconsBarrelMjs.push(`export const ${iconExportName}=${iconObject}`);
-  iconsBarrelDts.push(`export const ${iconExportName}:I;`);
+  iconsBarrelDts.push(
+    `\n/**${previewImage}*/\nexport const ${iconExportName}:I;`,
+  );
 });
 
 // write our generic index.js

--- a/scripts/build/package.js
+++ b/scripts/build/package.js
@@ -110,8 +110,7 @@ data.icons.forEach((icon) => {
   const previewImage = `![${icon.title}](data:image/svg+xml;base64,${base64IconPath})`;
   writeTs(
     dtsFilepath,
-    `/**${previewImage}*/
-declare const i:import("../alias").I;export default i;`,
+    `/**${previewImage}*/declare const i:import("../alias").I;export default i;`,
   );
 
   // add object to the barrel file

--- a/scripts/build/package.js
+++ b/scripts/build/package.js
@@ -100,9 +100,20 @@ data.icons.forEach((icon) => {
   writeJs(jsFilepath, `module.exports=${iconObject};`);
 
   const dtsFilepath = path.resolve(iconsDir, `${filename}.d.ts`);
+  const base64IconPath = Buffer.from(
+    `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="50" height="50"><path d="${icon.path}" /></svg>`,
+  ).toString('base64');
+  // console.log(
+  //   `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="${icon.path}" /></svg>`,
+  // );
+
+  const previewImage = `![${icon.title}](data:image/svg+xml;base64,${base64IconPath})`;
   writeTs(
     dtsFilepath,
-    'declare const i:import("../alias").I;export default i;',
+    `/**
+* ${previewImage}
+*/
+declare const i:import("../alias").I;export default i;`,
   );
 
   // add object to the barrel file

--- a/scripts/build/package.js
+++ b/scripts/build/package.js
@@ -110,9 +110,7 @@ data.icons.forEach((icon) => {
   const previewImage = `![${icon.title}](data:image/svg+xml;base64,${base64IconPath})`;
   writeTs(
     dtsFilepath,
-    `/**
-* ${previewImage}
-*/
+    `/**${previewImage}*/
 declare const i:import("../alias").I;export default i;`,
   );
 


### PR DESCRIPTION
This idea was inspired from tailwindlabs/heroicons#286.

It converts the SVG to base64 so jsdoc renders it. I did have to do undo some minification so TS could read the jsdoc comments.

I am marking this as "in discussion" because the package size increased from 18.6 MB to 23.0 MB, so I'm not sure if this change is worth it. Here are a few nice previews that this makes possible though:
![image](https://user-images.githubusercontent.com/58836760/142990792-844c1190-bf93-48c9-ad4d-22aee36a6c69.png)
![image](https://user-images.githubusercontent.com/58836760/142991180-2c5d32b5-7e0c-46b0-a5cb-835ea83c4be3.png)
![image](https://user-images.githubusercontent.com/58836760/142991252-9dfe2c46-99af-4f79-81dd-376d85102061.png)

