### PR TITLE
Convert prettierrc.js file to JSON

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,0 @@
-module.exports = {
-  trailingComma: 'all',
-  singleQuote: true,
-};

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "all",
+  "singleQuote": true
+}


### PR DESCRIPTION
This change is due to three main reasons:

- Avoid a possible security pitfall giving that *prettierrc.js* is executed by Prettier but not *prettierrc.json*.
- Avoid many CommonJS as possible as we are moving to ESM.
- Add editors JSON schema checking while typing:

  ![image](https://user-images.githubusercontent.com/23049315/168763086-220658fd-778d-4346-8d57-db8e1fe8cb58.png)
