### PR TITLE
Add XO linter

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,6 +2,5 @@
 . "$(dirname $0)/_/husky.sh"
 
 git stash -q --keep-index
-npm run format
 git add .
 git stash pop -q

--- a/.xo-config.json
+++ b/.xo-config.json
@@ -1,0 +1,5 @@
+{
+  "prettier": true,
+  "space": 2,
+  "ignores": ["scripts/build/templates/*"]
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export interface SimpleIcon {
+export type SimpleIcon = {
   title: string;
   slug: string;
   svg: string;
@@ -12,12 +12,13 @@ export interface SimpleIcon {
         url: string;
       }
     | undefined;
-}
+};
 
 /**
  * @deprecated The `simple-icons` entrypoint will be removed in the next major. Please switch to using `import * as icons from "simple-icons/icons"` if you need an object with all the icons.
  */
 declare const icons: Record<string, SimpleIcon> & {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   Get(name: string): SimpleIcon;
 };
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "svg-path-segments": "1.0.0",
     "svglint": "2.1.0",
     "svgo": "2.8.0",
-    "svgpath": "2.5.0"
+    "svgpath": "2.5.0",
+    "xo": "^0.52.3"
   },
   "scripts": {
     "build": "node scripts/build/package.js",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "mocha": "10.0.0",
     "named-html-entities-json": "1.0.0",
     "npm-run-all": "4.1.5",
-    "prettier": "2.7.1",
     "rimraf": "3.0.2",
     "svg-path-bbox": "1.2.2",
     "svg-path-segments": "1.0.0",
@@ -61,10 +60,9 @@
   "scripts": {
     "build": "node scripts/build/package.js",
     "clean": "rimraf index.js icons.js icons.mjs icons.d.ts",
-    "format": "prettier --write .",
     "lint": "run-s our-lint jslint jsonlint svglint wslint",
     "our-lint": "node scripts/lint/ourlint.js",
-    "jslint": "prettier --check .",
+    "jslint": "xo",
     "jsonlint": "node scripts/lint/jsonlint.js",
     "svglint": "svglint icons/*.svg --ci --config .svglintrc.mjs",
     "wslint": "editorconfig-checker",
@@ -77,8 +75,5 @@
     "svgo": "svgo --config svgo.config.js",
     "get-filename": "node scripts/get-filename.js",
     "add-icon-data": "node scripts/add-icon-data.js"
-  },
-  "engines": {
-    "node": ">=0.12.18"
   }
 }

--- a/scripts/get-filename.js
+++ b/scripts/get-filename.js
@@ -5,7 +5,8 @@
  * icon SVG filename to standard output.
  */
 
