### PR TITLE
Remove IcoMoon from contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,6 @@ There are many different tools for editing SVG files, some options include:
 | [Boxy SVG](https://boxy-svg.com/) | Vector Graphics Editor | Windows, Mac, Linux | $ / Free (Linux, Web) |
 | [Affinity Designer](https://affinity.serif.com/designer/) | Vector Graphics Editor | Windows, Mac | $ |
 | [Adobe Illustrator](https://www.adobe.com/products/illustrator.html) | Vector Graphics Editor | Windows, Mac | $ - $$$ |
-| [IcoMoon](https://icomoon.io/) | Icon Editing/Management Tool | Online | Free |
 
 Using your preferred tool you should:
 


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/SI-Sandbox/preview/
-->

**Issue:** closes #

**Similarweb rank:** N/A

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
This is not a PR to add or update an SVG icon, but to update the CONTRIBUTING.md file.
More accurately does this remove the entry of IcoMoon from the section `2. Extract the Icon from the Logo`. More detailed reason as to why it should be removed can be found in the discussion #7396 