### PR TITLE
Use proper Note markdown

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -11,9 +11,11 @@ Simple Icons asks that its users read this disclaimer fully before including an 
 
 ## Licenses, Copyrights & Trademarks
 
-> :information_source: NOTE: The addition of licenses to Simple Icons is an ongoing project. Hence, the absence of licence data for a particular icon does not imply that the icon is not released under a license.
+> **Note** 
+> The addition of licenses to Simple Icons is an ongoing project. Hence, the absence of licence data for a particular icon does not imply that the icon is not released under a license.
 
-> :information_source: NOTE: Simple Icons is released under CC0 - though that doesn't mean to imply that all icons within the project are also CC0. Please see individual licenses where available.
+> **Note** 
+> Simple Icons is released under CC0 - though that doesn't mean to imply that all icons within the project are also CC0. Please see individual licenses where available.
 
 Simple Icons provides data on the license under which icons are available. We ask users to carefully consider this when using an icon. As licenses are subject to change we also ask our users to regularly check if the license of the icons they use have been changed.
 
@@ -27,7 +29,8 @@ Simple Icons cannot be held responsible for any legal activity raised by a brand
 
 ## Brand Guidelines
 
-> :information_source: NOTE: the addition of guidelines to Simple Icons is an ongoing project. In the meantime, users of Simple Icons are instead encouraged to check the `source` URL as, in some cases, the icon will have been sourced from official guidelines. The lack of a `guidelines` entry for a particular brand does not imply that the brand has no guidelines.
+> **Note** 
+> The addition of guidelines to Simple Icons is an ongoing project. In the meantime, users of Simple Icons are instead encouraged to check the `source` URL as, in some cases, the icon will have been sourced from official guidelines. The lack of a `guidelines` entry for a particular brand does not imply that the brand has no guidelines.
 
 Simple Icons provides a link to a brand's _branding guidelines_ (or similar) if the brand provides one. We ask our users read these guidelines and ensure their usage of the brand's icon is in accordance with them. As guidelines are subject to change we also ask our users to regularly check if the brand guidelines of the icons they use have been updated.
 


### PR DESCRIPTION
This pull request replaces the custom Note markdown with the Github supported markdown. This change makes notes easier to read (markdown wise) and use. 

Before:
> :information_source: NOTE: This is a note

After:
> **Note**
> This is a note