### PR TITLE
Exclude "project" word discovering potential duplicates

### DIFF
--- a/.github/workflows/potential-duplicates.yml
+++ b/.github/workflows/potential-duplicates.yml
@@ -27,6 +27,7 @@ jobs:
             please
             requesting
             request
+            project
           state: all
           threshold: 0.7
           comment: |


### PR DESCRIPTION
It fixes further false positives like the one in https://github.com/simple-icons/simple-icons/issues/7103#issuecomment-1023290659 marked by Potential Duplicates workflow for issues containing the word "project" or "Project".