### PR TITLE
Check Github sources without hash using JSONSchema

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3,7 +3,7 @@
         {
             "title": ".NET",
             "hex": "512BD4",
-            "source": "https://github.com/dotnet/brand/"
+            "source": "https://github.com/dotnet/brand/tree/defe0408e765b48223a434a0d9a94213edc062f8"
         },
         {
             "title": "/e/",
@@ -928,7 +928,7 @@
         {
             "title": "asciinema",
             "hex": "D40000",
-            "source": "https://github.com/asciinema/asciinema-logo"
+            "source": "https://github.com/asciinema/asciinema-logo/tree/1c743621830c0d8c92fd0076b4f15f75b4cf79f4"
         },
         {
             "title": "ASDA",
@@ -1544,7 +1544,7 @@
         {
             "title": "Bulma",
             "hex": "00D1B2",
-            "source": "https://github.com/jgthms/bulma/"
+            "source": "https://github.com/jgthms/bulma/tree/b0ed28b0e63fdfe54ef802ad155c889241fb6ae1"
         },
         {
             "title": "bunq",
@@ -1595,7 +1595,7 @@
         {
             "title": "C++",
             "hex": "00599C",
-            "source": "https://github.com/isocpp/logos"
+            "source": "https://github.com/isocpp/logos/tree/64ef037049f87ac74875dbe72695e59118b52186"
         },
         {
             "title": "Cachet",
@@ -1985,7 +1985,7 @@
         {
             "title": "CocoaPods",
             "hex": "EE3322",
-            "source": "https://github.com/CocoaPods/shared_resources",
+            "source": "https://github.com/CocoaPods/shared_resources/tree/3125baf19976bd240c86459645f45b68d2facd10",
             "license": {
                 "type": "CC-BY-NC-4.0"
             }
@@ -2089,7 +2089,7 @@
         {
             "title": "Coderwall",
             "hex": "3E8DCC",
-            "source": "https://github.com/twolfson/coderwall-svg"
+            "source": "https://github.com/twolfson/coderwall-svg/tree/e87fb90eab5e401210a174f9418b5af0a246758e"
         },
         {
             "title": "CodeSandbox",
@@ -2104,7 +2104,7 @@
         {
             "title": "Codewars",
             "hex": "B1361E",
-            "source": "https://github.com/codewars/branding"
+            "source": "https://github.com/codewars/branding/tree/1ff0d44db52ac4a5e3a1c43277dc35f228eb6983"
         },
         {
             "title": "Coding Ninjas",
@@ -2180,7 +2180,7 @@
         {
             "title": "Conda-Forge",
             "hex": "000000",
-            "source": "https://github.com/conda-forge/conda-forge.github.io/"
+            "source": "https://github.com/conda-forge/conda-forge.github.io/tree/0fc7dac2b989f3601dcc1be8a9f92c5b617c291e"
         },
         {
             "title": "Conekta",
@@ -2407,7 +2407,7 @@
         {
             "title": "D3.js",
             "hex": "F9A03C",
-            "source": "https://github.com/d3/d3-logo"
+            "source": "https://github.com/d3/d3-logo/tree/6d9c471aa852033501d00ca63fe73d9f8be82d1d"
         },
         {
             "title": "Dacia",
@@ -2845,7 +2845,7 @@
         {
             "title": "Drone",
             "hex": "212121",
-            "source": "https://github.com/drone/brand"
+            "source": "https://github.com/drone/brand/tree/f3ba7a1ad3c35abfe9571ea9c3ea93dff9912955"
         },
         {
             "title": "Drooble",
@@ -3190,7 +3190,7 @@
         {
             "title": "Event Store",
             "hex": "5AB552",
-            "source": "https://github.com/eventstore/brand"
+            "source": "https://github.com/EventStore/Brand/tree/319d6f8dadc2881062917ea5a6dafa675775ea85"
         },
         {
             "title": "Eventbrite",
@@ -3959,11 +3959,10 @@
         {
             "title": "GNU Bash",
             "hex": "4EAA25",
-            "source": "https://github.com/odb/official-bash-logo",
+            "source": "https://github.com/odb/official-bash-logo/tree/61eff022f2dad3c7468f5deb4f06652d15f2c143",
             "guidelines": "https://github.com/odb/official-bash-logo",
             "license": {
-                "type": "custom",
-                "url": "http://artlibre.org/licence/lal/en/"
+                "type": "MIT"
             }
         },
         {
@@ -5041,7 +5040,10 @@
         {
             "title": "IPFS",
             "hex": "65C2CB",
-            "source": "https://github.com/ipfs/logo"
+            "source": "https://github.com/ipfs-inactive/logo/tree/73169b495332415b174ac2f37ec27c4b2ee8da83",
+            "license": {
+                "type": "CC-BY-SA-3.0"
+            }
         },
         {
             "title": "Issuu",
@@ -5119,7 +5121,7 @@
         {
             "title": "JavaScript",
             "hex": "F7DF1E",
-            "source": "https://github.com/voodootikigod/logo.js",
+            "source": "https://github.com/voodootikigod/logo.js/tree/1544bdeed6d618a6cfe4f0650d04ab8d9cfa76d9",
             "license": {
                 "type": "MIT"
             }
@@ -5167,7 +5169,7 @@
         {
             "title": "Jenkins X",
             "hex": "73C3D5",
-            "source": "https://github.com/cdfoundation/artwork"
+            "source": "https://github.com/cdfoundation/artwork/tree/358a7db882463b68f59ae9bc669b8f97c4539ffd"
         },
         {
             "title": "Jest",
@@ -5413,7 +5415,7 @@
         {
             "title": "KeePassXC",
             "hex": "6CAC4D",
-            "source": "https://github.com/keepassxreboot/keepassxc/"
+            "source": "https://github.com/keepassxreboot/keepassxc/tree/3fdafc6d25e85050976e0cc645db579086db3f45"
         },
         {
             "title": "Kentico",
@@ -5657,7 +5659,7 @@
         {
             "title": "Laravel",
             "hex": "FF2D20",
-            "source": "https://github.com/laravel/art"
+            "source": "https://github.com/laravel/art/tree/5a8325b064634b900f25dbb6f1cafd888b2d2211"
         },
         {
             "title": "Laravel Horizon",
@@ -5683,7 +5685,7 @@
         {
             "title": "LaTeX",
             "hex": "008080",
-            "source": "https://github.com/latex3/branding"
+            "source": "https://github.com/latex3/branding/tree/9def6b5f6075567d62b67424e11dbe6d4d5245b4"
         },
         {
             "title": "Launchpad",
@@ -6119,7 +6121,7 @@
         {
             "title": "Markdown",
             "hex": "000000",
-            "source": "https://github.com/dcurtis/markdown-mark",
+            "source": "https://github.com/dcurtis/markdown-mark/tree/360a3657fef7f6ad0b303296a95ad52985caa0d3",
             "guidelines": "https://github.com/dcurtis/markdown-mark",
             "license": {
                 "type": "CC0-1.0"
@@ -8042,7 +8044,7 @@
         {
             "title": "PowerShell",
             "hex": "5391FE",
-            "source": "https://github.com/PowerShell/PowerShell"
+            "source": "https://github.com/PowerShell/PowerShell/tree/11d7587f9b934cf27013d318886f97fb95c811cf"
         },
         {
             "title": "pr.co",
@@ -8099,7 +8101,7 @@
         {
             "title": "Prisma",
             "hex": "2D3748",
-            "source": "https://github.com/prisma/presskit"
+            "source": "https://github.com/prisma/presskit/tree/4bcb64181f266723439d955d60afa1c55fefa715"
         },
         {
             "title": "Prismic",
@@ -8240,7 +8242,7 @@
         {
             "title": "PureScript",
             "hex": "14161A",
-            "source": "https://github.com/purescript/logo",
+            "source": "https://github.com/purescript/logo/tree/1e7a57affdaeaf88ff594c08bd2b5a78fe2ed13c",
             "license": {
                 "type": "CC-BY-4.0"
             }
@@ -8428,7 +8430,7 @@
         {
             "title": "QuickLook",
             "hex": "22A2E3",
-            "source": "https://github.com/QL-Win/QuickLook/"
+            "source": "https://github.com/QL-Win/QuickLook/tree/f726841d99bbceafd5399e5777b4dba302bf1e51"
         },
         {
             "title": "QuickTime",
@@ -8589,7 +8591,7 @@
         {
             "title": "ReactOS",
             "hex": "0088CC",
-            "source": "https://github.com/reactos/press-media"
+            "source": "https://github.com/reactos/press-media/tree/48089e09e0c7e828f1eb81e5ea0d8da85ec41dc3"
         },
         {
             "title": "Read the Docs",
@@ -8822,8 +8824,11 @@
         {
             "title": "Robot Framework",
             "hex": "000000",
-            "source": "https://github.com/robotframework/visual-identity",
-            "guidelines": "https://github.com/robotframework/visual-identity/blob/master/robot-framework-brand-guidelines.pdf"
+            "source": "https://github.com/robotframework/visual-identity/tree/fadf8cda9f79ea31987a214f0047cca9626327b7",
+            "guidelines": "https://github.com/robotframework/visual-identity/blob/master/robot-framework-brand-guidelines.pdf",
+            "license": {
+                "type": "CC-BY-NC-SA-4.0"
+            }
         },
         {
             "title": "Rocket.Chat",
@@ -9525,7 +9530,7 @@
         {
             "title": "Snapcraft",
             "hex": "82BEA0",
-            "source": "https://github.com/snapcore/snap-store-badges",
+            "source": "https://github.com/snapcore/snap-store-badges/tree/eda2cb0495ef7f4d479e231079967c9d27f2bc70",
             "license": {
                 "type": "CC-BY-ND-2.0"
             }
@@ -10015,7 +10020,10 @@
         {
             "title": "Storybook",
             "hex": "FF4785",
-            "source": "https://github.com/storybookjs/brand"
+            "source": "https://github.com/storybookjs/brand/tree/6f4d67f65f8275c53c310a73a8da6c6e96c8488c",
+            "license": {
+                "type": "MIT"
+            }
         },
         {
             "title": "Strapi",
@@ -10365,7 +10373,7 @@
         {
             "title": "Teradata",
             "hex": "F37440",
-            "source": "https://github.com/Teradata/teradata.github.io/"
+            "source": "https://github.com/Teradata/teradata.github.io/tree/0b5124f0c652d7ba006a487c8b4b21bd61150ab2"
         },
         {
             "title": "teratail",
@@ -11001,7 +11009,7 @@
         {
             "title": "V",
             "hex": "5D87BF",
-            "source": "https://github.com/vlang/v-logo",
+            "source": "https://github.com/vlang/v-logo/tree/62dd9fe256f64190b53a306310c4a4cc27398d0f",
             "license": {
                 "type": "MIT"
             }
@@ -11243,12 +11251,11 @@
         {
             "title": "Vue.js",
             "hex": "4FC08D",
-            "source": "https://github.com/vuejs/art",
+            "source": "https://github.com/vuejs/art/tree/d840546f0779f0639ba3fe1cb78e7b04d8127eab",
+            "guidelines": "https://github.com/vuejs/art/blob/master/README.md",
             "license": {
-                "type": "custom",
-                "url": "https://github.com/vuejs/art/blob/master/README.md"
-            },
-            "guidelines": "https://github.com/vuejs/art/blob/master/README.md"
+                "type": "CC-BY-NC-SA-4.0"
+            }
         },
         {
             "title": "Vuetify",
@@ -11346,7 +11353,7 @@
         {
             "title": "WebAuthn",
             "hex": "3423A6",
-            "source": "https://github.com/webauthn-open-source/webauthn-logos",
+            "source": "https://github.com/webauthn-open-source/webauthn-logos/tree/b21be672811eb4a5caadaba41044970cae299a55",
             "guidelines": "https://github.com/webauthn-open-source/webauthn-logos"
         },
         {
@@ -11776,7 +11783,7 @@
         {
             "title": "Yarn",
             "hex": "2C8EBB",
-            "source": "https://github.com/yarnpkg/assets"
+            "source": "https://github.com/yarnpkg/assets/tree/76d30ca2aebed5b73ea8131d972218fb860bd32d"
         },
         {
             "title": "Yelp",
@@ -11935,7 +11942,7 @@
         {
             "title": "Zig",
             "hex": "F7A41D",
-            "source": "https://github.com/ziglang/logo",
+            "source": "https://github.com/ziglang/logo/tree/608770bf7303613c18a8c3faf284516fa31072f0",
             "license": {
                 "type": "CC-BY-SA-4.0"
             }


### PR DESCRIPTION
This is an improvement over #7359 that ensures that no more Github sources without hashes will be added.