### PR TITLE
Add Boxy SVG to list of vector graphics editors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,7 @@ There are many different tools for editing SVG files, some options include:
 | Name | Description | Platform | Price |
 | :---- | :---- | :----: | :----: |
 | [Inkscape](https://inkscape.org/) | Vector Graphics Editor | Windows, Mac, Linux | Free |
+| [Boxy SVG](https://boxy-svg.com/) | Vector Graphics Editor | Windows, Mac, Linux | $ / Free (Linux, Web) |
 | [Affinity Designer](https://affinity.serif.com/designer/) | Vector Graphics Editor | Windows, Mac | $ |
 | [Adobe Illustrator](https://www.adobe.com/products/illustrator.html) | Vector Graphics Editor | Windows, Mac | $ - $$$ |
 | [IcoMoon](https://icomoon.io/) | Icon Editing/Management Tool | Online | Free |


### PR DESCRIPTION
I've added [Boxy SVG](https://boxy-svg.com/) to the list of vector graphics editors in `CONTRIBUTING.md`. I've been using it for several years on Linux and like it much better than Inkscape. In my opinion, Boxy SVG has a much better UX, is cleaner and simpler, and adds significantly less editor-specific metadata to the SVG markup. It has worked very well for me also for extracting icons for Simple Icons.

It's only free on Linux and as a (regular) web app though. macOS users and users of the native browser apps need to buy in the respective app stores.