### PR TITLE
Add some stop words to the potential duplicates action

### DIFF
--- a/.github/workflows/potential-duplicates.yml
+++ b/.github/workflows/potential-duplicates.yml
@@ -28,6 +28,12 @@ jobs:
             requesting
             request
             project
+            updated
+            outdated
+            brand
+            assets
+            for
+            from
           state: all
           threshold: 0.7
           comment: |


### PR DESCRIPTION
I've trigerred a false positive when renaming #8649 and #8650 with the word "outdated", one previously using "not updated". Added also some other words seen in other issues.