### PR TITLE
Avoid certain cases for data consistency

### DIFF
--- a/.jsonschema.json
+++ b/.jsonschema.json
@@ -57,22 +57,6 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["type", "url"],
-              "properties": {
-                "type": {
-                  "description": "The license name or 'custom'",
-                  "type": "string",
-                  "enum": ["custom"]
-                },
-                "url": {
-                  "description": "The URL to the license text by the brand",
-                  "$ref": "#/definitions/url"
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
               "required": ["type"],
               "properties": {
                 "type": {
@@ -166,6 +150,22 @@
                 }
               },
               "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": ["type", "url"],
+              "properties": {
+                "type": {
+                  "description": "The license name or 'custom'",
+                  "type": "string",
+                  "enum": ["custom"]
+                },
+                "url": {
+                  "description": "The URL to the license text by the brand",
+                  "$ref": "#/definitions/url"
+                }
+              },
+              "additionalProperties": false
             }
           ]
         }
@@ -235,7 +235,6 @@
       "pattern": "^https?://[^\\s]+$"
     }
   },
-
   "type": "object",
   "properties": {
     "icons": {
@@ -243,5 +242,7 @@
       "type": "array",
       "items": { "$ref": "#/definitions/brand" }
     }
-  }
+  },
+  "additionalProperties": false,
+  "required": ["icons"]
 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,5 +1,5 @@
 import simpleIcons from '../index.js';
-import { getIconSlug, getIconsData } from '../scripts/utils.js';
+import { getIconSlug, getIconsData, titleToSlug } from '../scripts/utils.js';
 import { test } from 'mocha';
 import { strict as assert } from 'node:assert';
 
@@ -16,6 +16,15 @@ import { strict as assert } from 'node:assert';
       assert.equal(found.hex, icon.hex);
       assert.equal(found.source, icon.source);
     });
+
+    if (icon.slug) {
+      // if an icon data has a slug, it must be different to the
+      // slug inferred from the title, which prevents adding
+      // unnecessary slugs to icons data
+      test(`'${icon.title}' slug must be necessary`, () => {
+        assert.notEqual(titleToSlug(icon.title), icon.slug);
+      });
+    }
   });
 
   test(`Iterating over simpleIcons only exposes icons`, () => {


### PR DESCRIPTION
This PR fixes two main problems.

### Add another property to the root of `_data/simple-icons.json`

Before this change, you can add another property to the root of `_data/simple-icons.json`, at the same level of `"icons"` property, without triggering failures in the CI

![image](https://user-images.githubusercontent.com/23049315/158234704-834a4551-ca7a-4f76-8b37-9cb7a9bb39bb.png)

After this change:

![image](https://user-images.githubusercontent.com/23049315/158234805-895d9777-a516-4459-82d8-a3fc7865bb6b.png)

### Add an uneeded slug to an icon

If you have an icon named `foo.svg` with a title `Foo` and a slug `foo`, the CI passes. But this slug is not really needed.

---

Also, I've moved the definition of `license.oneOf` in `.jsonschema` so the linters like VSCode intellisense can display a better suggestion message. Before:

![image](https://user-images.githubusercontent.com/23049315/158235484-3033dde0-81bc-4d91-b857-9b97d7c09261.png)

After:

![image](https://user-images.githubusercontent.com/23049315/158235606-f68b1a9c-ccf8-4972-80ad-7bfa6447be31.png)