### PR TITLE
Add some badges to 'Contribute' section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@ Over 2100 Free SVG icons for popular brands. See them all on one page at <a href
 </p>
 
 <p align="center">
-<a href="https://github.com/simple-icons/simple-icons/actions?query=workflow%3AVerify+branch%3Adevelop"><img src="https://img.shields.io/github/workflow/status/simple-icons/simple-icons/Verify/develop?logo=github" alt="Build status"/></a>
+<a href="https://github.com/simple-icons/simple-icons/actions?query=workflow%3AVerify+branch%3Adevelop"><img src="https://img.shields.io/github/workflow/status/simple-icons/simple-icons/Verify/develop?logo=github&label=tests" alt="Build status"/></a>
 <a href="https://www.npmjs.com/package/simple-icons"><img src="https://img.shields.io/npm/v/simple-icons.svg?logo=npm" alt="NPM version"/></a>
 <a href="https://packagist.org/packages/simple-icons/simple-icons"><img src="https://img.shields.io/packagist/v/simple-icons/simple-icons?logo=packagist&logoColor=white" alt="Build status"/></a>
+</p>
+<p align="center">
+<a href="https://simpleicons.org"><img src="https://img.shields.io/badge/dynamic/json?color=informational&label=icons&prefix=%20&logo=simpleicons&query=%24.icons.length&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsimple-icons%2Fsimple-icons%2Fdevelop%2F_data%2Fsimple-icons.json" alt="Number of icons currently in the library"/></a>
+<a href="https://opencollective.com/simple-icons"><img src="https://img.shields.io/opencollective/all/simple-icons?logo=opencollective" alt="Backers and sponsors on Open Collective"/></a>
 </p>
 
 ## Usage
@@ -157,7 +161,7 @@ echo file_get_contents('path/to/package/icons/simpleicons.svg');
 
 ## Contribute
 
-[![Number of icons currently in the library](https://img.shields.io/badge/dynamic/json?color=informational&label=icons&prefix=%20&logo=simpleicons&query=%24.icons.length&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsimple-icons%2Fsimple-icons%2Fdevelop%2F_data%2Fsimple-icons.json)](https://simpleicons.org) [![Backers and sponsors on Open Collective](https://img.shields.io/opencollective/all/simple-icons?logo=opencollective)](https://opencollective.com/simple-icons) [![Good first issues open](https://img.shields.io/github/issues/simple-icons/simple-icons/good%20first%20issue?label=good%20first%20issues&logo=github)](https://github.com/simple-icons/simple-icons/labels/good%20first%20issue)
+[![Good first issues open](https://img.shields.io/github/issues/simple-icons/simple-icons/good%20first%20issue?label=good%20first%20issues&logo=git&logoColor=white)](https://github.com/simple-icons/simple-icons/labels/good%20first%20issue)
 
 Information describing how to contribute can be found here:
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ echo file_get_contents('path/to/package/icons/simpleicons.svg');
 
 ## Contribute
 
-[![Number of icons currently in the library](https://img.shields.io/badge/dynamic/json?color=success&label=icons&prefix=%20&logo=simpleicons&query=%24.icons.length&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsimple-icons%2Fsimple-icons%2Fdevelop%2F_data%2Fsimple-icons.json)](https://simpleicons.org) [![Backers and sponsors on Open Collective](https://img.shields.io/opencollective/all/simple-icons?logo=opencollective)](https://opencollective.com/simple-icons) [![Good first issues open](https://img.shields.io/github/issues/simple-icons/simple-icons/good%20first%20issue?label=good%20first%20issues&logo=github)](https://github.com/simple-icons/simple-icons/labels/good%20first%20issue)
+[![Number of icons currently in the library](https://img.shields.io/badge/dynamic/json?color=informational&label=icons&prefix=%20&logo=simpleicons&query=%24.icons.length&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsimple-icons%2Fsimple-icons%2Fdevelop%2F_data%2Fsimple-icons.json)](https://simpleicons.org) [![Backers and sponsors on Open Collective](https://img.shields.io/opencollective/all/simple-icons?logo=opencollective)](https://opencollective.com/simple-icons) [![Good first issues open](https://img.shields.io/github/issues/simple-icons/simple-icons/good%20first%20issue?label=good%20first%20issues&logo=github)](https://github.com/simple-icons/simple-icons/labels/good%20first%20issue)
 
 Information describing how to contribute can be found here:
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ echo file_get_contents('path/to/package/icons/simpleicons.svg');
 
 ## Contribute
 
+[![Number of icons currently in the library](https://img.shields.io/badge/dynamic/json?color=success&label=icons&prefix=%20&logo=simpleicons&query=%24.icons.length&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsimple-icons%2Fsimple-icons%2Fdevelop%2F_data%2Fsimple-icons.json)](https://simpleicons.org) [![Backers and sponsors](https://img.shields.io/opencollective/all/simple-icons?logo=opencollective)](https://opencollective.com/simple-icons)
+
 Information describing how to contribute can be found here:
 
 https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ echo file_get_contents('path/to/package/icons/simpleicons.svg');
 
 ## Contribute
 
-[![Number of icons currently in the library](https://img.shields.io/badge/dynamic/json?color=success&label=icons&prefix=%20&logo=simpleicons&query=%24.icons.length&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsimple-icons%2Fsimple-icons%2Fdevelop%2F_data%2Fsimple-icons.json)](https://simpleicons.org) [![Backers and sponsors on Open Collective](https://img.shields.io/opencollective/all/simple-icons?logo=opencollective)](https://opencollective.com/simple-icons)
+[![Number of icons currently in the library](https://img.shields.io/badge/dynamic/json?color=success&label=icons&prefix=%20&logo=simpleicons&query=%24.icons.length&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsimple-icons%2Fsimple-icons%2Fdevelop%2F_data%2Fsimple-icons.json)](https://simpleicons.org) [![Backers and sponsors on Open Collective](https://img.shields.io/opencollective/all/simple-icons?logo=opencollective)](https://opencollective.com/simple-icons) [![Good first issues open](https://img.shields.io/github/issues/simple-icons/simple-icons/good%20first%20issue?label=good%20first%20issues&logo=github)](https://github.com/simple-icons/simple-icons/labels/good%20first%20issue)
 
 Information describing how to contribute can be found here:
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ echo file_get_contents('path/to/package/icons/simpleicons.svg');
 
 ## Contribute
 
-[![Number of icons currently in the library](https://img.shields.io/badge/dynamic/json?color=success&label=icons&prefix=%20&logo=simpleicons&query=%24.icons.length&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsimple-icons%2Fsimple-icons%2Fdevelop%2F_data%2Fsimple-icons.json)](https://simpleicons.org) [![Backers and sponsors](https://img.shields.io/opencollective/all/simple-icons?logo=opencollective)](https://opencollective.com/simple-icons)
+[![Number of icons currently in the library](https://img.shields.io/badge/dynamic/json?color=success&label=icons&prefix=%20&logo=simpleicons&query=%24.icons.length&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsimple-icons%2Fsimple-icons%2Fdevelop%2F_data%2Fsimple-icons.json)](https://simpleicons.org) [![Backers and sponsors on Open Collective](https://img.shields.io/opencollective/all/simple-icons?logo=opencollective)](https://opencollective.com/simple-icons)
 
 Information describing how to contribute can be found here:
 


### PR DESCRIPTION
Adds a badge to "Contribute" section of the README and two to the header. You can see them [here](https://github.com/mondeja/simple-icons/tree/readme-contribute-badges#readme).

- Number of icons currently in the library.
- Number of backers and sponsors in Open Collective.
- Number of first good issues currently open in this repository.