### PR TITLE
Add DMM.com

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3160,6 +3160,16 @@
             "source": "https://www.dm.de/"
         },
         {
+            "title": "DMM.com",
+            "hex": "000000",
+            "source": "https://www.dmm.com/",
+            "aliases": {
+                "aka": [
+                    "DMM"
+                ]
+            }
+        },
+        {
             "title": "Docker",
             "hex": "2496ED",
             "source": "https://www.docker.com/company/newsroom/media-resources"

--- a/icons/dmmdotcom.svg
+++ b/icons/dmmdotcom.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>DMM.com</title><path d="M8.2.3H0v23.4h8.2c10.4 0 15.8-4 15.8-11.7S18.6.3 8.2.3zm3.2 14.8h-1.3V8.3h1.3s2.9 0 2.9 3.4c0 3.5-2.9 3.4-2.9 3.4z"/></svg>


### PR DESCRIPTION
![dmmdotcom](https://github.com/simple-icons/simple-icons/assets/19396809/43f75906-90dc-4422-9d57-fd508fa23253)

**Issue:** closes #

**Similarweb rank:**
[#723](https://www.similarweb.com/website/dmm.com/#overview)

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [x] I optimized the icon with SVGO or SVGOMG
  - [x] The SVG `viewbox` is `0 0 24 24`

### Description
Traced in Illustrator from the favicon, since that scales better than their full logo.
