### PR TITLE
switch from uvu to mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "prepare": "is-ci || husky install",
     "prepublishOnly": "npm run build",
     "postpublish": "npm run clean",
-    "test": "mocha tests --reporter min --inline-diffs",
+    "test": "mocha tests --reporter tests/min-reporter.cjs --inline-diffs",
     "pretest": "npm run prepublishOnly",
     "posttest": "npm run postpublish",
     "svgo": "svgo --config svgo.config.js",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "husky": "7.0.4",
     "is-ci": "3.0.1",
     "jsonschema": "1.4.0",
+    "mocha": "9.1.4",
     "named-html-entities-json": "1.0.0",
     "npm-run-all": "4.1.5",
     "prettier": "2.5.1",
@@ -45,8 +46,7 @@
     "svg-path-segments": "1.0.0",
     "svglint": "2.0.0",
     "svgo": "2.8.0",
-    "svgpath": "2.4.0",
-    "uvu": "0.5.2"
+    "svgpath": "2.4.0"
   },
   "scripts": {
     "build": "node scripts/build/package.js",
@@ -61,7 +61,7 @@
     "prepare": "is-ci || husky install",
     "prepublishOnly": "npm run build",
     "postpublish": "npm run clean",
-    "test": "uvu",
+    "test": "mocha tests --reporter min --inline-diffs",
     "pretest": "npm run prepublishOnly",
     "posttest": "npm run postpublish",
     "svgo": "svgo --config svgo.config.js",

--- a/tests/icons-cjs.test.js
+++ b/tests/icons-cjs.test.js
@@ -1,4 +1,3 @@
-import { exec } from 'uvu';
 import { testIcon } from './test-icon.js';
 import { getIconSlug, getIconsData } from '../scripts/utils.js';
 (async () => {
@@ -14,6 +13,4 @@ import { getIconSlug, getIconsData } from '../scripts/utils.js';
   });
 
   await Promise.all(tests);
-
-  exec();
 })();

--- a/tests/icons-esm.test.js
+++ b/tests/icons-esm.test.js
@@ -5,7 +5,7 @@ import {
 } from '../scripts/utils.js';
 import * as simpleIcons from '../icons.mjs';
 import { testIcon } from './test-icon.js';
-import { exec } from 'uvu';
+import { before } from 'mocha';
 
 (async () => {
   const icons = await getIconsData();
@@ -17,6 +17,4 @@ import { exec } from 'uvu';
 
     testIcon(icon, subject, slug);
   });
-
-  exec();
 })();

--- a/tests/icons-esm.test.js
+++ b/tests/icons-esm.test.js
@@ -5,7 +5,6 @@ import {
 } from '../scripts/utils.js';
 import * as simpleIcons from '../icons.mjs';
 import { testIcon } from './test-icon.js';
-import { before } from 'mocha';
 
 (async () => {
   const icons = await getIconsData();

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,7 +1,7 @@
 import simpleIcons from '../index.js';
 import { getIconSlug, getIconsData } from '../scripts/utils.js';
-import { test, exec } from 'uvu';
-import * as assert from 'uvu/assert';
+import { test } from 'mocha';
+import { strict as assert } from 'node:assert';
 
 (async () => {
   const icons = await getIconsData();
@@ -12,9 +12,9 @@ import * as assert from 'uvu/assert';
     test(`'Get' ${icon.title} by its slug`, () => {
       const found = simpleIcons.Get(slug);
       assert.ok(found);
-      assert.is(found.title, icon.title);
-      assert.is(found.hex, icon.hex);
-      assert.is(found.source, icon.source);
+      assert.equal(found.title, icon.title);
+      assert.equal(found.hex, icon.hex);
+      assert.equal(found.source, icon.source);
     });
   });
 
@@ -22,11 +22,7 @@ import * as assert from 'uvu/assert';
     const iconArray = Object.values(simpleIcons);
     for (let icon of iconArray) {
       assert.ok(icon);
-      assert.type(icon, 'object');
+      assert.equal(typeof icon, 'object');
     }
   });
-
-  test.run();
-
-  exec();
 })();

--- a/tests/min-reporter.cjs
+++ b/tests/min-reporter.cjs
@@ -1,0 +1,10 @@
+const { reporters } = require('mocha');
+
+class EvenMoreMin extends reporters.Base {
+  constructor(runner) {
+    super(runner);
+    runner.once('end', () => this.epilogue());
+  }
+}
+
+module.exports = EvenMoreMin;

--- a/tests/min-reporter.cjs
+++ b/tests/min-reporter.cjs
@@ -1,9 +1,11 @@
-const { reporters } = require('mocha');
+const { reporters, Runner } = require('mocha');
+
+const { EVENT_RUN_END } = Runner.constants;
 
 class EvenMoreMin extends reporters.Base {
   constructor(runner) {
     super(runner);
-    runner.once('end', () => this.epilogue());
+    runner.once(EVENT_RUN_END, () => this.epilogue());
   }
 }
 

