### PR TITLE
chore(icons): update lerna colour code

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -5857,7 +5857,7 @@
         },
         {
             "title": "Lerna",
-            "hex": "2F0268",
+            "hex": "9333EA",
             "source": "https://github.com/lerna/logo/blob/fb18db535d71aacc6ffb0f6b75a0c3bd9e353543/lerna.svg"
         },
         {


### PR DESCRIPTION
It updates the colour code of the Lerna logo to match the accent colour (`#9333EA`) of the newly released website: https://lerna.js.org.

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
