### PR TITLE
Fix README main image showing dark/light versions at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 <p align="center">
-<a href="https://simpleicons.org/">
-<img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/simpleicons.svg#gh-light-mode-only" alt="Simple Icons" width=70>
-<img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/assets/readme/simpleicons-white.svg#gh-dark-mode-only" alt="Simple Icons" width=70>
-</a>
+<img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/simpleicons.svg#gh-light-mode-only" alt="Simple Icons" width=70><img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/assets/readme/simpleicons-white.svg#gh-dark-mode-only" alt="Simple Icons" width=70>
 <h3 align="center">Simple Icons</h3>
 <p align="center">
 Over 2100 Free SVG icons for popular brands. See them all on one page at <a href="https://simpleicons.org">SimpleIcons.org</a>. Contributions, corrections & requests can be made on GitHub.</p>


### PR DESCRIPTION
The README is currently displaying two versions (light and dark) of main image. It seems that currently Github does not support dark/light image versions using HTML **if the image is inside a link**, so dropping the website link it is solved. The link is repeated in the description below, so no problem I guess.

### Before

![image](https://user-images.githubusercontent.com/23049315/149182896-e366bd75-804e-4966-9767-9423343c4266.png)

### After

![image](https://user-images.githubusercontent.com/23049315/149182949-247c99e1-ff83-40f0-84ba-7e2fbe9f065e.png)

