### PR TITLE
Reuse `svg` getter package template parts

### DIFF
--- a/scripts/build/package.js
+++ b/scripts/build/package.js
@@ -118,7 +118,7 @@ const build = async () => {
   await writeJs(indexFile, rawIndexJs);
 
   // write our file containing the exports of all icons in CommonJS ...
-  const rawIconsJs = `${constantsString};module.exports={${iconsBarrelJs.join(
+  const rawIconsJs = `${constantsString}module.exports={${iconsBarrelJs.join(
     '',
   )}};`;
   await writeJs(iconsJsFile, rawIconsJs);

--- a/scripts/build/package.js
+++ b/scripts/build/package.js
@@ -106,18 +106,24 @@ const build = async () => {
     }),
   );
 
+  // constants used in templates to reduce package size
+  const constantsString = `const a='<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>',b='</title><path d="',c='"/></svg>';`;
+
   // write our generic index.js
   const rawIndexJs = util.format(
     indexTemplate,
+    constantsString,
     buildIcons.map(iconToKeyValue).join(','),
   );
   await writeJs(indexFile, rawIndexJs);
 
   // write our file containing the exports of all icons in CommonJS ...
-  const rawIconsJs = `module.exports={${iconsBarrelJs.join('')}};`;
+  const rawIconsJs = `${constantsString};module.exports={${iconsBarrelJs.join(
+    '',
+  )}};`;
   await writeJs(iconsJsFile, rawIconsJs);
   // and ESM
-  const rawIconsMjs = iconsBarrelMjs.join('');
+  const rawIconsMjs = constantsString + iconsBarrelMjs.join('');
   await writeJs(iconsMjsFile, rawIconsMjs);
   // and create a type declaration file
   const rawIconsDts = `import {SimpleIcon} from ".";type I = SimpleIcon;${iconsBarrelDts.join(

--- a/scripts/build/templates/icon-object.js
+++ b/scripts/build/templates/icon-object.js
@@ -2,7 +2,7 @@
   title: '%s',
   slug: '%s',
   get svg() {
-    return '<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>%s</title><path d="' + this.path + '"/></svg>';
+    return a + '%s' + b + this.path + c;
   },
   path: '%s',
   source: '%s',

--- a/scripts/build/templates/index.js
+++ b/scripts/build/templates/index.js
@@ -1,5 +1,7 @@
 console.warn('Deprecation warning: The `simple-icons` entrypoint will be removed in the next major. Please switch to using `import * as icons from "simple-icons/icons"` if you need an object with all the icons.')
 
+%s
+
 var icons = {%s};
 
 Object.defineProperty(icons, "Get", {


### PR DESCRIPTION
The reduction in size of `icons.js` is not a lot but is something (in bytes): `4348959` -> `4158916`

### Basic performance test

Not very scientific, just median times of a few executions.

Before:

```
$ time node -e "for (let i=0; i<500000; i++) { require('./icons')['siElsevier'].svg }"

real	0m0,191s
user	0m0,186s
sys	0m0,016s
```

After is a bit slower:

```
real	0m0,198s
user	0m0,183s
sys	0m0,027s
```