### PR TITLE
update source and guidelines for Amazon/AWS icons

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -474,7 +474,8 @@
         {
             "title": "Amazon DynamoDB",
             "hex": "4053D6",
-            "source": "https://aws.amazon.com/architecture/icons/"
+            "source": "https://aws.amazon.com/architecture/icons/",
+            "guidelines": "https://aws.amazon.com/architecture/icons/"
         },
         {
             "title": "Amazon Fire TV",
@@ -484,7 +485,8 @@
         {
             "title": "Amazon Lumberyard",
             "hex": "66459B",
-            "source": "https://aws.amazon.com/lumberyard/support"
+            "source": "https://aws.amazon.com/architecture/icons/",
+            "guidelines": "https://aws.amazon.com/architecture/icons/"
         },
         {
             "title": "Amazon Pay",
@@ -499,7 +501,8 @@
         {
             "title": "Amazon S3",
             "hex": "569A31",
-            "source": "https://aws.amazon.com/architecture/icons/"
+            "source": "https://aws.amazon.com/architecture/icons/",
+            "guidelines": "https://aws.amazon.com/architecture/icons/"
         },
         {
             "title": "AMD",
@@ -1075,7 +1078,8 @@
         {
             "title": "AWS Amplify",
             "hex": "FF9900",
-            "source": "https://docs.amplify.aws/"
+            "source": "https://aws.amazon.com/architecture/icons/",
+            "guidelines": "https://aws.amazon.com/architecture/icons/"
         },
         {
             "title": "AWS Lambda",


### PR DESCRIPTION
This updates the `source` and `guidelines` for some icons to https://aws.amazon.com/architecture/icons/.