### PR TITLE
Fix project auto-assignment closing not merged PRs

### DIFF
--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -89,8 +89,8 @@ jobs:
     env:
       MY_GITHUB_TOKEN: ${{ secrets.AUTO_ASSIGN_WORKFLOW_TOKEN }}
     steps:
-      - name: Assign closed pull requests to "Unprioritised"
+      - name: Assign closed pull requests to "Completed or Abandoned"
         uses: srggrs/assign-one-project-github-action@1.3.1
         with:
           project: https://github.com/orgs/simple-icons/projects/2
-          column_name: Unprioritised
+          column_name: Completed or Abandoned

--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    if: github.event.action == 'opened'
     steps:
       - uses: ericcornelissen/labeler@label-based-on-status
         with:

--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -1,7 +1,7 @@
 name: Add Pull Request Labels and Assign to Project
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, closed]
 
 jobs:
   triage:
@@ -14,6 +14,7 @@ jobs:
   assign-to-project:
     runs-on: ubuntu-latest
     name: Assign to Project
+    if: github.event.action == 'opened'
     needs: triage
     env:
       MY_GITHUB_TOKEN: ${{ secrets.AUTO_ASSIGN_WORKFLOW_TOKEN }}
@@ -73,6 +74,22 @@ jobs:
         if: |
           steps.priority-1.conclusion == 'skipped' &&
           steps.priority-2.conclusion == 'skipped'
+        with:
+          project: https://github.com/orgs/simple-icons/projects/2
+          column_name: Unprioritised
+
+  unassign-from-project:
+    runs-on: ubuntu-latest
+    name: Unassign from Projects
+    if: |
+      github.event.action != 'opened' &&
+      github.event.pull_request.merged == false
+    needs: triage
+    env:
+      MY_GITHUB_TOKEN: ${{ secrets.AUTO_ASSIGN_WORKFLOW_TOKEN }}
+    steps:
+      - name: Assign closed pull requests to "Unprioritised"
+        uses: srggrs/assign-one-project-github-action@1.3.1
         with:
           project: https://github.com/orgs/simple-icons/projects/2
           column_name: Unprioritised

--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -80,7 +80,7 @@ jobs:
 
   unassign-from-project:
     runs-on: ubuntu-latest
-    name: Unassign from Projects
+    name: Unassign from Project
     if: |
       github.event.action != 'opened' &&
       github.event.pull_request.merged == false


### PR DESCRIPTION
As has been reported in https://github.com/simple-icons/simple-icons/pull/7085#issuecomment-1030646297 could happen that an user closes their PR without merging it while the "Assign to Project" workflow is being executed. The solution here is to execute the job when a pull request is closed without been merged, assigning it to "Completed or Abandoned" column.