### PR TITLE
Indicate the Similarweb ranking type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ We welcome icon requests. Before you submit a new issue please make sure the ico
 
 * Has not already been requested. If you find an existing issue or pull request for the brand you're looking for then please add a reaction or comment to show your support.
 * Is of a _popular_ brand:
-    - For websites, the [Similarweb rank](https://www.similarweb.com) should be less than 500k.
+    - For websites, the [Similarweb global rank](https://www.similarweb.com) should be less than 500k.
         - Note that for brands that have already been added the threshold for continued inclusion rises to 750k.
     - For GitHub projects, the amount of "stars" should be above 5k.
     - For anything else, popularity will be judged on a case-by-case basis.


### PR DESCRIPTION
We should indicate that the Similarweb ranking type is global rank, not country or category rank.

I found this problem from #8689.