### PR TITLE
Specify release action version with tag

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,7 +23,7 @@ jobs:
       did-create-pr: ${{ steps.release.outputs.did-create-pr }}
       new-version: ${{ steps.release.outputs.new-version }}
     steps:
-      - uses: simple-icons/release-action@master
+      - uses: simple-icons/release-action@v1
         id: release
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge-release.yml
+++ b/.github/workflows/merge-release.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'release')
     steps:
-      - uses: simple-icons/release-action@master
+      - uses: simple-icons/release-action@v1
         with:
           repo-token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
As of version [1.0.8](https://github.com/simple-icons/release-action/releases/tag/v1.0.8), the [release action](https://github.com/simple-icons/release-action) follows a semver releases system.