### PR TITLE
Fix link in issue template for icon requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/icon_request.yml
+++ b/.github/ISSUE_TEMPLATE/icon_request.yml
@@ -19,7 +19,7 @@ body:
 
         [contributing guidelines]: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
 
-        [new-icon-issues]: https://github.com/simple-icons/simple-icons/issues?q=is%3Aissue+label%3A%22new+icon%22+is%3Aopen
+        [new-icon-issues]: https://github.com/simple-icons/simple-icons/issues?q=is%3Aissue+label%3A%22new+icon%22
 
   - type: input
     attributes:


### PR DESCRIPTION
In the `value` of the template is defined:

> Before opening a new issue, make sure it isn't covered by an existing issue.
> Please search for [issues with the `new icon` label][new-icon-issues]
> (including closed issues) before you continue.

But the link points to opened issues with `new icon` label only. It seems that the link must point to issues with `new icon` label, regardless of the closing state of them.