### PR TITLE
Fix `guidelines` and `license` types on `SimpleIcon` TS interface

### DIFF
--- a/sdk.d.ts
+++ b/sdk.d.ts
@@ -3,6 +3,8 @@
  * Types for Simple Icons SDK.
  */
 
+import type { License } from './types.d.ts';
+
 /**
  * The data for a third-party extension.
  *
@@ -18,25 +20,6 @@ export type ThirdPartyExtension = {
 
 type ThirdPartyExtensionSubject = {
   name: string;
-  url: string;
-};
-
-/**
- * The license for a Simple Icon.
- *
- * Corresponds to the `license` property in the *_data/simple-icons.json* file.
- *
- * @see {@link https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#optional-data Optional Data}
- */
-export type License = SPDXLicense | CustomLicense;
-
-type SPDXLicense = {
-  type: string;
-  url?: string;
-};
-
-type CustomLicense = {
-  type: 'custom';
   url: string;
 };
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,3 +1,23 @@
+/**
+ * The license for a Simple Icon.
+ *
+ * @see {@link https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#optional-data Optional Data}
+ */
+export type License = SPDXLicense | CustomLicense;
+
+type SPDXLicense = {
+  type: string;
+  url?: string;
+};
+
+type CustomLicense = {
+  type: 'custom';
+  url: string;
+};
+
+/**
+ * The data for a Simple Icon as is exported by the npm package.
+ */
 export interface SimpleIcon {
   title: string;
   slug: string;
@@ -5,11 +25,6 @@ export interface SimpleIcon {
   path: string;
   source: string;
   hex: string;
-  guidelines?: string | undefined;
-  license?:
-    | {
-        type: string;
-        url: string;
-      }
-    | undefined;
+  guidelines: string | undefined;
+  license: License | undefined;
 }


### PR DESCRIPTION
Currently, the `SimpleIcon` TypeScript interface is exposing false types for `guidelines` and `license` fields. The question mark `?` [makes them optional](https://www.typescriptlang.org/docs/handbook/2/objects.html#optional-properties), but these fields are always included for all icons by the npm package. You can check it with:

```javascript
$ node
> require("simple-icons").siDotenv
{
  title: '.ENV',
  slug: 'dotenv',
  svg: [Getter],
  path: 'M24 0v24H0V0h24ZM10.933 15.89H6.84v5.52h4.198v-.93H7.955v-1.503h2.77v-.93h-2.77v-1.224h2.978v-.934Zm2.146 0h-1.084v5.52h1.035v-3.6l2.226 3.6h1.118v-5.52h-1.036v3.686l-2.259-3.687Zm5.117 0h-1.208l1.973 5.52h1.19l1.976-5.52h-1.182l-1.352 4.085-1.397-4.086ZM5.4 19.68H3.72v1.68H5.4v-1.68Z',
  source: 'https://github.com/motdotla/dotenv/tree/40e75440337d1de2345dc8326d6108331f583fd8',
  hex: 'ECD53F',
  guidelines: undefined,
  license: undefined
}
```

Also, the `license` field can be improved now as since #8077 we are exposing the full `license` interface from the SDK. This should be moved to the main types as is exposed by the package. I know that this could be seen as a breaking change for the SDK but I think that practically nobody is using the SDK yet, not even us on the website, so shouldn't hurt.

I'm planning to merge this if no one reviews it in a few days.