--- a/tests/readme-icons.test.js
+++ b/tests/readme-icons.test.js
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { test } from 'uvu';
-import * as assert from 'uvu/assert';
+import { test } from 'mocha';
+import { strict as assert } from 'node:assert';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.dirname(__dirname);
@@ -39,6 +39,4 @@ for (let whiteIconFileName of whiteIconsFileNames) {
       blackIconContent.replace('<svg', '<svg fill="white"'),
     );
   });
-
-  test.run();
 }

--- a/tests/test-icon.js
+++ b/tests/test-icon.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { suite } from 'uvu';
-import * as assert from 'uvu/assert';
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'mocha';
 
 const iconsDir = path.resolve(process.cwd(), 'icons');
 
@@ -12,60 +12,59 @@ const iconsDir = path.resolve(process.cwd(), 'icons');
  * @param {String} slug Icon data slug
  */
 export const testIcon = (icon, subject, slug) => {
-  const test = suite(icon.title);
   const svgPath = path.resolve(iconsDir, `${slug}.svg`);
 
-  test('has the correct "title"', () => {
-    assert.is(subject.title, icon.title);
-  });
+  describe(icon.title, () => {
+    it('has the correct "title"', () => {
+      assert.equal(subject.title, icon.title);
+    });
 
-  test('has the correct "slug"', () => {
-    assert.is(subject.slug, slug);
-  });
+    it('has the correct "slug"', () => {
+      assert.equal(subject.slug, slug);
+    });
 
-  test('has the correct "hex" value', () => {
-    assert.is(subject.hex, icon.hex);
-  });
+    it('has the correct "hex" value', () => {
+      assert.equal(subject.hex, icon.hex);
+    });
 
-  test('has the correct "source"', () => {
-    assert.is(subject.source, icon.source);
-  });
+    it('has the correct "source"', () => {
+      assert.equal(subject.source, icon.source);
+    });
 
-  test('has an "svg" value', () => {
-    assert.type(subject.svg, 'string');
-  });
+    it('has an "svg" value', () => {
+      assert.equal(typeof subject.svg, 'string');
+    });
 
-  test('has a valid "path" value', () => {
-    assert.match(subject.path, /^[MmZzLlHhVvCcSsQqTtAaEe0-9-,.\s]+$/g);
-  });
+    it('has a valid "path" value', () => {
+      assert.match(subject.path, /^[MmZzLlHhVvCcSsQqTtAaEe0-9-,.\s]+$/g);
+    });
 
-  test(`has ${icon.guidelines ? 'the correct' : 'no'} "guidelines"`, () => {
-    if (icon.guidelines) {
-      assert.is(subject.guidelines, icon.guidelines);
-    } else {
-      assert.is(subject.guidelines, undefined);
-    }
-  });
-
-  test(`has ${icon.license ? 'the correct' : 'no'} "license"`, () => {
-    if (icon.license) {
-      assert.is(subject.license.type, icon.license.type);
-      if (icon.license.type === 'custom') {
-        assert.is(subject.license.url, icon.license.url);
+    it(`has ${icon.guidelines ? 'the correct' : 'no'} "guidelines"`, () => {
+      if (icon.guidelines) {
+        assert.equal(subject.guidelines, icon.guidelines);
       } else {
-        assert.match(subject.license.url, /^https?:\/\/[^\s]+$/);
+        assert.equal(subject.guidelines, undefined);
       }
-    } else {
-      assert.is(subject.license, undefined);
-    }
-  });
+    });
 
-  test('has a valid svg value', () => {
-    const svgFileContents = fs
-      .readFileSync(svgPath, 'utf8')
-      .replace(/\r?\n/, '');
-    assert.is(subject.svg, svgFileContents);
-  });
+    it(`has ${icon.license ? 'the correct' : 'no'} "license"`, () => {
+      if (icon.license) {
+        assert.equal(subject.license.type, icon.license.type);
+        if (icon.license.type === 'custom') {
+          assert.equal(subject.license.url, icon.license.url);
+        } else {
+          assert.match(subject.license.url, /^https?:\/\/[^\s]+$/);
+        }
+      } else {
+        assert.equal(subject.license, undefined);
+      }
+    });
 
-  test.run();
+    it('has a valid svg value', () => {
+      const svgFileContents = fs
+        .readFileSync(svgPath, 'utf8')
+        .replace(/\r?\n/, '');
+      assert.equal(subject.svg, svgFileContents);
+    });
+  });
 };


### PR DESCRIPTION
uvu is small and fast, but the reporter (which cannot be configured) is not great for this project. It outputs all tests even if they pass so it is difficult to find failing tests in the 40,000 tests we run. [Mocha](https://github.com/mochajs/mocha) is also relatively small and fast and has a `min` reporter to show only the failing tests.

Benchmarks:
uvu:
```
Benchmark 1: npx uvu
  Time (mean ± σ):      2.518 s ±  0.099 s    [User: 2.878 s, System: 0.414 s]
  Range (min … max):    2.409 s …  2.702 s    10 runs
```

mocha:
```
Benchmark 1: npx mocha tests --reporter min --inline-diffs
  Time (mean ± σ):      3.312 s ±  0.110 s    [User: 4.018 s, System: 0.345 s]
  Range (min … max):    3.115 s …  3.441 s    10 runs
```

So mocha is slower, but not by much.