### PR TITLE
Add `funding` key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,11 @@
   "support": {
     "issues": "https://github.com/simple-icons/simple-icons/issues"
   },
-  "license": "CC0-1.0"
+  "license": "CC0-1.0",
+  "funding": [
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/simple-icons"
+    }
+  ]
 }


### PR DESCRIPTION
Following from #7218. See https://getcomposer.org/doc/04-schema.md#funding

This will add a brief notification to Packagist that the package can be fund:

![image](https://user-images.githubusercontent.com/23049315/158183009-5a1feb97-4b00-450f-877b-04bab3738548.png)
