### PR TITLE
Fix `getThirdPartyExtensions` of SDK when extracting from README shipped with npm package

### DIFF
--- a/sdk.mjs
+++ b/sdk.mjs
@@ -196,9 +196,9 @@ export const getThirdPartyExtensions = async (
       let [module, author] = line.split(' | ');
 
       // README shipped with package has not Github theme image links
-      module = module.includes('<picture>')
-        ? module.split('<picture>')[0]
-        : module.split('<img src="')[1].split(' ').slice(5).join(' ');
+      module = module.split(
+        module.includes('<picture>') ? '<picture>' : '<img src="',
+      )[0];
       return {
         module: {
           name: /\[(.+)\]/.exec(module)[1],


### PR DESCRIPTION
This function was not updated on https://github.com/simple-icons/simple-icons/pull/7983, now this error is being discovered when trying to use the SDK by the simple-icons-website build system.