### PR TITLE
[ADD] Icon Vega Altair

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -12071,6 +12071,15 @@
             "source": "https://www.veepee.fr/"
         },
         {
+            "title": "Vega Altair",
+            "hex": "03A9F4",
+            "source": "https://github.com/altair-viz/altair/blob/68d197e8783db5a53a49a246fc2c2ce0f0205ef7/design/altair-logo-light.svg",
+            "license": {
+                "type": "custom",
+                "url": "https://github.com/altair-viz/altair/blob/master/LICENSE"
+            }
+        },
+        {
             "title": "Velog",
             "hex": "20C997",
             "source": "https://github.com/velopert/velog-client/blob/8fbbb371f4b4525b6747e54d0c608900ea8bf03e/src/static/svg/velog-icon.svg"

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -12075,8 +12075,7 @@
             "hex": "03A9F4",
             "source": "https://github.com/altair-viz/altair/blob/68d197e8783db5a53a49a246fc2c2ce0f0205ef7/design/altair-logo-light.svg",
             "license": {
-                "type": "custom",
-                "url": "https://github.com/altair-viz/altair/blob/master/LICENSE"
+                "type": "BSD-3-Clause"
             }
         },
         {

--- a/icons/vegaaltair.svg
+++ b/icons/vegaaltair.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Vega Altair</title><path d="M17.74 15.478H24v6.957h-6.26zm-4.87-6.956h6.26v13.913h-6.26ZM8 1.565h6.26v20.87H8Zm0 20.87H0l8-20.87Z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/SI-Sandbox/preview/
-->
![vegaaltair](https://user-images.githubusercontent.com/92380416/204852339-955798db-1c01-4529-974d-169d60b63312.png)

**Issue:** closes #8064

**Similarweb rank:**
  <!-- The Similarweb rank can be retrieved at https://www.similarweb.com
       Please see our contributing guidelines for more details on how we
       assess a brand's popularity. -->
The project has 7.9k stars on [its github](https://github.com/altair-viz/altair).

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
- I picked this hexadecimal value because it is the most represented color on the logo of vega altair (light version, currently used on their [website](https://altair-viz.github.io/)).
- I filled in the license in the .json file as "custom" because "BSD-3-Clause" (from [SPDX License ID](https://spdx.org/licenses/)) would not pass the linter with "npm run lint". 