### PR TITLE
Forbid the usage of non secure URLs

### DIFF
--- a/.jsonschema.json
+++ b/.jsonschema.json
@@ -231,6 +231,7 @@
     },
     "url": {
       "$id": "#url",
+      "description": "HTTPS-only URL for a source",
       "type": "string",
       "pattern": "^https://[^\\s]+$"
     }

--- a/.jsonschema.json
+++ b/.jsonschema.json
@@ -232,7 +232,7 @@
     "url": {
       "$id": "#url",
       "type": "string",
-      "pattern": "^https?://[^\\s]+$"
+      "pattern": "^https://[^\\s]+$"
     }
   },
   "type": "object",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -291,6 +291,8 @@ Here is the object of the fictional brand from before, but with all optional val
 }
 ```
 
+> Non secured HTTP URLs are forbidden. If a brand's website only supports HTTP, you must still declare the URL using the `https://` protocol.
+
 #### Source Guidelines
 
 We use the source URL as a reference for the current SVG in our repository and as a jumping-off point to find updates if the logo changes. If you used one of the sources listed below, make sure to follow these guidelines. If you're unsure about the source URL you can open a Pull Request and ask for help from others.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -27,4 +27,4 @@ For these and/or other purposes and motivations, and without any expectation of 
     3. Affirmer disclaims responsibility for clearing rights of other persons that may apply to the Work or any use thereof, including without limitation any person’s Copyright and Related Rights in the Work. Further, Affirmer disclaims responsibility for obtaining any necessary consents, permissions or other rights required for any use of the Work.
     4. Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work.
 
