### PR TITLE
Add exclusion of brands of protective companies/organizations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,15 @@ We welcome icon requests. Before you submit a new issue please make sure the ico
     - Symbols, including flags and banners
     - Sport clubs
        - Allowed: Sports organizations
-    - Brands of companies or organizations that are excessively protective (e.g. Disney)
+    - Yearly releases
+    - Universities or other educational institutions
+    - Any brands representing individuals rather than an organization, company, or product. This includes musicians, bands, and social media personalities.
+
+Some companies and organizations are excessively protective with their brands, so please don't consider them:
+
+- Disney
+- Do you know more? Please, [report them](https://github.com/simple-icons/simple-icons/issues/new?labels=docs&template=documentation.yml).
+
     - Yearly releases
     - Universities or other educational institutions
     - Any brands representing individuals rather than an organization, company, or product. This includes musicians, bands, and social media personalities.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,10 +64,6 @@ Some companies and organizations are excessively protective with their brands, s
 - Disney
 - Do you know more? Please, [report them](https://github.com/simple-icons/simple-icons/issues/new?labels=docs&template=documentation.yml).
 
-    - Yearly releases
-    - Universities or other educational institutions
-    - Any brands representing individuals rather than an organization, company, or product. This includes musicians, bands, and social media personalities.
-
 If you are in doubt, feel free to submit it and we'll have a look.
 
 When submitting a request for a new or updated icon include helpful information such as:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ We welcome icon requests. Before you submit a new issue please make sure the ico
     - Symbols, including flags and banners
     - Sport clubs
        - Allowed: Sports organizations
+    - Brands of companies or organizations that are excessively protective (e.g. Disney)
     - Yearly releases
     - Universities or other educational institutions
     - Any brands representing individuals rather than an organization, company, or product. This includes musicians, bands, and social media personalities.


### PR DESCRIPTION
I've added an item to the list of exclusion criteria in `CONTRIBUTING.md` about excessively protective companies or organizations since, e.g., Disney brands have been requested several times (see #7430 etc.).