### PR TITLE
Upgrade `strip-gh-theme-links` action to v3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       - name: Remove dark theme images from README
-        uses: mondeja/strip-gh-theme-links@v2
+        uses: mondeja/strip-gh-theme-links@v3
         with:
           files: README.md
           strict: true
@@ -75,7 +75,7 @@ jobs:
           export PACKAGE_VERSION=$(cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//')
           echo "::set-output name=version::$PACKAGE_VERSION"
       - name: Remove dark theme images from README
-        uses: mondeja/strip-gh-theme-links@v2
+        uses: mondeja/strip-gh-theme-links@v3
         with:
           files: README.md
           strict: true


### PR DESCRIPTION
Just a needed major version update without changes affecting us.