### PR TITLE
Update "Potential Duplicates" reporter markup

### DIFF
--- a/.github/workflows/potential-duplicates.yml
+++ b/.github/workflows/potential-duplicates.yml
@@ -7,7 +7,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: bubkoo/potential-duplicates@v1
+      - uses: wow-actions/potential-duplicates@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           label: potential duplicate
@@ -32,5 +32,5 @@ jobs:
           comment: |
             This issue is potentially a duplicate of one of the following issues:
             {{#issues}}
-              - [#{{ number }}] {{ title }} ({{ accuracy }}%)
+              - #{{ number }} ({{ accuracy }}%)
             {{/issues}}


### PR DESCRIPTION
Github changed how it shows issue links, so the `comment` option of "Potential Duplicates" workflow must be updated accordingly.

### Before

![image](https://user-images.githubusercontent.com/23049315/150120813-d3d17cec-32fa-4333-8973-2a3ddd9737e9.png)


### After

![image](https://user-images.githubusercontent.com/23049315/150121067-9d38dc7f-4155-455b-b8c6-2d6e55285195.png)

