### PR TITLE
Upgrade SVGLint dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -370,7 +370,7 @@ If you have an affiliation to the brand you contributing that allows you to spea
 
 ## Testing Package Locally
 
-* Make sure you have [NodeJS](https://nodejs.org/en/download/) installed. At least version 12.20.0 is required.
+* Make sure you have [Node.js](https://nodejs.org/en/download/) installed. At least version `^12.20.0 || ^14.13.1 || >=16.0.0` is required.
 * Install the dependencies using `$ npm install`.
 * Build and test the package using `$ npm test`.
 * Run the project linting process using `$ npm run lint`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -370,7 +370,7 @@ If you have an affiliation to the brand you contributing that allows you to spea
 
 ## Testing Package Locally
 
-* Make sure you have [NodeJS](https://nodejs.org/en/download/) installed. At least version 12.4.0 is required.
+* Make sure you have [NodeJS](https://nodejs.org/en/download/) installed. At least version 12.20.0 is required.
 * Install the dependencies using `$ npm install`.
 * Build and test the package using `$ npm test`.
 * Run the project linting process using `$ npm run lint`.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "rimraf": "3.0.2",
     "svg-path-bbox": "1.0.1",
     "svg-path-segments": "1.0.0",
-    "svglint": "1.3.0",
+    "svglint": "2.0.0",
     "svgo": "2.8.0",
     "svgpath": "2.3.1",
     "uvu": "0.5.2"


### PR DESCRIPTION
### Description

Opening this PR to upgrade the [SVGLint](https://github.com/birjolaxew/svglint) dependency to `v2.0.0`, the major version bump requires a higher minimum NodeJS version for development than is currently mentioned in this project's Contributing Guidelines.
