### PR TITLE
Add Tuple icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -10867,6 +10867,11 @@
             "source": "https://cms.tunein.com/press/"
         },
         {
+            "title": "Tuple",
+            "hex": "4652AF",
+            "source": "https://tuple.app/"
+        },
+        {
             "title": "Turborepo",
             "hex": "EF4444",
             "source": "https://github.com/vercel/turborepo/blob/7312e316629a2138f895a90c9704045891be817b/docs/public/logo-light.svg"

--- a/icons/tuple.svg
+++ b/icons/tuple.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Tuple</title><path d="M15.653 0 4.175 3.619v11.762l4.174 1.316v3.684L19.827 24V5l-4.174 1.316V0Zm-5.217 17.355L15.653 19V8.421l2.087-.658v13.473l-7.304-2.303v-1.578Z"/></svg>


### PR DESCRIPTION
![tuple](https://user-images.githubusercontent.com/10208811/169109455-ac130b61-8eef-4e36-b8b4-9bcf8a3adb6e.png)

**Similarweb rank:** [797,917](https://www.similarweb.com/fr/website/tuple.app/#overview)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
- [Tuple](https://tuple.app/) is a pair programming tool for macOS and Linux.
- Hex value `#4652AF` is the main color in [Tuple's current logo](https://tuple.app/img/logo.svg).
- I reworked the logo which isn't monochromatic, with an outlined rectangle for the background frame. I'm actually the designer at Tuple so I hope you'll allow me 🙂 