### PR TITLE
Decrease Typescript icon size in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ for (const iconSlug in simpleIcons) {
 }
 ```
 
-#### TypeScript Usage <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/typescript.svg#gh-light-mode-only" alt="Typescript" align=left width=24 height=24><img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/assets/readme/typescript-white.svg#gh-dark-mode-only" alt="Typescript" align=left width=24 height=24>
+#### TypeScript Usage <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/typescript.svg#gh-light-mode-only" alt="Typescript" align=left width=19 height=19><img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/assets/readme/typescript-white.svg#gh-dark-mode-only" alt="Typescript" align=left width=19 height=19>
 
 Type definitions are bundled with the package.
 


### PR DESCRIPTION
Typescript icon is placed inside an `h4` (`####` in Markdown) in the README while other sections with icons are using `h3` but the icons has the same size (24 now). It seems reasonable to me to reduce the size of the Typescript icon so that it is more in line with the dimensions of the section title.

### Before

![image](https://user-images.githubusercontent.com/23049315/149189527-1364b8d1-10b9-48da-9af6-3ea3d8ecded0.png)


### After

![image](https://user-images.githubusercontent.com/23049315/149189585-6ed7df53-1ba2-4751-a402-9990ee74d809.png)