-import { titleToSlug } from './utils.js';
+import process from 'node:process';
+import {titleToSlug} from './utils.js';
 
 if (process.argv.length < 3) {
   console.error('Provide a brand name as argument');
@@ -13,6 +14,7 @@ if (process.argv.length < 3) {
 } else {
   const brandName = process.argv
     .slice(3)
+    // eslint-disable-next-line unicorn/no-array-reduce
     .reduce((acc, arg) => `${acc} ${arg}`, process.argv[2]);
 
   const filename = titleToSlug(brandName);

--- a/scripts/lint/jsonlint.js
+++ b/scripts/lint/jsonlint.js
@@ -4,10 +4,11 @@
  * CLI tool to run jsonschema on the simple-icons.json data file.
  */
 
-import { promises as fs } from 'node:fs';
+import {promises as fs} from 'node:fs';
 import path from 'node:path';
-import { Validator } from 'jsonschema';
-import { getDirnameFromImportMeta, getIconsData } from '../utils.js';
+import process from 'node:process';
+import {Validator} from 'jsonschema';
+import {getDirnameFromImportMeta, getIconsData} from '../utils.js';
 
 const __dirname = getDirnameFromImportMeta(import.meta.url);
 
@@ -19,11 +20,11 @@ const schemaFile = path.resolve(rootDir, '.jsonschema.json');
   const schema = JSON.parse(await fs.readFile(schemaFile, 'utf8'));
 
   const validator = new Validator();
-  const result = validator.validate({ icons }, schema);
+  const result = validator.validate({icons}, schema);
   if (result.errors.length > 0) {
-    result.errors.forEach((error) => {
+    for (const error of result.errors) {
       console.error(error);
-    });
+    }
 
     console.error(
       `Found ${result.errors.length} error(s) in simple-icons.json`,

--- a/scripts/lint/ourlint.js
+++ b/scripts/lint/ourlint.js
@@ -5,8 +5,9 @@
  * linters (e.g. jsonlint/svglint).
  */
 
+import process from 'node:process';
 import fakeDiff from 'fake-diff';
-import { getIconsDataString, normalizeNewlines, collator } from '../utils.js';
+import {getIconsDataString, normalizeNewlines, collator} from '../utils.js';
 
 /**
  * Contains our tests so they can be isolated from each other.
@@ -14,39 +15,43 @@ import { getIconsDataString, normalizeNewlines, collator } from '../utils.js';
  */
 const TESTS = {
   /* Tests whether our icons are in alphabetical order */
-  alphabetical: (data) => {
+  alphabetical(data) {
     const collector = (invalidEntries, icon, index, array) => {
       if (index > 0) {
-        const prev = array[index - 1];
-        const comparison = collator.compare(icon.title, prev.title);
+        const previous = array[index - 1];
+        const comparison = collator.compare(icon.title, previous.title);
         if (comparison < 0) {
           invalidEntries.push(icon);
-        } else if (comparison === 0) {
-          if (prev.slug) {
-            if (!icon.slug || collator.compare(icon.slug, prev.slug) < 0) {
-              invalidEntries.push(icon);
-            }
-          }
+        } else if (
+          comparison === 0 &&
+          previous.slug &&
+          (!icon.slug || collator.compare(icon.slug, previous.slug) < 0)
+        ) {
+          invalidEntries.push(icon);
         }
       }
+
       return invalidEntries;
     };
+
     const format = (icon) => {
       if (icon.slug) {
         return `${icon.title} (${icon.slug})`;
       }
+
       return icon.title;
     };
 
+    // eslint-disable-next-line unicorn/no-array-reduce, unicorn/no-array-callback-reference
     const invalids = data.icons.reduce(collector, []);
-    if (invalids.length) {
+    if (invalids.length > 0) {
       return `Some icons aren't in alphabetical order:
         ${invalids.map((icon) => format(icon)).join(', ')}`;
     }
   },
 
   /* Check the formatting of the data file */
-  prettified: async (data, dataString) => {
+  async prettified(data, dataString) {
     const normalizedDataString = normalizeNewlines(dataString);
     const dataPretty = `${JSON.stringify(data, null, 4)}\n`;
 
@@ -57,19 +62,16 @@ const TESTS = {
   },
 };
 
-// execute all tests and log all errors
-(async () => {
-  const dataString = await getIconsDataString();
-  const data = JSON.parse(dataString);
+// Execute all tests and log all errors
+const dataString = await getIconsDataString();
+const data = JSON.parse(dataString);
 
-  const errors = (
-    await Promise.all(
-      Object.keys(TESTS).map((test) => TESTS[test](data, dataString)),
-    )
-  ).filter(Boolean);
+const testSets = await Promise.all(
+  Object.keys(TESTS).map((test) => TESTS[test](data, dataString)),
+);
+const errors = testSets.filter(Boolean);
 
-  if (errors.length > 0) {
-    errors.forEach((error) => console.error(`\u001b[31m${error}\u001b[0m`));
-    process.exit(1);
-  }
-})();
+if (errors.length > 0) {
+  for (const error of errors) console.error(`\u001B[31m${error}\u001B[0m`);
+  process.exit(1);
+}

--- a/scripts/release/bump-version.js
+++ b/scripts/release/bump-version.js
@@ -6,7 +6,8 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getDirnameFromImportMeta } from '../utils.js';
+import process from 'node:process';
+import {getDirnameFromImportMeta} from '../utils.js';
 
 const __dirname = getDirnameFromImportMeta(import.meta.url);
 
@@ -14,7 +15,7 @@ const rootDir = path.resolve(__dirname, '..', '..');
 const packageJsonFile = path.resolve(rootDir, 'package.json');
 
 const readManifest = (file) => {
-  const manifestRaw = fs.readFileSync(file, 'utf-8');
+  const manifestRaw = fs.readFileSync(file, 'utf8');
   const manifestJson = JSON.parse(manifestRaw);
   return manifestJson;
 };

--- a/scripts/release/update-cdn-urls.js
+++ b/scripts/release/update-cdn-urls.js
@@ -7,7 +7,8 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getDirnameFromImportMeta } from '../utils.js';
+import process from 'node:process';
+import {getDirnameFromImportMeta} from '../utils.js';
 
 const __dirname = getDirnameFromImportMeta(import.meta.url);
 
@@ -17,11 +18,11 @@ const readmeFile = path.resolve(rootDir, 'README.md');
 
 const getMajorVersion = (semVerVersion) => {
   const majorVersionAsString = semVerVersion.split('.')[0];
-  return parseInt(majorVersionAsString);
+  return Number.parseInt(majorVersionAsString, 10);
 };
 
 const getManifest = () => {
-  const manifestRaw = fs.readFileSync(packageJsonFile, 'utf-8');
+  const manifestRaw = fs.readFileSync(packageJsonFile, 'utf8');
   return JSON.parse(manifestRaw);
 };
 
@@ -29,7 +30,7 @@ const updateVersionInReadmeIfNecessary = (majorVersion) => {
   let content = fs.readFileSync(readmeFile).toString();
 
   content = content.replace(
-    /simple-icons@v[0-9]+/g,
+    /simple-icons@v\d+/g,
     `simple-icons@v${majorVersion}`,
   );
 

--- a/scripts/release/update-slugs-table.js
+++ b/scripts/release/update-slugs-table.js
@@ -4,10 +4,10 @@
  * Generates a MarkDown file that lists every brand name and their slug.
  */
 
-import { promises as fs } from 'node:fs';
+import {promises as fs} from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { getIconsData, getIconSlug } from '../utils.js';
+import {fileURLToPath} from 'node:url';
+import {getIconsData, getIconSlug} from '../utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -29,11 +29,11 @@ update the script at '${path.relative(rootDir, __filename)}'.
 (async () => {
   const icons = await getIconsData();
 
-  icons.forEach((icon) => {
+  for (const icon of icons) {
     const brandName = icon.title;
     const brandSlug = getIconSlug(icon);
     content += `| \`${brandName}\` | \`${brandSlug}\` |\n`;
-  });
+  }
 
   await fs.writeFile(slugsFile, content);
 })();

--- a/scripts/release/update-svgs-count.js
+++ b/scripts/release/update-svgs-count.js
@@ -5,9 +5,10 @@
  * at README every time the number of current icons is more than `updateRange`
  * more than the previous milestone.
  */
-import { promises as fs } from 'node:fs';
+import {promises as fs} from 'node:fs';
+import process from 'node:process';
 import path from 'node:path';
-import { getDirnameFromImportMeta, getIconsData } from '../utils.js';
+import {getDirnameFromImportMeta, getIconsData} from '../utils.js';
 
 const regexMatcher = /Over\s(\d+)\s/;
 const updateRange = 100;
@@ -18,20 +19,24 @@ const rootDir = path.resolve(__dirname, '..', '..');
 const readmeFile = path.resolve(rootDir, 'README.md');
 
 (async () => {
-  const readmeContent = await fs.readFile(readmeFile, 'utf-8');
+  const readmeContent = await fs.readFile(readmeFile, 'utf8');
 
   let overNIconsInReadme;
   try {
-    overNIconsInReadme = parseInt(regexMatcher.exec(readmeContent)[1]);
-  } catch (err) {
+    overNIconsInReadme = Number.parseInt(
+      regexMatcher.exec(readmeContent)[1],
+      10,
+    );
+  } catch (error) {
     console.error(
       'Failed to obtain number of SVG icons of current milestone in README:',
-      err,
+      error,
     );
     process.exit(1);
   }
 
-  const nIcons = (await getIconsData()).length;
+  const iconsData = await getIconsData();
+  const nIcons = iconsData.length;
   const newNIcons = overNIconsInReadme + updateRange;
 
   if (nIcons <= newNIcons) {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -5,7 +5,7 @@
 
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
+import {fileURLToPath} from 'node:url';
 
 const TITLE_TO_SLUG_REPLACEMENTS = {
   '+': 'plus',
@@ -21,14 +21,14 @@ const TITLE_TO_SLUG_REPLACEMENTS = {
   ŧ: 't',
 };
 
-const TITLE_TO_SLUG_CHARS_REGEX = RegExp(
+const TITLE_TO_SLUG_CHARS_REGEX = new RegExp(
   `[${Object.keys(TITLE_TO_SLUG_REPLACEMENTS).join('')}]`,
   'g',
 );
 
-const TITLE_TO_SLUG_RANGE_REGEX = /[^a-z0-9]/g;
+const TITLE_TO_SLUG_RANGE_REGEX = /[^a-z\d]/g;
 
-export const URL_REGEX = /^https:\/\/[^\s]+$/;
+export const URL_REGEX = /^https:\/\/\S+$/;
 
 /**
  * Get the slug/filename for an icon.
@@ -78,7 +78,7 @@ export const titleToHtmlFriendly = (brandTitle) =>
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/./g, (char) => {
-      const charCode = char.charCodeAt(0);
+      const charCode = char.codePointAt(0);
       return charCode > 127 ? `&#${charCode};` : char;
     });
 
@@ -89,10 +89,12 @@ export const titleToHtmlFriendly = (brandTitle) =>
  */
 export const htmlFriendlyToTitle = (htmlFriendlyTitle) =>
   htmlFriendlyTitle
-    .replace(/&#([0-9]+);/g, (_, num) => String.fromCharCode(parseInt(num)))
+    .replace(/&#(\d+);/g, (_, number_) =>
+      String.fromCodePoint(Number.parseInt(number_, 10)),
+    )
     .replace(
       /&(quot|amp|lt|gt);/g,
-      (_, ref) => ({ quot: '"', amp: '&', lt: '<', gt: '>' }[ref]),
+      (_, ref) => ({quot: '"', amp: '&', lt: '<', gt: '>'}[ref]),
     );
 
 /**
@@ -103,6 +105,7 @@ export const getIconDataPath = (rootDir) => {
   if (rootDir === undefined) {
     rootDir = path.resolve(getDirnameFromImportMeta(import.meta.url), '..');
   }
+
   return path.resolve(rootDir, '_data', 'simple-icons.json');
 };
 
@@ -163,6 +166,7 @@ export const normalizeColor = (text) => {
   } else if (color.length > 6) {
     color = color.slice(0, 6);
   }
+
   return color;
 };
 
@@ -180,11 +184,11 @@ export const getThirdPartyExtensions = async (readmePath) =>
       const [module, author] = line.split(' | ');
       return {
         module: {
-          name: /\[(.+)\]/.exec(module)[1],
+          name: /\[(.+)]/.exec(module)[1],
           url: /\((.+)\)/.exec(module)[1],
         },
         author: {
-          name: /\[(.+)\]/.exec(author)[1],
+          name: /\[(.+)]/.exec(author)[1],
           url: /\((.+)\)/.exec(author)[1],
         },
       };

--- a/svgo.config.js
+++ b/svgo.config.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line unicorn/prefer-module
 module.exports = {
   multipass: true,
   eol: 'lf',
@@ -62,7 +63,7 @@ module.exports = {
       // Convert basic shapes (such as <circle>) to <path>
       name: 'convertShapeToPath',
       params: {
-        // including <arc>
+        // Including <arc>
         convertArcs: true,
       },
     },
@@ -89,7 +90,7 @@ module.exports = {
       // to the <svg> tag if it's not there already
       name: 'addAttributesToSVGElement',
       params: {
-        attributes: [{ role: 'img', xmlns: 'http://www.w3.org/2000/svg' }],
+        attributes: [{role: 'img', xmlns: 'http://www.w3.org/2000/svg'}],
       },
     },
     'removeOffCanvasPaths',

--- a/tests/docs.test.js
+++ b/tests/docs.test.js
@@ -1,11 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { describe, test } from 'mocha';
-import { strict as assert } from 'node:assert';
+import {strict as assert} from 'node:assert';
+import {describe, test} from 'mocha';
 import {
   getThirdPartyExtensions,
   getDirnameFromImportMeta,
-  URL_REGEX,
 } from '../scripts/utils.js';
 
 const __dirname = getDirnameFromImportMeta(import.meta.url);
@@ -16,7 +15,7 @@ describe('README icons assets must be consistent with Github themes', () => {
   const whiteIconsPath = path.join(root, 'assets', 'readme');
   const whiteIconsFileNames = fs.readdirSync(whiteIconsPath);
 
-  for (let whiteIconFileName of whiteIconsFileNames) {
+  for (const whiteIconFileName of whiteIconsFileNames) {
     const whiteIconPath = path.join(whiteIconsPath, whiteIconFileName);
     const blackIconPath = path.join(
       blackIconsPath,
@@ -66,24 +65,24 @@ test('README third party extensions must be alphabetically sorted', async () => 
 });
 
 test('Only allow HTTPS links in documentation pages', async () => {
-  const ignoreHttpLinks = ['http://www.w3.org/2000/svg'];
+  const ignoreHttpLinks = new Set(['http://www.w3.org/2000/svg']);
 
   const docsFiles = fs
     .readdirSync(root)
     .filter((fname) => fname.endsWith('.md'));
 
-  const linksGetter = new RegExp('http://[^\\s"\']+', 'g');
-  for (let docsFile of docsFiles) {
+  const linksGetter = /http:\/\/b[^\s"']+/g;
+  for (const docsFile of docsFiles) {
     const docsFilePath = path.join(root, docsFile);
     const docsFileContent = fs.readFileSync(docsFilePath, 'utf8');
 
-    Array.from(docsFileContent.matchAll(linksGetter)).forEach((match) => {
+    for (const match of Array.from(docsFileContent.matchAll(linksGetter))) {
       const link = match[0];
       assert.ok(
-        ignoreHttpLinks.includes(link) || link.startsWith('https://'),
+        ignoreHttpLinks.has(link) || link.startsWith('https://'),
         `Link '${link}' in '${docsFile}' (at index ${match.index})` +
           ` must use the HTTPS protocol.`,
       );
-    });
+    }
   }
 });

--- a/tests/icons.test.js
+++ b/tests/icons.test.js
@@ -4,16 +4,16 @@ import {
   slugToVariableName,
 } from '../scripts/utils.js';
 import * as simpleIcons from '../icons.mjs';
-import { testIcon } from './test-icon.js';
+import {testIcon} from './test-icon.js';
 
 (async () => {
   const icons = await getIconsData();
 
-  icons.map((icon) => {
+  for (const icon of icons) {
     const slug = getIconSlug(icon);
     const variableName = slugToVariableName(slug);
     const subject = simpleIcons[variableName];
 
     testIcon(icon, subject, slug);
-  });
+  }
 })();

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,15 +1,16 @@
+import {strict as assert} from 'node:assert';
+import {test} from 'mocha';
 import simpleIcons from '../index.js';
-import { getIconSlug, getIconsData, titleToSlug } from '../scripts/utils.js';
-import { test } from 'mocha';
-import { strict as assert } from 'node:assert';
+import {getIconSlug, getIconsData, titleToSlug} from '../scripts/utils.js';
 
 (async () => {
   const icons = await getIconsData();
 
-  icons.forEach((icon) => {
+  for (const icon of icons) {
     const slug = getIconSlug(icon);
 
     test(`'Get' ${icon.title} by its slug`, () => {
+      // eslint-disable-next-line new-cap
       const found = simpleIcons.Get(slug);
       assert.ok(found);
       assert.equal(found.title, icon.title);
@@ -18,18 +19,18 @@ import { strict as assert } from 'node:assert';
     });
 
     if (icon.slug) {
-      // if an icon data has a slug, it must be different to the
+      // If an icon data has a slug, it must be different to the
       // slug inferred from the title, which prevents adding
       // unnecessary slugs to icons data
       test(`'${icon.title}' slug must be necessary`, () => {
         assert.notEqual(titleToSlug(icon.title), icon.slug);
       });
     }
-  });
+  }
 
   test(`Iterating over simpleIcons only exposes icons`, () => {
     const iconArray = Object.values(simpleIcons);
-    for (let icon of iconArray) {
+    for (const icon of iconArray) {
       assert.ok(icon);
       assert.equal(typeof icon, 'object');
     }

--- a/tests/min-reporter.cjs
+++ b/tests/min-reporter.cjs
@@ -1,6 +1,6 @@
-const { reporters, Runner } = require('mocha');
+const {reporters, Runner} = require('mocha');
 
-const { EVENT_RUN_END } = Runner.constants;
+const {EVENT_RUN_END} = Runner.constants;
 
 class EvenMoreMin extends reporters.Base {
   constructor(runner) {

--- a/tests/test-icon.js
+++ b/tests/test-icon.js
@@ -1,8 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { strict as assert } from 'node:assert';
-import { describe, it } from 'mocha';
-import { URL_REGEX } from '../scripts/utils.js';
+import process from 'node:process';
+import {strict as assert} from 'node:assert';
+import {describe, it} from 'mocha';
+import {URL_REGEX} from '../scripts/utils.js';
 
 const iconsDir = path.resolve(process.cwd(), 'icons');
 
@@ -38,7 +39,7 @@ export const testIcon = (icon, subject, slug) => {
     });
 
     it('has a valid "path" value', () => {
-      assert.match(subject.path, /^[MmZzLlHhVvCcSsQqTtAaEe0-9-,.\s]+$/g);
+      assert.match(subject.path, /^[MmZzLlHhVvCcSsQqTtAaEe\d-,.\s]+$/g);
     });
 
     it(`has ${icon.guidelines ? 'the correct' : 'no'} "guidelines"`, () => {


### PR DESCRIPTION
[![XO code style](https://shields.io/badge/code_style-5ed9c7?logo=xo&labelColor=gray)](https://github.com/xojs/xo)

Resolves #7870 

### Why [XO](https://github.com/xojs/xo)?

XO has built-in support for TypeScript and Prettier. And it's designed for ESM projects.

For more features, you can find them at https://github.com/xojs/xo#highlights.

### Linting errors

<details>
<summary>Click here to see linting errors</summary>

[xo-summary](https://github.com/LitoMore/xo-summary) is a tool for displaying output from `xo` as a list of style errors, ordered by count.

```
❯ npm i -g xo-summary
❯ npx xo | xo-summary
174    Block-scoped variables in strict mode are not supported until Node.js 4.0.0. The configured version range is >=0.12.18.
92     Arrow functions are not supported until Node.js 4.0.0. The configured version range is >=0.12.18.
41     Template literals are not supported until Node.js 4.0.0. The configured version range is >=0.12.18.
21     Trailing commas in function syntax are not supported until Node.js 8.0.0. The configured version range is >=0.12.18.
16     Async functions are not supported until Node.js 7.6.0. The configured version range is >=0.12.18.
13     Unexpected use of the global variable process. Use require("process") instead.
11     Expected blank line before this statement.
9      Destructuring is not supported until Node.js 6.0.0. The configured version range is >=0.12.18.
8      Comments should not begin with a lowercase character.
6      Use for…of instead of Array#forEach(…).
4      Replace ·promises·as·fs· with promises·as·fs
4      Property shorthands are not supported until Node.js 4.0.0. The configured version range is >=0.12.18.
3      Do not access a member directly from an await expression.
3      Prefer Number.parseInt() over parseInt().
3      Missing radix parameter.
3      Replace ·strict·as·assert· with strict·as·assert
3      Rest/spread properties are not supported until Node.js 8.3.0. The configured version range is >=0.12.18.
3      Expected method shorthand.
3      Prefer utf8 over utf-8.
2      Replace ·fileURLToPath· with fileURLToPath
2      /\[(.+)\]/ can be optimized to /\[(.+)]/.
2      Replace ·hasLicense· with hasLicense
2      Unexpected if as the only statement in a if block without else.
2      Array#reduce() is not allowed
2      Use uppercase characters for the value of the escape sequence.
2      Replace ·getDirnameFromImportMeta· with getDirnameFromImportMeta
2      Replace ·getDirnameFromImportMeta,·getIconsData· with getDirnameFromImportMeta,·getIconsData
1      Replace ·transform·as·esbuildTransform· with transform·as·esbuildTransform
1      RegExp lookbehind assertions are not supported until Node.js 8.10.0. The configured version range is >=0.12.18.
1      Replace ·code· with code
1      Replace ·icon,·iconObject,·iconExportName· with icon,·iconObject,·iconExportName
1      Replace ·iconObject,·iconExportName· with iconObject,·iconExportName
1      Replace ·icon· with icon
1      Use new RegExp() instead of RegExp().
1      /[^a-z0-9]/g can be optimized to /[^a-z\d]/g.
1      /^https:\/\/[^\s]+$/ can be optimized to /^https:\/\/\S+$/.
1      Prefer String#codePointAt() over String#charCodeAt().
1      /&#([0-9]+);/g can be optimized to /&#(\d+);/g.
1      The variable num should be named number_. A more descriptive name will do too.
1      Prefer String.fromCodePoint() over String.fromCharCode().
1      Replace ·quot:·'"',·amp:·'&',·lt:·'<',·gt:·'>'· with quot:·'"',·amp:·'&',·lt:·'<',·gt:·'>'
1      Spread elements are not supported until Node.js 5.0.0. The configured version range is >=0.12.18.
1      Replace ·describe,·test· with describe,·test
1      node:assert import should occur before import of mocha
1      URL_REGEX is defined but never used.
1      whiteIconFileName is never reassigned. Use const instead.
1      ignoreHttpLinks should be a Set, and use ignoreHttpLinks.has() to check existence or non-existence.
1      Use a regular expression literal instead of the RegExp constructor.
1      docsFile is never reassigned. Use const instead.
1      The Array.from is not supported until Node.js 4.0.0. The configured version range is >=0.12.18.
1      fs is defined but never used.
1      getIconDataPath is defined but never used.
1      /^#?[a-f0-9]{3,8}$/i can be optimized to /^#?[a-f\d]{3,8}$/i.
1      Prefer .some(…) over .find(…).
1      Replace ·guidelines:·answers.guidelines· with guidelines:·answers.guidelines
1      Replace ·url:·answers.licenseUrl· with url:·answers.licenseUrl
1      Replace ·hasGuidelines· with hasGuidelines
1      method validate is equivalent to Boolean. Use Boolean directly.
1      Redundant Boolean call.
1      Only use process.exit() in CLI apps. Throw an error instead.
1      Replace ·getIconsDataString,·normalizeNewlines,·collator· with getIconsDataString,·normalizeNewlines,·collator
1      The variable prev should be named previous. A more descriptive name will do too.
1      Do not pass function collector directly to .reduce(…).
1      Use .length > 0 when checking length is not zero.
1      /simple-icons@v[0-9]+/g can be optimized to /simple-icons@v\d+/g.
1      Replace ·getIconSlug,·getIconsData,·titleToSlug· with getIconSlug,·getIconsData,·titleToSlug
1      mocha import should occur before import of ../index.js
1      Replace ·test· with test
1      node:assert import should occur before import of ../index.js
1      A function with a name starting with an uppercase letter should only be used as a constructor.
1      The Object.values is not supported until Node.js 7.0.0. The configured version range is >=0.12.18.
1      icon is never reassigned. Use const instead.
1      The catch parameter err should be named error.
1      The variable err should be named error. A more descriptive name will do too.
1      Replace ·describe,·it· with describe,·it
1      Replace ·URL_REGEX· with URL_REGEX
1      /^[MmZzLlHhVvCcSsQqTtAaEe0-9-,.\s]+$/g can be optimized to /^[MmZzLlHhVvCcSsQqTtAaEe\d-,.\s]+$/g.
1      Replace ·Validator· with Validator
1      Replace ·icons· with icons
1      Replace ·getIconsData,·getIconSlug· with getIconsData,·getIconSlug
1      Replace ·titleToSlug· with titleToSlug
1      Replace ·testIcon· with testIcon
1      Array.prototype.map() expects a return value from arrow function.
1      Replace ·reporters,·Runner· with reporters,·Runner
1      Replace ·EVENT_RUN_END· with EVENT_RUN_END
1      Classes in strict mode are not supported until Node.js 4.0.0. The configured version range is >=0.12.18.
1      Use a type instead of an interface.
1      Type Method name Get must match one of the following formats: strictCamelCase
1      Do not use "module".
1      Replace ·role:·'img',·xmlns:·'http://www.w3.org/2000/svg'· with role:·'img',·xmlns:·'http://www.w3.org/2000/svg'
```

After `npx xo --fix`

```
❯ npx xo | xo-summary
13     Unexpected use of the global variable process. Use require("process") instead.
3      Do not access a member directly from an await expression.
3      Missing radix parameter.
2      Array#reduce() is not allowed
1      fs is defined but never used.
1      getIconDataPath is defined but never used.
1      Prefer .some(…) over .find(…).
1      Only use process.exit() in CLI apps. Throw an error instead.
1      Do not pass function collector directly to .reduce(…).
1      Prefer String#codePointAt() over String#charCodeAt().
1      Prefer String.fromCodePoint() over String.fromCharCode().
1      URL_REGEX is defined but never used.
1      Use a regular expression literal instead of the RegExp constructor.
1      Type Method name Get must match one of the following formats: strictCamelCase
1      Do not use "module".
1      Array.prototype.map() expects a return value from arrow function.
1      A function with a name starting with an uppercase letter should only be used as a constructor.
```

</details>

### Editor setup

#### VS Code

```json
{
  "xo.enable": true,
  "xo.format.enable": true,
  "editor.formatOnSave": true,
  "editor.defaultFormatter": "samverschueren.linter-xo"
}
```

For other editors, see https://github.com/xojs/xo#editor-plugins.