-For more information, please see http://creativecommons.org/publicdomain/zero/1.0/.
+For more information, please see https://creativecommons.org/publicdomain/zero/1.0/.

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -118,12 +118,12 @@
         {
             "title": "ACM",
             "hex": "0085CA",
-            "source": "http://identitystandards.acm.org/"
+            "source": "https://identitystandards.acm.org/"
         },
         {
             "title": "ActiGraph",
             "hex": "0B2C4A",
-            "source": "http://www.actigraphcorp.com/"
+            "source": "https://www.actigraphcorp.com/"
         },
         {
             "title": "Activision",
@@ -148,7 +148,7 @@
         {
             "title": "AddThis",
             "hex": "FF6550",
-            "source": "http://www.addthis.com/"
+            "source": "https://www.addthis.com/"
         },
         {
             "title": "AdGuard",
@@ -265,7 +265,7 @@
         {
             "title": "Aerospike",
             "hex": "C41E25",
-            "source": "http://pages.aerospike.com/rs/aerospike/images/Acid_Whitepaper.pdf"
+            "source": "https://pages.aerospike.com/rs/aerospike/images/Acid_Whitepaper.pdf"
         },
         {
             "title": "AEW",
@@ -335,7 +335,7 @@
         {
             "title": "Air China",
             "hex": "E30E17",
-            "source": "http://www.airchina.com.cn/en/investor_relations/"
+            "source": "https://www.airchina.com.cn/en/investor_relations/"
         },
         {
             "title": "Air France",
@@ -410,7 +410,7 @@
         {
             "title": "Alfa Romeo",
             "hex": "981E32",
-            "source": "http://www.fcaci.com/x/Alfa"
+            "source": "https://www.fcaci.com/x/Alfa"
         },
         {
             "title": "Alfred",
@@ -465,7 +465,7 @@
         {
             "title": "AlloCiné",
             "hex": "FECC00",
-            "source": "http://www.allocine.fr/"
+            "source": "https://www.allocine.fr/"
         },
         {
             "title": "AllTrails",
@@ -796,7 +796,7 @@
         {
             "title": "Apache CloudStack",
             "hex": "2AA5DC",
-            "source": "http://cloudstack.apache.org/trademark-guidelines.html"
+            "source": "https://cloudstack.apache.org/trademark-guidelines.html"
         },
         {
             "title": "Apache Cordova",
@@ -1269,7 +1269,7 @@
         {
             "title": "Azure DevOps",
             "hex": "0078D7",
-            "source": "http://azure.com/devops"
+            "source": "https://azure.microsoft.com/products/devops/"
         },
         {
             "title": "Azure Functions",
@@ -1627,7 +1627,7 @@
         {
             "title": "Bootstrap",
             "hex": "7952B3",
-            "source": "http://getbootstrap.com/about"
+            "source": "https://getbootstrap.com/about"
         },
         {
             "title": "BorgBackup",
@@ -1890,7 +1890,7 @@
         {
             "title": "Castro",
             "hex": "00B265",
-            "source": "http://supertop.co/castro/press/"
+            "source": "https://supertop.co/castro/press/"
         },
         {
             "title": "Caterpillar",
@@ -2192,7 +2192,7 @@
         {
             "title": "Co-op",
             "hex": "00B1E7",
-            "source": "http://www.co-operative.coop/corporate/press/logos/"
+            "source": "https://www.co-operative.coop/media/assets"
         },
         {
             "title": "Cockpit",
@@ -2271,7 +2271,7 @@
         {
             "title": "Codeforces",
             "hex": "1F8ACB",
-            "source": "http://codeforces.com/"
+            "source": "https://codeforces.com/"
         },
         {
             "title": "CodeIgniter",
@@ -2594,12 +2594,12 @@
         {
             "title": "CSS Wizardry",
             "hex": "F43059",
-            "source": "http://csswizardry.com"
+            "source": "https://csswizardry.com"
         },
         {
             "title": "CSS3",
             "hex": "1572B6",
-            "source": "http://www.w3.org/html/logo/"
+            "source": "https://www.w3.org/html/logo/"
         },
         {
             "title": "Cucumber",
@@ -2842,7 +2842,7 @@
             "title": "del.icio.us",
             "slug": "delicious",
             "hex": "0000FF",
-            "source": "http://del.icio.us/",
+            "source": "https://del.icio.us/",
             "aliases": {
                 "aka": [
                     "Delicious"
@@ -2916,7 +2916,7 @@
         {
             "title": "DeviantArt",
             "hex": "05CC47",
-            "source": "http://help.deviantart.com/21"
+            "source": "https://help.deviantart.com/21"
         },
         {
             "title": "Devpost",
@@ -3381,7 +3381,7 @@
         {
             "title": "Empire Kred",
             "hex": "72BE50",
-            "source": "http://www.empire.kred"
+            "source": "https://www.empire.kred"
         },
         {
             "title": "Enpass",
@@ -3529,7 +3529,7 @@
         {
             "title": "Expo",
             "hex": "000020",
-            "source": "http://expo.io/brand/"
+            "source": "https://expo.io/brand/"
         },
         {
             "title": "Express",
@@ -3665,7 +3665,7 @@
         {
             "title": "FeatHub",
             "hex": "9B9B9B",
-            "source": "http://feathub.com/"
+            "source": "https://feathub.com/"
         },
         {
             "title": "FedEx",
@@ -3706,7 +3706,7 @@
         {
             "title": "Fiat",
             "hex": "941711",
-            "source": "http://www.fcaci.com/x/FIATv15"
+            "source": "https://www.fcaci.com/x/FIATv15"
         },
         {
             "title": "Fido Alliance",
@@ -3775,7 +3775,7 @@
         {
             "title": "Fitbit",
             "hex": "00B0B9",
-            "source": "http://www.fitbit.com/uk/home"
+            "source": "https://www.fitbit.com/uk/home"
         },
         {
             "title": "FITE",
@@ -3880,7 +3880,7 @@
         {
             "title": "Fnac",
             "hex": "E1A925",
-            "source": "http://www.fnac.com/"
+            "source": "https://www.fnac.com/"
         },
         {
             "title": "Folium",
@@ -3925,7 +3925,7 @@
         {
             "title": "Fortinet",
             "hex": "EE3124",
-            "source": "http://www.fortinet.com/"
+            "source": "https://www.fortinet.com/"
         },
         {
             "title": "Fortran",
@@ -4179,7 +4179,7 @@
         {
             "title": "Git",
             "hex": "F05032",
-            "source": "http://git-scm.com/downloads/logos",
+            "source": "https://git-scm.com/downloads/logos",
             "license": {
                 "type": "CC-BY-3.0"
             }
@@ -4381,7 +4381,7 @@
         {
             "title": "GoldenLine",
             "hex": "FFE005",
-            "source": "http://www.goldenline.pl"
+            "source": "https://www.goldenline.pl"
         },
         {
             "title": "Goodreads",
@@ -4575,7 +4575,7 @@
         {
             "title": "Google Sheets",
             "hex": "34A853",
-            "source": "http://sheets.google.com/"
+            "source": "https://sheets.google.com/"
         },
         {
             "title": "Google Street View",
@@ -4642,7 +4642,7 @@
         {
             "title": "Grav",
             "hex": "221E1F",
-            "source": "http://getgrav.org/media"
+            "source": "https://getgrav.org/media"
         },
         {
             "title": "Gravatar",
@@ -4844,7 +4844,7 @@
         {
             "title": "Hatena Bookmark",
             "hex": "00A4DE",
-            "source": "http://hatenacorp.jp/press/resource"
+            "source": "https://hatenacorp.jp/press/resource"
         },
         {
             "title": "haveibeenpwned",
@@ -5049,7 +5049,7 @@
         {
             "title": "HTML5",
             "hex": "E34F26",
-            "source": "http://www.w3.org/html/logo/"
+            "source": "https://www.w3.org/html/logo/"
         },
         {
             "title": "HTTPie",
@@ -5473,7 +5473,7 @@
             "title": "Jabber",
             "hex": "CC0000",
             "source": "https://commons.wikimedia.org/wiki/File:Jabber-bulb.svg",
-            "guidelines": "http://www.jabber.org/faq.html#logo",
+            "guidelines": "https://www.jabber.org/faq.html#logo",
             "license": {
                 "type": "CC-BY-2.5"
             }
@@ -5525,8 +5525,8 @@
         {
             "title": "Jeep",
             "hex": "000000",
-            "source": "http://www.fcaci.com/x/JEEPv15",
-            "guidelines": "http://www.fcaci.com/x/JEEPv15"
+            "source": "https://www.fcaci.com/x/JEEPv15",
+            "guidelines": "https://www.fcaci.com/x/JEEPv15"
         },
         {
             "title": "Jekyll",
@@ -5989,8 +5989,8 @@
         {
             "title": "Komoot",
             "hex": "6AA127",
-            "source": "http://newsroom.komoot.com/media_kits/219423/",
-            "guidelines": "http://newsroom.komoot.com/media_kits/219423/"
+            "source": "https://newsroom.komoot.com/media_kits/219423/",
+            "guidelines": "https://newsroom.komoot.com/media_kits/219423/"
         },
         {
             "title": "Konami",
@@ -6282,8 +6282,8 @@
         {
             "title": "LINE",
             "hex": "00C300",
-            "source": "http://line.me/en/logo",
-            "guidelines": "http://line.me/en/logo"
+            "source": "https://line.me/en/logo",
+            "guidelines": "https://line.me/en/logo"
         },
         {
             "title": "LineageOS",
@@ -6379,7 +6379,7 @@
         {
             "title": "LiveJournal",
             "hex": "00B0EA",
-            "source": "http://www.livejournal.com"
+            "source": "https://www.livejournal.com"
         },
         {
             "title": "Livewire",
@@ -6522,7 +6522,7 @@
         {
             "title": "Magento",
             "hex": "EE672F",
-            "source": "http://magento.com"
+            "source": "https://magento.com"
         },
         {
             "title": "Magisk",
@@ -6537,8 +6537,8 @@
         {
             "title": "MailChimp",
             "hex": "FFE01B",
-            "source": "http://mailchimp.com/about/brand-assets",
-            "guidelines": "http://mailchimp.com/about/brand-assets"
+            "source": "https://mailchimp.com/about/brand-assets",
+            "guidelines": "https://mailchimp.com/about/brand-assets"
         },
         {
             "title": "Mailgun",
@@ -6554,7 +6554,7 @@
         {
             "title": "MakerBot",
             "hex": "FF1E0D",
-            "source": "http://www.makerbot.com/makerbot-press-assets"
+            "source": "https://www.makerbot.com/makerbot-press-assets"
         },
         {
             "title": "MAMP",
@@ -6675,7 +6675,7 @@
         {
             "title": "Matternet",
             "hex": "261C29",
-            "source": "http://mttr.net"
+            "source": "https://mttr.net"
         },
         {
             "title": "Max",
@@ -6813,7 +6813,7 @@
         {
             "title": "Meteor",
             "hex": "DE4F4F",
-            "source": "http://logo.meteorapp.com/"
+            "source": "https://logo.meteorapp.com/"
         },
         {
             "title": "Metro",
@@ -6853,7 +6853,7 @@
         {
             "title": "Microgenetics",
             "hex": "FF0000",
-            "source": "http://microgenetics.co.uk/"
+            "source": "https://microgenetics.co.uk/"
         },
         {
             "title": "MicroPython",
@@ -7313,7 +7313,7 @@
         {
             "title": "NetApp",
             "hex": "0067C5",
-            "source": "http://www.netapp.com/",
+            "source": "https://www.netapp.com/",
             "guidelines": "https://www.netapp.com/company/legal/trademark-guidelines/"
         },
         {
@@ -7643,7 +7643,7 @@
         {
             "title": "OCaml",
             "hex": "EC6813",
-            "source": "http://ocaml.org/img/OCaml_Sticker.svg",
+            "source": "https://ocaml.org/img/OCaml_Sticker.svg",
             "guidelines": "https://ocaml.org/docs/logos.html",
             "license": {
                 "type": "Unlicense"
@@ -8099,7 +8099,7 @@
         {
             "title": "Parity Substrate",
             "hex": "282828",
-            "source": "http://substrate.dev/"
+            "source": "https://substrate.dev/"
         },
         {
             "title": "Parse.ly",
@@ -8110,7 +8110,7 @@
         {
             "title": "Passport",
             "hex": "34E27A",
-            "source": "http://www.passportjs.org/"
+            "source": "https://www.passportjs.org/"
         },
         {
             "title": "Pastebin",
@@ -8179,8 +8179,8 @@
         {
             "title": "Pepsi",
             "hex": "2151A1",
-            "source": "http://gillettepepsicola.com/promotions-media/media-kit/",
-            "guidelines": "http://gillettepepsicola.com/promotions-media/media-kit/"
+            "source": "https://gillettepepsicola.com/promotions-media/media-kit/",
+            "guidelines": "https://gillettepepsicola.com/promotions-media/media-kit/"
         },
         {
             "title": "Percy",
@@ -8256,7 +8256,7 @@
         {
             "title": "PHP",
             "hex": "777BB4",
-            "source": "http://php.net/download-logos.php",
+            "source": "https://php.net/download-logos.php",
             "license": {
                 "type": "CC-BY-SA-4.0"
             }
@@ -9144,8 +9144,8 @@
         {
             "title": "Ram",
             "hex": "000000",
-            "source": "http://www.fcaci.com/x/RAMv15",
-            "guidelines": "http://www.fcaci.com/x/RAMv15"
+            "source": "https://www.fcaci.com/x/RAMv15",
+            "guidelines": "https://www.fcaci.com/x/RAMv15"
         },
         {
             "title": "Rancher",
@@ -9639,7 +9639,7 @@
         {
             "title": "Ruby on Rails",
             "hex": "CC0000",
-            "source": "http://rubyonrails.org/",
+            "source": "https://rubyonrails.org/",
             "guidelines": "https://rubyonrails.org/trademarks/"
         },
         {
@@ -9738,7 +9738,7 @@
         {
             "title": "San Francisco Municipal Railway",
             "hex": "BA0C2F",
-            "source": "http://www.actransit.org/wp-content/uploads/HSP_CC-sched.pdf"
+            "source": "https://www.actransit.org/wp-content/uploads/HSP_CC-sched.pdf"
         },
         {
             "title": "SanDisk",
@@ -9758,8 +9758,8 @@
         {
             "title": "Sass",
             "hex": "CC6699",
-            "source": "http://sass-lang.com/styleguide/brand",
-            "guidelines": "http://sass-lang.com/styleguide/brand",
+            "source": "https://sass-lang.com/styleguide/brand",
+            "guidelines": "https://sass-lang.com/styleguide/brand",
             "license": {
                 "type": "CC-BY-NC-SA-3.0"
             }
@@ -9927,8 +9927,8 @@
         {
             "title": "Sencha",
             "hex": "86BC40",
-            "source": "http://design.sencha.com/",
-            "guidelines": "http://design.sencha.com/productlogo.html"
+            "source": "https://design.sencha.com/",
+            "guidelines": "https://design.sencha.com/productlogo.html"
         },
         {
             "title": "Sennheiser",
@@ -9959,7 +9959,7 @@
         {
             "title": "Server Fault",
             "hex": "E7282D",
-            "source": "http://stackoverflow.com/company/logos",
+            "source": "https://stackoverflow.com/company/logos",
             "guidelines": "https://stackoverflow.com/legal/trademark-guidance"
         },
         {
@@ -10116,7 +10116,7 @@
         {
             "title": "SitePoint",
             "hex": "258AAF",
-            "source": "http://www.sitepoint.com"
+            "source": "https://www.sitepoint.com"
         },
         {
             "title": "Sketch",
@@ -10163,7 +10163,7 @@
         {
             "title": "Skype",
             "hex": "00AFF0",
-            "source": "http://blogs.skype.com/?attachment_id=56273"
+            "source": "https://blogs.skype.com/?attachment_id=56273"
         },
         {
             "title": "Skype for Business",
@@ -10407,7 +10407,7 @@
         {
             "title": "Spacemacs",
             "hex": "9266CC",
-            "source": "http://spacemacs.org/",
+            "source": "https://spacemacs.org/",
             "license": {
                 "type": "CC-BY-SA-4.0"
             }
@@ -10560,7 +10560,7 @@
             "title": "Squarespace",
             "hex": "000000",
             "source": "https://www.squarespace.com/logo-guidelines",
-            "guidelines": "http://www.squarespace.com/brand-guidelines"
+            "guidelines": "https://www.squarespace.com/brand-guidelines"
         },
         {
             "title": "SSRN",
@@ -10570,7 +10570,7 @@
         {
             "title": "Stack Exchange",
             "hex": "1E5397",
-            "source": "http://stackoverflow.com/company/logos",
+            "source": "https://stackoverflow.com/company/logos",
             "guidelines": "https://stackoverflow.com/legal/trademark-guidance"
         },
         {
@@ -10714,7 +10714,7 @@
         {
             "title": "Stencyl",
             "hex": "8E1C04",
-            "source": "http://www.stencyl.com/about/press/"
+            "source": "https://www.stencyl.com/about/press/"
         },
         {
             "title": "Stimulus",
@@ -10782,7 +10782,7 @@
         {
             "title": "StubHub",
             "hex": "003168",
-            "source": "http://www.stubhub.com"
+            "source": "https://www.stubhub.com"
         },
         {
             "title": "styled-components",
@@ -10822,7 +10822,7 @@
         {
             "title": "Subversion",
             "hex": "809CC9",
-            "source": "http://subversion.apache.org/logo"
+            "source": "https://subversion.apache.org/logo"
         },
         {
             "title": "suckless",
@@ -11328,7 +11328,7 @@
         {
             "title": "Tinder",
             "hex": "FF6B6B",
-            "source": "http://www.gotinder.com/press"
+            "source": "https://www.gotinder.com/press"
         },
         {
             "title": "TinyLetter",
@@ -11601,7 +11601,7 @@
         {
             "title": "Twoo",
             "hex": "FF7102",
-            "source": "http://www.twoo.com/about/press"
+            "source": "https://www.twoo.com/about/press"
         },
         {
             "title": "Typeform",
@@ -12024,7 +12024,7 @@
         {
             "title": "VLC media player",
             "hex": "FF8800",
-            "source": "http://git.videolan.org/?p=vlc.git;a=tree;f=extras/package/macosx/asset_sources"
+            "source": "https://git.videolan.org/?p=vlc.git;a=tree;f=extras/package/macosx/asset_sources"
         },
         {
             "title": "VMware",
@@ -12268,7 +12268,7 @@
         {
             "title": "WEBTOON",
             "hex": "00D564",
-            "source": "http://webtoons.com/"
+            "source": "https://webtoons.com/"
         },
         {
             "title": "WeChat",
@@ -12421,7 +12421,7 @@
         {
             "title": "Wire",
             "hex": "000000",
-            "source": "http://brand.wire.com",
+            "source": "https://brand.wire.com",
             "guidelines": "https://brand.wire.com/"
         },
         {
@@ -12454,7 +12454,7 @@
         {
             "title": "Wix",
             "hex": "0C6EFC",
-            "source": "http://www.wix.com/about/design-assets"
+            "source": "https://www.wix.com/about/design-assets"
         },
         {
             "title": "Wizz Air",
@@ -12464,17 +12464,17 @@
         {
             "title": "Wolfram",
             "hex": "DD1100",
-            "source": "http://company.wolfram.com/press-center/wolfram-corporate/"
+            "source": "https://company.wolfram.com/press-center/wolfram-corporate/"
         },
         {
             "title": "Wolfram Language",
             "hex": "DD1100",
-            "source": "http://company.wolfram.com/press-center/language/"
+            "source": "https://company.wolfram.com/press-center/language/"
         },
         {
             "title": "Wolfram Mathematica",
             "hex": "DD1100",
-            "source": "http://company.wolfram.com/press-center/mathematica/"
+            "source": "https://company.wolfram.com/press-center/mathematica/"
         },
         {
             "title": "Woo",

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -28,6 +28,8 @@ const TITLE_TO_SLUG_CHARS_REGEX = RegExp(
 
 const TITLE_TO_SLUG_RANGE_REGEX = /[^a-z0-9]/g;
 
+export const URL_REGEX = /^https:\/\/[^\s]+$/;
+
 /**
  * Get the slug/filename for an icon.
  * @param {Object} icon The icon data as it appears in _data/simple-icons.json

--- a/tests/docs.test.js
+++ b/tests/docs.test.js
@@ -5,6 +5,7 @@ import { strict as assert } from 'node:assert';
 import {
   getThirdPartyExtensions,
   getDirnameFromImportMeta,
+  URL_REGEX,
 } from '../scripts/utils.js';
 
 const __dirname = getDirnameFromImportMeta(import.meta.url);
@@ -62,4 +63,27 @@ test('README third party extensions must be alphabetically sorted', async () => 
     expectedOrder,
     'Wrong alphabetical order of third party extensions in README.',
   );
+});
+
+test('Only allow HTTPS links in documentation pages', async () => {
+  const ignoreHttpLinks = ['http://www.w3.org/2000/svg'];
+
+  const docsFiles = fs
+    .readdirSync(root)
+    .filter((fname) => fname.endsWith('.md'));
+
+  const linksGetter = new RegExp('http://[^\\s"\']+', 'g');
+  for (let docsFile of docsFiles) {
+    const docsFilePath = path.join(root, docsFile);
+    const docsFileContent = fs.readFileSync(docsFilePath, 'utf8');
+
+    Array.from(docsFileContent.matchAll(linksGetter)).forEach((match) => {
+      const link = match[0];
+      assert.ok(
+        ignoreHttpLinks.includes(link) || link.startsWith('https://'),
+        `Link '${link}' in '${docsFile}' (at index ${match.index})` +
+          ` must use the HTTPS protocol.`,
+      );
+    });
+  }
 });

--- a/tests/test-icon.js
+++ b/tests/test-icon.js
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'mocha';
+import { URL_REGEX } from '../scripts/utils.js';
 
 const iconsDir = path.resolve(process.cwd(), 'icons');
 
@@ -29,6 +30,7 @@ export const testIcon = (icon, subject, slug) => {
 
     it('has the correct "source"', () => {
       assert.equal(subject.source, icon.source);
+      assert.match(subject.source, URL_REGEX);
     });
 
     it('has an "svg" value', () => {
@@ -53,7 +55,7 @@ export const testIcon = (icon, subject, slug) => {
         if (icon.license.type === 'custom') {
           assert.equal(subject.license.url, icon.license.url);
         } else {
-          assert.match(subject.license.url, /^https?:\/\/[^\s]+$/);
+          assert.match(subject.license.url, URL_REGEX);
         }
       } else {
         assert.equal(subject.license, undefined);


### PR DESCRIPTION
Changed all URLs to use `https://` and tests to forbid `http://` protocol in URLs. If a URL is not properly secured with a certificate, a screen like the next will appear in the browser:

![image](https://user-images.githubusercontent.com/23049315/192079458-5a835bda-f6e2-4d01-91f3-6e9d80af7787.png)

Closes #7850