### PR TITLE
Fix `aliases` prompt

### DIFF
--- a/scripts/add-icon-data.js
+++ b/scripts/add-icon-data.js
@@ -159,7 +159,7 @@ const dataPrompt = [
     suffix: ' (separate with commas)',
     validate: (text) => Boolean(text),
     transformer: aliasesTransformer,
-    when: (answers) => answers?.aliasesTypes.includes(x.value),
+    when: (answers) => answers?.aliasesTypes?.includes(x.value),
   })),
   {
     type: 'confirm',


### PR DESCRIPTION
Fix the error:

```
file:///path/to/simple-icons/scripts/add-icon-data.js:162
    when: (answers) => answers?.aliasesTypes.includes(x.value),
                                            ^

TypeError: Cannot read properties of undefined (reading 'includes')
```