### PR TITLE
Renamed Pytorch Lightning to Lightning

### DIFF
--- a/icons/lightning.svg
+++ b/icons/lightning.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Lightning</title><path d="M12 0L1.75 6v12L12 24l10.25-6V6zm-1.775 18l1.08-4.657-2.428-2.397L13.79 6l-1.082 4.665 2.414 2.384z"/></svg>

--- a/icons/pytorchlightning.svg
+++ b/icons/pytorchlightning.svg
@@ -1,1 +1,0 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>PyTorch Lightning</title><path d="M12 0L1.75 6v12L12 24l10.25-6V6zm-1.775 18l1.08-4.657-2.428-2.397L13.79 6l-1.082 4.665 2.414 2.384z"/></svg>

--- a/slugs.md
+++ b/slugs.md
@@ -1702,7 +1702,7 @@ update the script at 'scripts/release/update-slugs-table.js'.
 | `Pytest` | `pytest` |
 | `Python` | `python` |
 | `PyTorch` | `pytorch` |
-| `PyTorch Lightning` | `pytorchlightning` |
+| `Lightning` | `lightning` |
 | `PyUp` | `pyup` |
 | `Qantas` | `qantas` |
 | `Qatar Airways` | `qatarairways` |


### PR DESCRIPTION
Pytorch Lightning have been renamed. See its [README](https://github.com/Lightning-AI/lightning#readme) for reference.