### PR TITLE
deprecate index entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,7 @@ The icons are also available through our npm package. To install, simply run:
 npm install simple-icons
 ```
 
-The API can then be used as follows, where `[ICON SLUG]` is replaced by a [slug]:
-
-```javascript
-const simpleIcons = require('simple-icons');
-
-// Get a specific icon by its slug as:
-// simpleIcons.Get('[ICON SLUG]');
-
-// For example:
-const icon = simpleIcons.Get('simpleicons');
-
-```
-
-Alternatively, you can also import all icons from a single file, where `[ICON SLUG]` is replaced by a capitalized [slug]. We highly recommend using a bundler that can tree shake such as [webpack](https://webpack.js.org/) to remove the unused icon code:
+You can also import all icons from a single file, where `[ICON SLUG]` is replaced by a capitalized [slug]. We highly recommend using a bundler that can tree shake such as [webpack](https://webpack.js.org/) to remove the unused icon code:
 ```javascript
 // Import a specific icon by its slug as:
 // import { si[ICON SLUG] } from 'simple-icons/icons'
@@ -97,18 +84,6 @@ console.log(siSimpleicons);
 NOTE: the `guidelines` entry will be `undefined` if we do not yet have guidelines for the icon.
 NOTE: the `license` entry will be `undefined` if we do not yet have license data for the icon.
 */
-```
-
-Lastly, the `simpleIcons` object is also enumerable.
-This is useful if you want to do a computation on every icon:
-
-```javascript
-const simpleIcons = require('simple-icons');
-
-for (const iconSlug in simpleIcons) {
-  const icon = simpleIcons.Get(iconSlug);
-  // do stuff
-}
 ```
 
 #### TypeScript Usage <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/typescript.svg#gh-light-mode-only" alt="Typescript" align=left width=19 height=19><img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/assets/readme/typescript-white.svg#gh-dark-mode-only" alt="Typescript" align=left width=19 height=19>

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,9 @@ export interface SimpleIcon {
     | undefined;
 }
 
+/**
+ * @deprecated The `simple-icons` entrypoint will be removed in the next major. Please switch to using `import * as icons from "simple-icons/icons"` if you need an object with all the icons.
+ */
 declare const icons: Record<string, SimpleIcon> & {
   Get(name: string): SimpleIcon;
 };

--- a/scripts/build/templates/index.js
+++ b/scripts/build/templates/index.js
@@ -1,3 +1,5 @@
+console.warn('Deprecation warning: The `simple-icons` entrypoint will be removed in the next major. Please switch to using `import * as icons from "simple-icons/icons"` if you need an object with all the icons.')
+
 var icons = {%s};
 
 Object.defineProperty(icons, "Get", {


### PR DESCRIPTION
discussion in #6789
#6788 should be merged first

Deprecate the `simple-icons` entry point as it has very little usage and can be replaced with `import * as icons from 'simple-icons'`