### PR TITLE
Push tag manually in 'Publish Releases' workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,18 +79,20 @@ jobs:
         with:
           files: README.md
           strict: true
-      # Add commit that will only be included in the tag
+      - name: Configure GIT credentials
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+      # Commit that will only be included in the tag
       - name: Commit dark theme images strip
         run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
           git add README.md
           git commit -m 'Strip README dark theme image links'
       - name: Create and push git tag
-        uses: actions-ecosystem/action-push-tag@v1
-        with:
-          tag: ${{ steps.get-version.outputs.version }}
-          message: ${{ steps.commit.outputs.git-message }}
+        run: |
+          tag="${{ steps.get-version.outputs.version }}"
+          git tag -a "${tag}" -m "${{ steps.commit.outputs.git-message }}"
+          git push origin "${tag}"
       - name: Create release
         uses: actions/create-release@v1
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,6 +90,7 @@ jobs:
           git commit -m 'Strip README dark theme image links'
       - name: Create and push git tag
         run: |
+          set -e
           tag="${{ steps.get-version.outputs.version }}"
           git tag -a "${tag}" -m "${{ steps.commit.outputs.git-message }}"
           git push origin "${tag}"


### PR DESCRIPTION
Fixes #7339

Just used the same commands that the action uses, [see them here](https://github.com/actions-ecosystem/action-push-tag/blob/b6bf942d9ccb9ec4d3029801476b54de8697c310/entrypoint.sh#L3-L12).