### PR TITLE
Pin release-action version to a previous hash

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,7 +23,7 @@ jobs:
       did-create-pr: ${{ steps.release.outputs.did-create-pr }}
       new-version: ${{ steps.release.outputs.new-version }}
     steps:
-      - uses: simple-icons/release-action@v1
+      - uses: simple-icons/release-action@5edfadcb9d0fcced712defd84c26d8fd3913beb9
         id: release
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The new version of the action is creating bad PRs bodies. See https://github.com/simple-icons/release-action/issues/68

Temporally pinned to https://github.com/simple-icons/release-action/tree/5edfadcb9d0fcced712defd84c26d8fd3913beb9