### PR TITLE
Bump `named-html-entities-json` to stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jest": "27.2.5",
     "jest-diff": "27.2.5",
     "jsonschema": "1.4.0",
-    "named-html-entities-json": "0.1.0",
+    "named-html-entities-json": "1.0.0",
     "npm-run-all": "4.1.5",
     "prettier": "2.4.1",
     "rimraf": "3.0.2",


### PR DESCRIPTION
Just bumped the version number. The [new release](https://github.com/mondeja/named-html-entities-json/releases/tag/v1.0.0) hasn't new changes.