### PR TITLE
Automatically remove `help wanted` labels from closed issues

### DIFF
--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -48,3 +48,4 @@ jobs:
             in discussion
             pending
             tracking
+            help wanted


### PR DESCRIPTION
It could really confusing `help wanted` labels in closed issues. See [#4205 (event)](https://github.com/simple-icons/simple-icons/issues/4205#event-6251479436).