### PR TITLE
Add guidelines link to GitLab icon data

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3851,7 +3851,8 @@
         {
             "title": "GitLab",
             "hex": "FCA121",
-            "source": "https://about.gitlab.com/press/press-kit/"
+            "source": "https://about.gitlab.com/press/press-kit/",
+            "guidelines": "https://about.gitlab.com/handbook/marketing/corporate-marketing/brand-activation/trademark-guidelines/"
         },
         {
             "title": "Gitpod",


### PR DESCRIPTION
I've added a link to the [GitLab Trademark Guidelines](https://about.gitlab.com/handbook/marketing/corporate-marketing/brand-activation/trademark-guidelines/) in the data file.