### PR TITLE
Add Vega icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -12618,6 +12618,16 @@
             "source": "https://www.veepee.fr"
         },
         {
+            "title": "Vega",
+            "hex": "2450B2",
+            "source": "https://github.com/vega/logos/blob/af32bc29f0c09c8de826aaafb037935fb69e960a/assets/VG_Black.svg",
+            "guidelines": "https://github.com/vega/logos",
+            "license": {
+                "type": "custom",
+                "url": "https://github.com/vega/vega/blob/72b9b3bbf912212e7879b6acaccc84aff969ef1c/LICENSE"
+            }
+        },
+        {
             "title": "Velog",
             "hex": "20C997",
             "source": "https://github.com/velopert/velog-client/blob/8fbbb371f4b4525b6747e54d0c608900ea8bf03e/src/static/svg/velog-icon.svg"

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -12623,7 +12623,7 @@
             "source": "https://github.com/vega/logos/blob/af32bc29f0c09c8de826aaafb037935fb69e960a/assets/VG_Black.svg",
             "guidelines": "https://github.com/vega/logos",
             "license": {
-                "type": "BSD-3-Clause",
+                "type": "BSD-3-Clause"
             }
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -12624,7 +12624,6 @@
             "guidelines": "https://github.com/vega/logos",
             "license": {
                 "type": "BSD-3-Clause",
-                "url": "https://github.com/vega/logos/blob/af32bc29f0c09c8de826aaafb037935fb69e960a/LICENSE"
             }
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -12623,7 +12623,7 @@
             "source": "https://github.com/vega/logos/blob/af32bc29f0c09c8de826aaafb037935fb69e960a/assets/VG_Black.svg",
             "guidelines": "https://github.com/vega/logos",
             "license": {
-                "type": "custom",
+                "type": "BSD-3-Clause",
                 "url": "https://github.com/vega/vega/blob/72b9b3bbf912212e7879b6acaccc84aff969ef1c/LICENSE"
             }
         },

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -12624,7 +12624,7 @@
             "guidelines": "https://github.com/vega/logos",
             "license": {
                 "type": "BSD-3-Clause",
-                "url": "https://github.com/vega/vega/blob/72b9b3bbf912212e7879b6acaccc84aff969ef1c/LICENSE"
+                "url": "https://github.com/vega/logos/blob/af32bc29f0c09c8de826aaafb037935fb69e960a/LICENSE"
             }
         },
         {

--- a/icons/vega.svg
+++ b/icons/vega.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Vega</title><path d="M19.39 8.693H24l-3.123-6.68ZM6.68 1.987H0L7.098 22.03h.008l2.86-10.73zm14.197-.016-7.098 20.042h-6.68L14.195 1.97"/></svg>


### PR DESCRIPTION
**Issue:** closes #8088

**Popularity Metric**
Vega has 10.1k stars on [its GitHub repository](https://github.com/vega/vega).

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->

The color (`#2450b2`) is the dominant color from the svg file of the [logo with color](https://github.com/vega/logos/blob/master/assets/VG_Color.svg).

:warning: I put `custom` as license type because `BSD-3-Clause` would not pass the linter even though it is a [SPDX License ID](https://spdx.org/licenses/). It looks like something that would require an issue for further investigation.

### Preview

![vega](https://user-images.githubusercontent.com/42720099/204853864-3eddb95d-bea5-4470-9ca4-457e16ffb993.png)

