### PR TITLE
Minor improvements for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Over 2300 Free SVG icons for popular brands. See them all on one page at <a href
 
 ### General Usage
 
-Icons can be downloaded as SVGs directly from [our website](https://simpleicons.org/) - simply click the icon you want, and the download should start automatically.
+Icons can be downloaded as SVGs directly from [our website](https://simpleicons.org/) - simply click the download button of the icon you want, and the download will start automatically.
 
 ### CDN Usage
 
@@ -32,7 +32,7 @@ Icons can be served from a CDN such as [JSDelivr](https://www.jsdelivr.com/packa
 <img height="32" width="32" src="https://unpkg.com/simple-icons@v7/icons/[ICON SLUG].svg" />
 ```
 
-Where `[ICON SLUG]` is replaced by the [slug] of the icon you want to use, for example:
+Where `[ICON SLUG]` is replaced by the [slug](https://github.com/simple-icons/simple-icons/blob/master/slugs.md) of the icon you want to use, for example:
 
 ```html
 <img height="32" width="32" src="https://cdn.jsdelivr.net/npm/simple-icons@v7/icons/simpleicons.svg" />
@@ -138,13 +138,10 @@ echo file_get_contents('path/to/package/icons/simpleicons.svg');
 | <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/vuedotjs.svg#gh-light-mode-only" alt="Vue" align=left width=24 height=24><img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/assets/readme/vuedotjs-white.svg#gh-dark-mode-only" alt="Vue" align=left width=24 height=24> [Vue package](https://github.com/mainvest/vue-simple-icons) | [@noahlitvin](https://github.com/noahlitvin) |
 | <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/wordpress.svg#gh-light-mode-only" alt="Wordpress" align=left width=24 height=24><img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/assets/readme/wordpress-white.svg#gh-dark-mode-only" alt="Wordpress" align=left width=24 height=24> [WordPress plugin](https://wordpress.org/plugins/simple-icons/) | [@tjtaylo](https://github.com/tjtaylo) |
 
-
-[slug]: ./slugs.md
-
 ## Contribute
 
 [![Good first issues open](https://img.shields.io/github/issues/simple-icons/simple-icons/good%20first%20issue?label=good%20first%20issues&logo=git&logoColor=white)](https://github.com/simple-icons/simple-icons/labels/good%20first%20issue)
 
-Information describing how to contribute can be found here:
+Information describing how to contribute can be found in the file [CONTRIBUTING.md](https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md)
 
-https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
+


### PR DESCRIPTION
- To download an icon using the website is not possible by clicking on the icon itself.
- Inline link for *CONTRIBUTING.md* file.
- Slugs file is referenced in the link explicitly to make it work the README when the npm package is installed (slugs file doesn't exists) pointing to the `master` branch, which is the one that includes the current published slugs.