### PR TITLE
Build icons in order

### DIFF
--- a/scripts/build/package.js
+++ b/scripts/build/package.js
@@ -81,30 +81,28 @@ const build = async () => {
   };
 
   // 'main'
-  const iconsBarrelMjs = [];
-  const iconsBarrelJs = [];
-  const iconsBarrelDts = [];
-  const buildIcons = [];
-
-  await Promise.all(
+  const buildIcons = await Promise.all(
     icons.map(async (icon) => {
       const filename = getIconSlug(icon);
       const svgFilepath = path.resolve(iconsDir, `${filename}.svg`);
       icon.svg = (await fs.readFile(svgFilepath, UTF8)).replace(/\r?\n/, '');
       icon.path = svgToPath(icon.svg);
       icon.slug = filename;
-      buildIcons.push(icon);
-
       const iconObject = iconToObject(icon);
-
       const iconExportName = slugToVariableName(icon.slug);
-
-      // add object to the barrel file
-      iconsBarrelJs.push(`${iconExportName}:${iconObject},`);
-      iconsBarrelMjs.push(`export const ${iconExportName}=${iconObject}`);
-      iconsBarrelDts.push(`export const ${iconExportName}:I;`);
+      return { icon, iconObject, iconExportName };
     }),
   );
+
+  const iconsBarrelDts = [];
+  const iconsBarrelJs = [];
+  const iconsBarrelMjs = [];
+
+  buildIcons.forEach(({ icon, iconObject, iconExportName }) => {
+    iconsBarrelDts.push(`export const ${iconExportName}:I;`);
+    iconsBarrelJs.push(`${iconExportName}:${iconObject},`);
+    iconsBarrelMjs.push(`export const ${iconExportName}=${iconObject}`);
+  });
 
   // constants used in templates to reduce package size
   const constantsString = `const a='<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>',b='</title><path d="',c='"/></svg>';`;
@@ -113,7 +111,7 @@ const build = async () => {
   const rawIndexJs = util.format(
     indexTemplate,
     constantsString,
-    buildIcons.map(iconToKeyValue).join(','),
+    buildIcons.map(({ icon }) => iconToKeyValue(icon)).join(','),
   );
   await writeJs(indexFile, rawIndexJs);
 


### PR DESCRIPTION
### Background

I noticed the build process of https://github.com/icons-pack/react-simple-icons is based on our exported module. They are using `Object.keys(simpleIcons)` stuff to map our icons. The order in which they are built depends on our order.

Every time they bump the simple-icons version, their `index.ts` file changes unpredictably. For example [this diff](https://github.com/icons-pack/react-simple-icons/commit/8a10296e3f4a889f3eba0abcb7998541698a8cfd#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) (you may need to click `Load diff` since the diff is too large).

### Before

We are using `.push` inside the `Promise.all`. So we cannot guarantee that its order is identical to the JSON file.

https://github.com/simple-icons/simple-icons/blob/d5444f699528a456ee2894751994b4eef7274235/scripts/build/package.js#L89-L96

### After

I moved the `.push` logic outside the `Promise.all`. Now the order looks good :)