### PR TITLE
Remove TransferWise

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -10169,11 +10169,6 @@
             "source": "https://trakt.tv"
         },
         {
-            "title": "TransferWise",
-            "hex": "00B9FF",
-            "source": "https://brand.transferwise.com/logo"
-        },
-        {
             "title": "Transport for Ireland",
             "hex": "00B274",
             "source": "https://www.transportforireland.ie/"

--- a/icons/transferwise.svg
+++ b/icons/transferwise.svg
@@ -1,1 +1,0 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>TransferWise</title><path d="M9.871 24h3.11L23.127 0H3.694l3.748 6.291-6.571 6.283h11.361l1.068-2.517H7.03l3.792-3.783L8.61 2.516h10.337z"/></svg>


### PR DESCRIPTION
Further to @adsingh14's comments in #7003 - TransferWise has been renamed to 'Wise' (added in #7020). This PR serves to remove Transferwise when it comes to our next major release.