### PR TITLE
Add lint for checking redundant slashes

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -23,7 +23,7 @@
         {
             "title": "1001Tracklists",
             "hex": "40AEF0",
-            "source": "https://www.1001tracklists.com/"
+            "source": "https://www.1001tracklists.com"
         },
         {
             "title": "1Password",
@@ -33,22 +33,22 @@
         {
             "title": "3M",
             "hex": "FF0000",
-            "source": "https://www.3m.com/"
+            "source": "https://www.3m.com"
         },
         {
             "title": "42",
             "hex": "000000",
-            "source": "https://www.42.fr/"
+            "source": "https://www.42.fr"
         },
         {
             "title": "4chan",
             "hex": "006600",
-            "source": "https://www.4chan.org/"
+            "source": "https://www.4chan.org"
         },
         {
             "title": "4D",
             "hex": "004088",
-            "source": "https://www.4d.com/"
+            "source": "https://www.4d.com"
         },
         {
             "title": "500px",
@@ -73,7 +73,7 @@
         {
             "title": "Abbvie",
             "hex": "071D49",
-            "source": "https://www.abbvie.com/"
+            "source": "https://www.abbvie.com"
         },
         {
             "title": "Ableton Live",
@@ -93,17 +93,17 @@
         {
             "title": "Academia",
             "hex": "41454A",
-            "source": "https://www.academia.edu/"
+            "source": "https://www.academia.edu"
         },
         {
             "title": "Accenture",
             "hex": "A100FF",
-            "source": "https://www.accenture.com/"
+            "source": "https://www.accenture.com"
         },
         {
             "title": "Acclaim",
             "hex": "26689A",
-            "source": "https://www.youracclaim.com/"
+            "source": "https://www.youracclaim.com"
         },
         {
             "title": "Accusoft",
@@ -118,37 +118,37 @@
         {
             "title": "ACM",
             "hex": "0085CA",
-            "source": "https://identitystandards.acm.org/"
+            "source": "https://identitystandards.acm.org"
         },
         {
             "title": "ActiGraph",
             "hex": "0B2C4A",
-            "source": "https://www.actigraphcorp.com/"
+            "source": "https://www.actigraphcorp.com"
         },
         {
             "title": "Activision",
             "hex": "000000",
-            "source": "https://www.activision.com/"
+            "source": "https://www.activision.com"
         },
         {
             "title": "Adafruit",
             "hex": "000000",
-            "source": "https://www.adafruit.com/"
+            "source": "https://www.adafruit.com"
         },
         {
             "title": "AdBlock",
             "hex": "F40D12",
-            "source": "https://getadblock.com/"
+            "source": "https://getadblock.com"
         },
         {
             "title": "Adblock Plus",
             "hex": "C70D2C",
-            "source": "https://adblockplus.org/"
+            "source": "https://adblockplus.org"
         },
         {
             "title": "AddThis",
             "hex": "FF6550",
-            "source": "https://www.addthis.com/"
+            "source": "https://www.addthis.com"
         },
         {
             "title": "AdGuard",
@@ -163,17 +163,17 @@
         {
             "title": "Adminer",
             "hex": "34567C",
-            "source": "https://www.adminer.org/"
+            "source": "https://www.adminer.org"
         },
         {
             "title": "Adobe",
             "hex": "FF0000",
-            "source": "https://www.adobe.com/"
+            "source": "https://www.adobe.com"
         },
         {
             "title": "Adobe Acrobat Reader",
             "hex": "EC1C24",
-            "source": "https://acrobat.adobe.com/"
+            "source": "https://acrobat.adobe.com"
         },
         {
             "title": "Adobe After Effects",
@@ -238,13 +238,13 @@
         {
             "title": "AdonisJS",
             "hex": "5A45FF",
-            "source": "https://adonisjs.com/",
+            "source": "https://adonisjs.com",
             "guidelines": "https://www.notion.so/adonisjs/Welcome-to-the-AdonisJS-Brand-Assets-Guidelines-a042a6d0be7640c6bc78eb32e1bbaaa1"
         },
         {
             "title": "ADP",
             "hex": "D0271D",
-            "source": "https://www.adp.com/",
+            "source": "https://www.adp.com",
             "guidelines": "https://www.adp.com/legal.aspx"
         },
         {
@@ -256,7 +256,7 @@
         {
             "title": "Aer Lingus",
             "hex": "006272",
-            "source": "https://www.aerlingus.com/"
+            "source": "https://www.aerlingus.com"
         },
         {
             "title": "Aeroflot",
@@ -266,7 +266,7 @@
         {
             "title": "Aeroméxico",
             "hex": "0B2343",
-            "source": "https://www.aeromexico.com/"
+            "source": "https://www.aeromexico.com"
         },
         {
             "title": "Aerospike",
@@ -286,12 +286,12 @@
         {
             "title": "AFFiNE",
             "hex": "1E96EB",
-            "source": "https://affine.pro/"
+            "source": "https://affine.pro"
         },
         {
             "title": "Affinity",
             "hex": "222324",
-            "source": "https://affinity.serif.com/"
+            "source": "https://affinity.serif.com"
         },
         {
             "title": "Affinity Designer",
@@ -321,7 +321,7 @@
         {
             "title": "AIB",
             "hex": "7F2B7B",
-            "source": "https://aib.ie/",
+            "source": "https://aib.ie",
             "aliases": {
                 "aka": [
                     "Allied Irish Banks"
@@ -341,7 +341,7 @@
         {
             "title": "Air Canada",
             "hex": "F01428",
-            "source": "https://www.aircanada.com/"
+            "source": "https://www.aircanada.com"
         },
         {
             "title": "Air China",
@@ -351,7 +351,7 @@
         {
             "title": "Air France",
             "hex": "002157",
-            "source": "https://www.airfrance.fr/"
+            "source": "https://www.airfrance.fr"
         },
         {
             "title": "AirAsia",
@@ -371,12 +371,12 @@
         {
             "title": "Airbyte",
             "hex": "615EFF",
-            "source": "https://airbyte.com/"
+            "source": "https://airbyte.com"
         },
         {
             "title": "Aircall",
             "hex": "00B388",
-            "source": "https://aircall.io/"
+            "source": "https://aircall.io"
         },
         {
             "title": "AirPlay Audio",
@@ -411,7 +411,7 @@
         {
             "title": "Albert Heijn",
             "hex": "04ACE6",
-            "source": "https://www.ah.nl/"
+            "source": "https://www.ah.nl"
         },
         {
             "title": "Alchemy",
@@ -436,7 +436,7 @@
         {
             "title": "Alfred",
             "hex": "5C1F87",
-            "source": "https://www.alfredapp.com/"
+            "source": "https://www.alfredapp.com"
         },
         {
             "title": "Algolia",
@@ -471,27 +471,27 @@
         {
             "title": "Allegro",
             "hex": "FF5A00",
-            "source": "https://allegro.pl/"
+            "source": "https://allegro.pl"
         },
         {
             "title": "AlliedModders",
             "hex": "1578D3",
-            "source": "https://forums.alliedmods.net/"
+            "source": "https://forums.alliedmods.net"
         },
         {
             "title": "AlloCiné",
             "hex": "FECC00",
-            "source": "https://www.allocine.fr/"
+            "source": "https://www.allocine.fr"
         },
         {
             "title": "AllTrails",
             "hex": "428813",
-            "source": "https://www.alltrails.com/"
+            "source": "https://www.alltrails.com"
         },
         {
             "title": "Alpine Linux",
             "hex": "0D597F",
-            "source": "https://alpinelinux.org/"
+            "source": "https://alpinelinux.org"
         },
         {
             "title": "Alpine.js",
@@ -620,7 +620,7 @@
         {
             "title": "Amazon Pay",
             "hex": "FF9900",
-            "source": "https://pay.amazon.com/"
+            "source": "https://pay.amazon.com"
         },
         {
             "title": "Amazon Prime",
@@ -665,12 +665,12 @@
         {
             "title": "AMD",
             "hex": "ED1C24",
-            "source": "https://www.amd.com/"
+            "source": "https://www.amd.com"
         },
         {
             "title": "Ameba",
             "hex": "2D8C3C",
-            "source": "https://ameblo.jp/",
+            "source": "https://ameblo.jp",
             "aliases": {
                 "aka": [
                     "Ameba Blog",
@@ -699,7 +699,7 @@
         {
             "title": "AMP",
             "hex": "005AF0",
-            "source": "https://amp.dev/"
+            "source": "https://amp.dev"
         },
         {
             "title": "Amul",
@@ -719,12 +719,12 @@
         {
             "title": "Analogue",
             "hex": "1A1A1A",
-            "source": "https://www.analogue.co/"
+            "source": "https://www.analogue.co"
         },
         {
             "title": "Anchor",
             "hex": "5000B9",
-            "source": "https://anchor.fm/"
+            "source": "https://anchor.fm"
         },
         {
             "title": "Andela",
@@ -765,7 +765,7 @@
         {
             "title": "AngularJS",
             "hex": "E23237",
-            "source": "https://angularjs.org/"
+            "source": "https://angularjs.org"
         },
         {
             "title": "AniList",
@@ -780,7 +780,7 @@
         {
             "title": "Answer",
             "hex": "0033FF",
-            "source": "https://answer.dev/"
+            "source": "https://answer.dev"
         },
         {
             "title": "Ansys",
@@ -795,23 +795,23 @@
         {
             "title": "Anta",
             "hex": "D70010",
-            "source": "https://www.anta.com/"
+            "source": "https://www.anta.com"
         },
         {
             "title": "Antena 3",
             "hex": "FF7328",
-            "source": "https://www.antena3.com/"
+            "source": "https://www.antena3.com"
         },
         {
             "title": "AnyDesk",
             "hex": "EF443B",
-            "source": "https://anydesk.com/"
+            "source": "https://anydesk.com"
         },
         {
             "title": "AOL",
             "hex": "3399FF",
-            "source": "https://www.aol.com/",
-            "guidelines": "https://styleguide.aol.com/"
+            "source": "https://www.aol.com",
+            "guidelines": "https://styleguide.aol.com"
         },
         {
             "title": "Apache",
@@ -866,7 +866,7 @@
         {
             "title": "Apache Groovy",
             "hex": "4298B8",
-            "source": "https://groovy-lang.org/"
+            "source": "https://groovy-lang.org"
         },
         {
             "title": "Apache Hadoop",
@@ -997,7 +997,7 @@
         {
             "title": "AppSignal",
             "hex": "21375A",
-            "source": "https://appsignal.com/"
+            "source": "https://appsignal.com"
         },
         {
             "title": "AppVeyor",
@@ -1045,7 +1045,7 @@
         {
             "title": "Archive of Our Own",
             "hex": "990000",
-            "source": "https://archiveofourown.org/"
+            "source": "https://archiveofourown.org"
         },
         {
             "title": "Ardour",
@@ -1065,7 +1065,7 @@
         {
             "title": "Argos",
             "hex": "DA291C",
-            "source": "https://www.argos.co.uk/"
+            "source": "https://www.argos.co.uk"
         },
         {
             "title": "ARK Ecosystem",
@@ -1075,12 +1075,12 @@
         {
             "title": "Arlo",
             "hex": "49B48A",
-            "source": "https://www.arlo.com/"
+            "source": "https://www.arlo.com"
         },
         {
             "title": "Arm",
             "hex": "0091BD",
-            "source": "https://www.arm.com/",
+            "source": "https://www.arm.com",
             "guidelines": "https://www.arm.com/company/policies/trademarks/guidelines-corporate-logo"
         },
         {
@@ -1122,33 +1122,33 @@
         {
             "title": "ASDA",
             "hex": "68A51C",
-            "source": "https://www.asda.com/"
+            "source": "https://www.asda.com"
         },
         {
             "title": "Aseprite",
             "hex": "7D929E",
-            "source": "https://www.aseprite.org/"
+            "source": "https://www.aseprite.org"
         },
         {
             "title": "Ask Ubuntu",
             "hex": "DC461D",
-            "source": "https://askubuntu.com/",
+            "source": "https://askubuntu.com",
             "guidelines": "https://stackoverflow.com/legal/trademark-guidance"
         },
         {
             "title": "ASKfm",
             "hex": "DB3552",
-            "source": "https://ask.fm/"
+            "source": "https://ask.fm"
         },
         {
             "title": "AssemblyScript",
             "hex": "007AAC",
-            "source": "https://www.assemblyscript.org/"
+            "source": "https://www.assemblyscript.org"
         },
         {
             "title": "Aston Martin",
             "hex": "000000",
-            "source": "https://www.astonmartin.com/"
+            "source": "https://www.astonmartin.com"
         },
         {
             "title": "Astro",
@@ -1161,7 +1161,7 @@
         {
             "title": "ASUS",
             "hex": "000000",
-            "source": "https://www.asus.com/"
+            "source": "https://www.asus.com"
         },
         {
             "title": "AT&T",
@@ -1171,7 +1171,7 @@
         {
             "title": "Atari",
             "hex": "E4202E",
-            "source": "https://atarivcs.com/"
+            "source": "https://atarivcs.com"
         },
         {
             "title": "Atlassian",
@@ -1186,7 +1186,7 @@
         {
             "title": "Auchan",
             "hex": "D6180B",
-            "source": "https://www.auchan.fr/"
+            "source": "https://www.auchan.fr"
         },
         {
             "title": "Audacity",
@@ -1216,12 +1216,12 @@
         {
             "title": "Audiomack",
             "hex": "FFA200",
-            "source": "https://styleguide.audiomack.com/"
+            "source": "https://styleguide.audiomack.com"
         },
         {
             "title": "Aurelia",
             "hex": "ED2B88",
-            "source": "https://aurelia.io/"
+            "source": "https://aurelia.io"
         },
         {
             "title": "Auth0",
@@ -1231,18 +1231,18 @@
         {
             "title": "Authy",
             "hex": "EC1C24",
-            "source": "https://authy.com/"
+            "source": "https://authy.com"
         },
         {
             "title": "Autodesk",
             "hex": "000000",
-            "source": "https://brand.autodesk.com/",
+            "source": "https://brand.autodesk.com",
             "guidelines": "https://brand.autodesk.com/brand-system/logo/"
         },
         {
             "title": "AutoHotkey",
             "hex": "334455",
-            "source": "https://www.autohotkey.com/"
+            "source": "https://www.autohotkey.com"
         },
         {
             "title": "Automattic",
@@ -1262,7 +1262,7 @@
         {
             "title": "Avast",
             "hex": "FF7800",
-            "source": "https://www.avast.com/",
+            "source": "https://www.avast.com",
             "guidelines": "https://press.avast.com/media-materials"
         },
         {
@@ -1273,7 +1273,7 @@
         {
             "title": "awesomeWM",
             "hex": "535D6C",
-            "source": "https://awesomewm.org/"
+            "source": "https://awesomewm.org"
         },
         {
             "title": "AWS Amplify",
@@ -1326,7 +1326,7 @@
         {
             "title": "B&R Automation",
             "hex": "FF8800",
-            "source": "https://www.br-automation.com/"
+            "source": "https://www.br-automation.com"
         },
         {
             "title": "Babel",
@@ -1351,7 +1351,7 @@
         {
             "title": "Backendless",
             "hex": "FFFFFF",
-            "source": "https://backendless.com/"
+            "source": "https://backendless.com"
         },
         {
             "title": "Backstage",
@@ -1362,7 +1362,7 @@
         {
             "title": "Badgr",
             "hex": "282C4C",
-            "source": "https://info.badgr.com/"
+            "source": "https://info.badgr.com"
         },
         {
             "title": "Badoo",
@@ -1397,17 +1397,17 @@
         {
             "title": "Bank of America",
             "hex": "012169",
-            "source": "https://www.bankofamerica.com/"
+            "source": "https://www.bankofamerica.com"
         },
         {
             "title": "Barclays",
             "hex": "00AEEF",
-            "source": "https://home.barclays/"
+            "source": "https://home.barclays"
         },
         {
             "title": "Baremetrics",
             "hex": "6078FF",
-            "source": "https://baremetrics.com/"
+            "source": "https://baremetrics.com"
         },
         {
             "title": "Basecamp",
@@ -1427,7 +1427,7 @@
         {
             "title": "Bata",
             "hex": "DD282E",
-            "source": "https://www.bata.com/"
+            "source": "https://www.bata.com"
         },
         {
             "title": "Bath ASU",
@@ -1453,7 +1453,7 @@
         {
             "title": "Beatport",
             "hex": "01FF95",
-            "source": "https://brand.beatport.com/",
+            "source": "https://brand.beatport.com",
             "guidelines": "https://support.beatport.com/hc/en-us/articles/200353255-Beatport-Logos-and-Images"
         },
         {
@@ -1464,7 +1464,7 @@
         {
             "title": "Beats by Dre",
             "hex": "E01F3D",
-            "source": "https://www.beatsbydre.com/"
+            "source": "https://www.beatsbydre.com"
         },
         {
             "title": "Behance",
@@ -1479,7 +1479,7 @@
         {
             "title": "BEM",
             "hex": "000000",
-            "source": "https://en.bem.info/"
+            "source": "https://en.bem.info"
         },
         {
             "title": "Bentley",
@@ -1494,7 +1494,7 @@
         {
             "title": "Betfair",
             "hex": "FFB80B",
-            "source": "https://partnerships.betfair.com/"
+            "source": "https://partnerships.betfair.com"
         },
         {
             "title": "Big Cartel",
@@ -1504,7 +1504,7 @@
         {
             "title": "bigbasket",
             "hex": "A5CD39",
-            "source": "https://www.bigbasket.com/"
+            "source": "https://www.bigbasket.com"
         },
         {
             "title": "BigBlueButton",
@@ -1520,12 +1520,12 @@
         {
             "title": "Bilibili",
             "hex": "00A1D6",
-            "source": "https://www.bilibili.com/"
+            "source": "https://www.bilibili.com"
         },
         {
             "title": "Billboard",
             "hex": "000000",
-            "source": "https://www.billboard.com/"
+            "source": "https://www.billboard.com"
         },
         {
             "title": "BIM",
@@ -1535,12 +1535,12 @@
         {
             "title": "Binance",
             "hex": "F0B90B",
-            "source": "https://binance.com/"
+            "source": "https://binance.com"
         },
         {
             "title": "Bio Link",
             "hex": "000000",
-            "source": "https://bio.link/"
+            "source": "https://bio.link"
         },
         {
             "title": "Bit",
@@ -1565,7 +1565,7 @@
         {
             "title": "Bitcoin SV",
             "hex": "EAB300",
-            "source": "https://bitcoinsv.com/"
+            "source": "https://bitcoinsv.com"
         },
         {
             "title": "Bitdefender",
@@ -1590,17 +1590,17 @@
         {
             "title": "Bitwig",
             "hex": "FF5A00",
-            "source": "https://www.bitwig.com/"
+            "source": "https://www.bitwig.com"
         },
         {
             "title": "Blackberry",
             "hex": "000000",
-            "source": "https://www.blackberry.com/"
+            "source": "https://www.blackberry.com"
         },
         {
             "title": "Blazemeter",
             "hex": "CA2133",
-            "source": "https://www.blazemeter.com/"
+            "source": "https://www.blazemeter.com"
         },
         {
             "title": "Blazor",
@@ -1615,7 +1615,7 @@
         {
             "title": "Blockchain.com",
             "hex": "121D33",
-            "source": "https://www.blockchain.com/",
+            "source": "https://www.blockchain.com",
             "guidelines": "https://www.blockchain.com/en/press"
         },
         {
@@ -1641,17 +1641,17 @@
         {
             "title": "BMC Software",
             "hex": "FE5000",
-            "source": "https://www.bmc.com/"
+            "source": "https://www.bmc.com"
         },
         {
             "title": "BMW",
             "hex": "0066B1",
-            "source": "https://www.bmw.de/"
+            "source": "https://www.bmw.de"
         },
         {
             "title": "BoardGameGeek",
             "hex": "FF5100",
-            "source": "https://boardgamegeek.com/"
+            "source": "https://boardgamegeek.com"
         },
         {
             "title": "Boehringer Ingelheim",
@@ -1666,7 +1666,7 @@
         {
             "title": "Bookalope",
             "hex": "DC2829",
-            "source": "https://bookalope.net/"
+            "source": "https://bookalope.net"
         },
         {
             "title": "BookBub",
@@ -1676,22 +1676,22 @@
         {
             "title": "Bookmeter",
             "hex": "64BC4B",
-            "source": "https://bookmeter.com/"
+            "source": "https://bookmeter.com"
         },
         {
             "title": "BookMyShow",
             "hex": "C4242B",
-            "source": "https://in.bookmyshow.com/"
+            "source": "https://in.bookmyshow.com"
         },
         {
             "title": "BookStack",
             "hex": "0288D1",
-            "source": "https://www.bookstackapp.com/"
+            "source": "https://www.bookstackapp.com"
         },
         {
             "title": "Boost",
             "hex": "F7901E",
-            "source": "https://www.boostmobile.com/"
+            "source": "https://www.boostmobile.com"
         },
         {
             "title": "Boots",
@@ -1706,12 +1706,12 @@
         {
             "title": "BorgBackup",
             "hex": "00DD00",
-            "source": "https://www.borgbackup.org/"
+            "source": "https://www.borgbackup.org"
         },
         {
             "title": "Bosch",
             "hex": "EA0016",
-            "source": "https://www.bosch.de/"
+            "source": "https://www.bosch.de"
         },
         {
             "title": "Bose",
@@ -1721,12 +1721,12 @@
         {
             "title": "Botble CMS",
             "hex": "205081",
-            "source": "https://botble.com/"
+            "source": "https://botble.com"
         },
         {
             "title": "boulanger",
             "hex": "FD5300",
-            "source": "https://www.boulanger.com/"
+            "source": "https://www.boulanger.com"
         },
         {
             "title": "Bower",
@@ -1771,7 +1771,7 @@
         {
             "title": "BT",
             "hex": "6400AA",
-            "source": "https://www.bt.com/"
+            "source": "https://www.bt.com"
         },
         {
             "title": "Buddy",
@@ -1796,7 +1796,7 @@
         {
             "title": "Bugatti",
             "hex": "BE0030",
-            "source": "https://www.bugatti.com/"
+            "source": "https://www.bugatti.com"
         },
         {
             "title": "Bugcrowd",
@@ -1837,7 +1837,7 @@
         {
             "title": "Burger King",
             "hex": "D62300",
-            "source": "https://www.bk.com/",
+            "source": "https://www.bk.com",
             "guidelines": "https://www.bk.com/trademarks"
         },
         {
@@ -1879,7 +1879,7 @@
         {
             "title": "ByteDance",
             "hex": "3C8CFF",
-            "source": "https://www.bytedance.com/"
+            "source": "https://www.bytedance.com"
         },
         {
             "title": "C",
@@ -1909,7 +1909,7 @@
         {
             "title": "Caffeine",
             "hex": "0000FF",
-            "source": "https://www.caffeine.tv/",
+            "source": "https://www.caffeine.tv",
             "guidelines": "https://www.caffeine.tv/newsroom.html"
         },
         {
@@ -1944,7 +1944,7 @@
         {
             "title": "Canva",
             "hex": "00C4CC",
-            "source": "https://www.canva.com/"
+            "source": "https://www.canva.com"
         },
         {
             "title": "Capacitor",
@@ -1954,7 +1954,7 @@
         {
             "title": "Car Throttle",
             "hex": "FF9C42",
-            "source": "https://www.carthrottle.com/"
+            "source": "https://www.carthrottle.com"
         },
         {
             "title": "Cardano",
@@ -1984,7 +1984,7 @@
         {
             "title": "Castorama",
             "hex": "0078D7",
-            "source": "https://www.castorama.fr/"
+            "source": "https://www.castorama.fr"
         },
         {
             "title": "Castro",
@@ -1999,7 +1999,7 @@
         {
             "title": "CBS",
             "hex": "033963",
-            "source": "https://www.cbs.com/"
+            "source": "https://www.cbs.com"
         },
         {
             "title": "CD Projekt",
@@ -2034,7 +2034,7 @@
         {
             "title": "Chainguard",
             "hex": "4445E7",
-            "source": "https://www.chainguard.dev/"
+            "source": "https://www.chainguard.dev"
         },
         {
             "title": "Chainlink",
@@ -2049,7 +2049,7 @@
         {
             "title": "Chart.js",
             "hex": "FF6384",
-            "source": "https://www.chartjs.org/"
+            "source": "https://www.chartjs.org"
         },
         {
             "title": "ChartMogul",
@@ -2064,8 +2064,8 @@
         {
             "title": "ChatBot",
             "hex": "0066FF",
-            "source": "https://chatbot.design/",
-            "guidelines": "https://chatbot.design/"
+            "source": "https://chatbot.design",
+            "guidelines": "https://chatbot.design"
         },
         {
             "title": "CheckiO",
@@ -2080,7 +2080,7 @@
         {
             "title": "Chef",
             "hex": "F09820",
-            "source": "https://www.chef.io/"
+            "source": "https://www.chef.io"
         },
         {
             "title": "Chemex",
@@ -2125,7 +2125,7 @@
         {
             "title": "Chupa Chups",
             "hex": "CF103E",
-            "source": "https://www.chupachups.co.uk/"
+            "source": "https://www.chupachups.co.uk"
         },
         {
             "title": "Cilium",
@@ -2140,7 +2140,7 @@
         {
             "title": "Circle",
             "hex": "8669AE",
-            "source": "https://www.circle.com/"
+            "source": "https://www.circle.com"
         },
         {
             "title": "CircleCI",
@@ -2160,12 +2160,12 @@
         {
             "title": "Cisco",
             "hex": "1BA0D7",
-            "source": "https://www.cisco.com/"
+            "source": "https://www.cisco.com"
         },
         {
             "title": "Citrix",
             "hex": "452170",
-            "source": "https://brand.citrix.com/"
+            "source": "https://brand.citrix.com"
         },
         {
             "title": "Citroën",
@@ -2191,7 +2191,7 @@
         {
             "title": "Claris",
             "hex": "000000",
-            "source": "https://www.claris.com/"
+            "source": "https://www.claris.com"
         },
         {
             "title": "ClickHouse",
@@ -2227,28 +2227,28 @@
         {
             "title": "Cloud 66",
             "hex": "3C72B9",
-            "source": "https://www.cloud66.com/"
+            "source": "https://www.cloud66.com"
         },
         {
             "title": "Cloud Foundry",
             "hex": "0C9ED5",
-            "source": "https://www.cloudfoundry.org/",
+            "source": "https://www.cloudfoundry.org",
             "guidelines": "https://www.cloudfoundry.org/logo/"
         },
         {
             "title": "CloudBees",
             "hex": "1997B5",
-            "source": "https://www.cloudbees.com/"
+            "source": "https://www.cloudbees.com"
         },
         {
             "title": "CloudCannon",
             "hex": "407AFC",
-            "source": "https://cloudcannon.com/"
+            "source": "https://cloudcannon.com"
         },
         {
             "title": "Cloudera",
             "hex": "F96702",
-            "source": "https://www.cloudera.com/"
+            "source": "https://www.cloudera.com"
         },
         {
             "title": "Cloudflare",
@@ -2259,7 +2259,7 @@
         {
             "title": "Cloudflare Pages",
             "hex": "F38020",
-            "source": "https://pages.cloudflare.com/",
+            "source": "https://pages.cloudflare.com",
             "guidelines": "https://www.cloudflare.com/trademark/"
         },
         {
@@ -2275,13 +2275,13 @@
         {
             "title": "Clubhouse",
             "hex": "6515DD",
-            "source": "https://brand.clubhouse.io/",
-            "guidelines": "https://brand.clubhouse.io/"
+            "source": "https://brand.clubhouse.io",
+            "guidelines": "https://brand.clubhouse.io"
         },
         {
             "title": "Clyp",
             "hex": "3CBDB1",
-            "source": "https://clyp.it/"
+            "source": "https://clyp.it"
         },
         {
             "title": "CMake",
@@ -2297,7 +2297,7 @@
         {
             "title": "CNN",
             "hex": "CC0000",
-            "source": "https://edition.cnn.com/"
+            "source": "https://edition.cnn.com"
         },
         {
             "title": "Co-op",
@@ -2317,7 +2317,7 @@
         {
             "title": "Cockroach Labs",
             "hex": "6933FF",
-            "source": "https://www.cockroachlabs.com/"
+            "source": "https://www.cockroachlabs.com"
         },
         {
             "title": "CocoaPods",
@@ -2335,7 +2335,7 @@
         {
             "title": "Coda",
             "hex": "F46A54",
-            "source": "https://coda.io/"
+            "source": "https://coda.io"
         },
         {
             "title": "Codacy",
@@ -2350,7 +2350,7 @@
         {
             "title": "Code Review",
             "hex": "485A62",
-            "source": "https://codereview.stackexchange.com/",
+            "source": "https://codereview.stackexchange.com",
             "guidelines": "https://stackoverflow.com/legal/trademark-guidance"
         },
         {
@@ -2361,7 +2361,7 @@
         {
             "title": "Codecademy",
             "hex": "1F4056",
-            "source": "https://www.codecademy.com/"
+            "source": "https://www.codecademy.com"
         },
         {
             "title": "CodeceptJS",
@@ -2371,22 +2371,22 @@
         {
             "title": "CodeChef",
             "hex": "5B4638",
-            "source": "https://www.codechef.com/"
+            "source": "https://www.codechef.com"
         },
         {
             "title": "Codecov",
             "hex": "F01F7A",
-            "source": "https://codecov.io/"
+            "source": "https://codecov.io"
         },
         {
             "title": "CodeFactor",
             "hex": "F44A6A",
-            "source": "https://www.codefactor.io/"
+            "source": "https://www.codefactor.io"
         },
         {
             "title": "Codeforces",
             "hex": "1F8ACB",
-            "source": "https://codeforces.com/"
+            "source": "https://codeforces.com"
         },
         {
             "title": "CodeIgniter",
@@ -2396,7 +2396,7 @@
         {
             "title": "Codemagic",
             "hex": "F45E3F",
-            "source": "https://codemagic.io/"
+            "source": "https://codemagic.io"
         },
         {
             "title": "CodeMirror",
@@ -2406,7 +2406,7 @@
         {
             "title": "CodeNewbie",
             "hex": "9013FE",
-            "source": "https://community.codenewbie.org/"
+            "source": "https://community.codenewbie.org"
         },
         {
             "title": "CodePen",
@@ -2416,7 +2416,7 @@
         {
             "title": "CodeProject",
             "hex": "FF9900",
-            "source": "https://www.codeproject.com/"
+            "source": "https://www.codeproject.com"
         },
         {
             "title": "CodersRank",
@@ -2436,7 +2436,7 @@
         {
             "title": "Codeship",
             "hex": "004466",
-            "source": "https://app.codeship.com/"
+            "source": "https://app.codeship.com"
         },
         {
             "title": "Codewars",
@@ -2461,12 +2461,12 @@
         {
             "title": "CoffeeScript",
             "hex": "2F2625",
-            "source": "https://coffeescript.org/"
+            "source": "https://coffeescript.org"
         },
         {
             "title": "Cognizant",
             "hex": "1A4CA1",
-            "source": "https://www.cognizant.com/"
+            "source": "https://www.cognizant.com"
         },
         {
             "title": "Coil",
@@ -2482,7 +2482,7 @@
         {
             "title": "CoinMarketCap",
             "hex": "17181B",
-            "source": "https://www.coinmarketcap.com/"
+            "source": "https://www.coinmarketcap.com"
         },
         {
             "title": "Commerzbank",
@@ -2497,7 +2497,7 @@
         {
             "title": "Commodore",
             "hex": "1E2A4E",
-            "source": "https://commodore.inc/"
+            "source": "https://commodore.inc"
         },
         {
             "title": "Common Workflow Language",
@@ -2512,7 +2512,7 @@
         {
             "title": "Composer",
             "hex": "885630",
-            "source": "https://getcomposer.org/"
+            "source": "https://getcomposer.org"
         },
         {
             "title": "Comsol",
@@ -2522,12 +2522,12 @@
         {
             "title": "Conan",
             "hex": "6699CB",
-            "source": "https://conan.io/"
+            "source": "https://conan.io"
         },
         {
             "title": "Concourse",
             "hex": "3398DC",
-            "source": "https://concourse-ci.org/"
+            "source": "https://concourse-ci.org"
         },
         {
             "title": "Conda-Forge",
@@ -2547,8 +2547,8 @@
         {
             "title": "Construct 3",
             "hex": "00FFDA",
-            "source": "https://www.construct.net/",
-            "guidelines": "https://www.construct.net/"
+            "source": "https://www.construct.net",
+            "guidelines": "https://www.construct.net"
         },
         {
             "title": "Consul",
@@ -2588,7 +2588,7 @@
         {
             "title": "Convertio",
             "hex": "FF3333",
-            "source": "https://convertio.co/"
+            "source": "https://convertio.co"
         },
         {
             "title": "Cookiecutter",
@@ -2598,12 +2598,12 @@
         {
             "title": "Cora",
             "hex": "E61845",
-            "source": "https://www.cora.fr/"
+            "source": "https://www.cora.fr"
         },
         {
             "title": "Corona Engine",
             "hex": "F96F29",
-            "source": "https://coronalabs.com/",
+            "source": "https://coronalabs.com",
             "guidelines": "https://coronalabs.com/presskit.pdf"
         },
         {
@@ -2620,7 +2620,7 @@
         {
             "title": "Couchbase",
             "hex": "EA2328",
-            "source": "https://www.couchbase.com/"
+            "source": "https://www.couchbase.com"
         },
         {
             "title": "Counter-Strike",
@@ -2640,7 +2640,7 @@
         {
             "title": "Coveralls",
             "hex": "3F5767",
-            "source": "https://coveralls.io/"
+            "source": "https://coveralls.io"
         },
         {
             "title": "cPanel",
@@ -2670,12 +2670,12 @@
         {
             "title": "Creative Commons",
             "hex": "EF9421",
-            "source": "https://creativecommons.org/"
+            "source": "https://creativecommons.org"
         },
         {
             "title": "Creative Technology",
             "hex": "000000",
-            "source": "https://creative.com/"
+            "source": "https://creative.com"
         },
         {
             "title": "Credly",
@@ -2685,12 +2685,12 @@
         {
             "title": "Crehana",
             "hex": "4B22F4",
-            "source": "https://www.crehana.com/"
+            "source": "https://www.crehana.com"
         },
         {
             "title": "Critical Role",
             "hex": "000000",
-            "source": "https://critrole.com/"
+            "source": "https://critrole.com"
         },
         {
             "title": "Crowdin",
@@ -2755,7 +2755,7 @@
         {
             "title": "Cultura",
             "hex": "1D2C54",
-            "source": "https://www.cultura.com/"
+            "source": "https://www.cultura.com"
         },
         {
             "title": "curl",
@@ -2765,12 +2765,12 @@
         {
             "title": "CurseForge",
             "hex": "6441A4",
-            "source": "https://www.curseforge.com/"
+            "source": "https://www.curseforge.com"
         },
         {
             "title": "Cycling '74",
             "hex": "111111",
-            "source": "https://cycling74.com/"
+            "source": "https://cycling74.com"
         },
         {
             "title": "Cypress",
@@ -2795,7 +2795,7 @@
         {
             "title": "D-Wave Systems",
             "hex": "008CD7",
-            "source": "https://www.dwavesys.com/"
+            "source": "https://www.dwavesys.com"
         },
         {
             "title": "D3.js",
@@ -2805,7 +2805,7 @@
         {
             "title": "Dacia",
             "hex": "122AFF",
-            "source": "https://www.dacia.ro/"
+            "source": "https://www.dacia.ro"
         },
         {
             "title": "DAF",
@@ -2846,7 +2846,7 @@
         {
             "title": "Darty",
             "hex": "EB1B23",
-            "source": "https://www.darty.com/"
+            "source": "https://www.darty.com"
         },
         {
             "title": "Das Erste",
@@ -2872,7 +2872,7 @@
         {
             "title": "Dassault Systèmes",
             "hex": "005386",
-            "source": "https://www.3ds.com/"
+            "source": "https://www.3ds.com"
         },
         {
             "title": "data.ai",
@@ -2882,13 +2882,13 @@
         {
             "title": "Databricks",
             "hex": "FF3621",
-            "source": "https://www.databricks.com/",
+            "source": "https://www.databricks.com",
             "guidelines": "https://brand.databricks.com/Styleguide/Guide/"
         },
         {
             "title": "DataCamp",
             "hex": "03EF62",
-            "source": "https://www.datacamp.com/"
+            "source": "https://www.datacamp.com"
         },
         {
             "title": "Datadog",
@@ -2943,7 +2943,7 @@
         {
             "title": "dblp",
             "hex": "004F9F",
-            "source": "https://dblp.org/"
+            "source": "https://dblp.org"
         },
         {
             "title": "dbt",
@@ -2953,12 +2953,12 @@
         {
             "title": "DC Entertainment",
             "hex": "0078F0",
-            "source": "https://www.readdc.com/"
+            "source": "https://www.readdc.com"
         },
         {
             "title": "De'Longhi",
             "hex": "072240",
-            "source": "https://www.delonghi.com/"
+            "source": "https://www.delonghi.com"
         },
         {
             "title": "Debian",
@@ -2977,19 +2977,19 @@
         {
             "title": "Deepnote",
             "hex": "3793EF",
-            "source": "https://deepnote.com/"
+            "source": "https://deepnote.com"
         },
         {
             "title": "Deezer",
             "hex": "FEAA2D",
-            "source": "https://deezerbrand.com/",
-            "guidelines": "https://deezerbrand.com/"
+            "source": "https://deezerbrand.com",
+            "guidelines": "https://deezerbrand.com"
         },
         {
             "title": "del.icio.us",
             "slug": "delicious",
             "hex": "0000FF",
-            "source": "https://del.icio.us/",
+            "source": "https://del.icio.us",
             "aliases": {
                 "aka": [
                     "Delicious"
@@ -2999,12 +2999,12 @@
         {
             "title": "Deliveroo",
             "hex": "00CCBC",
-            "source": "https://deliveroo.com/"
+            "source": "https://deliveroo.com"
         },
         {
             "title": "Dell",
             "hex": "007DB8",
-            "source": "https://www.dell.com/",
+            "source": "https://www.dell.com",
             "guidelines": "https://brand.delltechnologies.com/logos/"
         },
         {
@@ -3028,12 +3028,12 @@
         {
             "title": "Dependabot",
             "hex": "025E8C",
-            "source": "https://dependabot.com/"
+            "source": "https://dependabot.com"
         },
         {
             "title": "Der Spiegel",
             "hex": "E64415",
-            "source": "https://www.spiegel.de/"
+            "source": "https://www.spiegel.de"
         },
         {
             "title": "Designer News",
@@ -3043,17 +3043,17 @@
         {
             "title": "Deutsche Bahn",
             "hex": "F01414",
-            "source": "https://www.bahn.de/"
+            "source": "https://www.bahn.de"
         },
         {
             "title": "Deutsche Bank",
             "hex": "0018A8",
-            "source": "https://www.db.com/"
+            "source": "https://www.db.com"
         },
         {
             "title": "dev.to",
             "hex": "0A0A0A",
-            "source": "https://dev.to/"
+            "source": "https://dev.to"
         },
         {
             "title": "DevExpress",
@@ -3078,7 +3078,7 @@
         {
             "title": "Dgraph",
             "hex": "E50695",
-            "source": "https://dgraph.io/"
+            "source": "https://dgraph.io"
         },
         {
             "title": "DHL",
@@ -3099,7 +3099,7 @@
         {
             "title": "Dialogflow",
             "hex": "FF9800",
-            "source": "https://dialogflow.cloud.google.com/"
+            "source": "https://dialogflow.cloud.google.com"
         },
         {
             "title": "Diaspora",
@@ -3109,12 +3109,12 @@
         {
             "title": "Digg",
             "hex": "000000",
-            "source": "https://digg.com/"
+            "source": "https://digg.com"
         },
         {
             "title": "Digi-Key Electronics",
             "hex": "CC0000",
-            "source": "https://www.digikey.com/"
+            "source": "https://www.digikey.com"
         },
         {
             "title": "DigitalOcean",
@@ -3125,12 +3125,12 @@
         {
             "title": "Dior",
             "hex": "000000",
-            "source": "https://www.dior.com/"
+            "source": "https://www.dior.com"
         },
         {
             "title": "Directus",
             "hex": "263238",
-            "source": "https://directus.io/"
+            "source": "https://directus.io"
         },
         {
             "title": "Discogs",
@@ -3146,7 +3146,7 @@
         {
             "title": "Discourse",
             "hex": "000000",
-            "source": "https://www.discourse.org/"
+            "source": "https://www.discourse.org"
         },
         {
             "title": "Discover",
@@ -3181,7 +3181,7 @@
         {
             "title": "dm",
             "hex": "002878",
-            "source": "https://www.dm.de/"
+            "source": "https://www.dm.de"
         },
         {
             "title": "Docker",
@@ -3191,7 +3191,7 @@
         {
             "title": "Docs.rs",
             "hex": "000000",
-            "source": "https://docs.rs/"
+            "source": "https://docs.rs"
         },
         {
             "title": "DocuSign",
@@ -3239,12 +3239,12 @@
         {
             "title": "DPD",
             "hex": "DC0032",
-            "source": "https://www.dpd.com/"
+            "source": "https://www.dpd.com"
         },
         {
             "title": "Dragonframe",
             "hex": "D4911E",
-            "source": "https://dragonframe.com/"
+            "source": "https://dragonframe.com"
         },
         {
             "title": "Draugiem.lv",
@@ -3294,12 +3294,12 @@
         {
             "title": "DuckDB",
             "hex": "FFF000",
-            "source": "https://duckdb.org/"
+            "source": "https://duckdb.org"
         },
         {
             "title": "DuckDuckGo",
             "hex": "DE5833",
-            "source": "https://duckduckgo.com/"
+            "source": "https://duckduckgo.com"
         },
         {
             "title": "Dungeons & Dragons",
@@ -3315,12 +3315,12 @@
         {
             "title": "Dunked",
             "hex": "2DA9D7",
-            "source": "https://dunked.com/"
+            "source": "https://dunked.com"
         },
         {
             "title": "Duolingo",
             "hex": "58CC02",
-            "source": "https://www.duolingo.com/"
+            "source": "https://www.duolingo.com"
         },
         {
             "title": "DVC",
@@ -3376,7 +3376,7 @@
         {
             "title": "Eagle",
             "hex": "0072EF",
-            "source": "https://en.eagle.cool/"
+            "source": "https://en.eagle.cool"
         },
         {
             "title": "easyJet",
@@ -3416,7 +3416,7 @@
         {
             "title": "EDEKA",
             "hex": "1B66B3",
-            "source": "https://www.edeka.de/"
+            "source": "https://www.edeka.de"
         },
         {
             "title": "EditorConfig",
@@ -3426,12 +3426,12 @@
         {
             "title": "edX",
             "hex": "02262B",
-            "source": "https://www.edx.org/"
+            "source": "https://www.edx.org"
         },
         {
             "title": "egghead",
             "hex": "FCFBFA",
-            "source": "https://egghead.io/"
+            "source": "https://egghead.io"
         },
         {
             "title": "Egnyte",
@@ -3471,7 +3471,7 @@
         {
             "title": "Electron",
             "hex": "47848F",
-            "source": "https://www.electronjs.org/"
+            "source": "https://www.electronjs.org"
         },
         {
             "title": "Electron Fiddle",
@@ -3481,12 +3481,12 @@
         {
             "title": "electron-builder",
             "hex": "FFFFFF",
-            "source": "https://www.electron.build/"
+            "source": "https://www.electron.build"
         },
         {
             "title": "Element",
             "hex": "0DBD8B",
-            "source": "https://element.io/"
+            "source": "https://element.io"
         },
         {
             "title": "elementary",
@@ -3543,7 +3543,7 @@
         {
             "title": "Emby",
             "hex": "52B54B",
-            "source": "https://emby.media/"
+            "source": "https://emby.media"
         },
         {
             "title": "Emirates",
@@ -3574,12 +3574,12 @@
         {
             "title": "EnterpriseDB",
             "hex": "FF3E00",
-            "source": "https://www.enterprisedb.com/"
+            "source": "https://www.enterprisedb.com"
         },
         {
             "title": "Envato",
             "hex": "81B441",
-            "source": "https://envato.com/"
+            "source": "https://envato.com"
         },
         {
             "title": "Envoy Proxy",
@@ -3605,7 +3605,7 @@
         {
             "title": "Equinix Metal",
             "hex": "ED2224",
-            "source": "https://metal.equinix.com/"
+            "source": "https://metal.equinix.com"
         },
         {
             "title": "Erlang",
@@ -3620,18 +3620,18 @@
         {
             "title": "ESEA",
             "hex": "0E9648",
-            "source": "https://play.esea.net/"
+            "source": "https://play.esea.net"
         },
         {
             "title": "ESLGaming",
             "hex": "FFFF09",
-            "source": "https://brand.eslgaming.com/",
-            "guidelines": "https://brand.eslgaming.com/"
+            "source": "https://brand.eslgaming.com",
+            "guidelines": "https://brand.eslgaming.com"
         },
         {
             "title": "ESLint",
             "hex": "4B32C3",
-            "source": "https://eslint.org/"
+            "source": "https://eslint.org"
         },
         {
             "title": "ESPHome",
@@ -3641,7 +3641,7 @@
         {
             "title": "Espressif",
             "hex": "E7352C",
-            "source": "https://www.espressif.com/"
+            "source": "https://www.espressif.com"
         },
         {
             "title": "ESRI",
@@ -3700,7 +3700,7 @@
         {
             "title": "Exordo",
             "hex": "DAA449",
-            "source": "https://www.exordo.com/"
+            "source": "https://www.exordo.com"
         },
         {
             "title": "Exoscale",
@@ -3717,7 +3717,7 @@
         {
             "title": "Experts Exchange",
             "hex": "00AAE7",
-            "source": "https://www.experts-exchange.com/"
+            "source": "https://www.experts-exchange.com"
         },
         {
             "title": "Expo",
@@ -3738,12 +3738,12 @@
         {
             "title": "EyeEm",
             "hex": "000000",
-            "source": "https://www.eyeem.com/"
+            "source": "https://www.eyeem.com"
         },
         {
             "title": "F-Droid",
             "hex": "1976D2",
-            "source": "https://f-droid.org/"
+            "source": "https://f-droid.org"
         },
         {
             "title": "F-Secure",
@@ -3753,7 +3753,7 @@
         {
             "title": "F1",
             "hex": "E10600",
-            "source": "https://www.formula1.com/"
+            "source": "https://www.formula1.com"
         },
         {
             "title": "F5",
@@ -3763,7 +3763,7 @@
         {
             "title": "Facebook",
             "hex": "1877F2",
-            "source": "https://en.facebookbrand.com/"
+            "source": "https://en.facebookbrand.com"
         },
         {
             "title": "Facebook Gaming",
@@ -3773,7 +3773,7 @@
         {
             "title": "Facebook Live",
             "hex": "ED4242",
-            "source": "https://en.facebookbrand.com/"
+            "source": "https://en.facebookbrand.com"
         },
         {
             "title": "FACEIT",
@@ -3788,7 +3788,7 @@
         {
             "title": "Falcon",
             "hex": "F0AD4E",
-            "source": "https://falconframework.org/"
+            "source": "https://falconframework.org"
         },
         {
             "title": "FamPay",
@@ -3803,7 +3803,7 @@
         {
             "title": "Fandom",
             "hex": "FA005A",
-            "source": "https://fandomdesignsystem.com/"
+            "source": "https://fandomdesignsystem.com"
         },
         {
             "title": "Fanfou",
@@ -3813,12 +3813,12 @@
         {
             "title": "Fantom",
             "hex": "0928FF",
-            "source": "https://fantom.foundation/"
+            "source": "https://fantom.foundation"
         },
         {
             "title": "FARFETCH",
             "hex": "000000",
-            "source": "https://www.farfetch.com/"
+            "source": "https://www.farfetch.com"
         },
         {
             "title": "FastAPI",
@@ -3848,7 +3848,7 @@
         {
             "title": "Fauna",
             "hex": "3A1AB6",
-            "source": "https://fauna.com/"
+            "source": "https://fauna.com"
         },
         {
             "title": "Favro",
@@ -3858,12 +3858,12 @@
         {
             "title": "FeatHub",
             "hex": "9B9B9B",
-            "source": "https://feathub.com/"
+            "source": "https://feathub.com"
         },
         {
             "title": "FedEx",
             "hex": "4D148C",
-            "source": "https://newsroom.fedex.com/"
+            "source": "https://newsroom.fedex.com"
         },
         {
             "title": "Fedora",
@@ -3878,18 +3878,18 @@
         {
             "title": "Feedly",
             "hex": "2BB24C",
-            "source": "https://blog.feedly.com/"
+            "source": "https://blog.feedly.com"
         },
         {
             "title": "Ferrari",
             "hex": "D40000",
-            "source": "https://www.ferrari.com/"
+            "source": "https://www.ferrari.com"
         },
         {
             "title": "Ferrari N.V.",
             "slug": "ferrarinv",
             "hex": "EB2E2C",
-            "source": "https://corporate.ferrari.com/"
+            "source": "https://corporate.ferrari.com"
         },
         {
             "title": "FFmpeg",
@@ -3936,7 +3936,7 @@
         {
             "title": "Files",
             "hex": "4285F4",
-            "source": "https://files.google.com/"
+            "source": "https://files.google.com"
         },
         {
             "title": "FileZilla",
@@ -3946,7 +3946,7 @@
         {
             "title": "Fing",
             "hex": "009AEE",
-            "source": "https://www.fing.com/"
+            "source": "https://www.fing.com"
         },
         {
             "title": "Firebase",
@@ -3988,12 +3988,12 @@
         {
             "title": "FITE",
             "hex": "CA0404",
-            "source": "https://www.fite.tv/"
+            "source": "https://www.fite.tv"
         },
         {
             "title": "FiveM",
             "hex": "F40552",
-            "source": "https://fivem.net/"
+            "source": "https://fivem.net"
         },
         {
             "title": "Fiverr",
@@ -4017,7 +4017,7 @@
         {
             "title": "Flathub",
             "hex": "000000",
-            "source": "https://flathub.org/"
+            "source": "https://flathub.org"
         },
         {
             "title": "Flatpak",
@@ -4028,12 +4028,12 @@
         {
             "title": "Flattr",
             "hex": "000000",
-            "source": "https://flattr.com/"
+            "source": "https://flattr.com"
         },
         {
             "title": "Flickr",
             "hex": "0063DC",
-            "source": "https://www.flickr.com/"
+            "source": "https://www.flickr.com"
         },
         {
             "title": "Flipboard",
@@ -4043,17 +4043,17 @@
         {
             "title": "Flipkart",
             "hex": "2874F0",
-            "source": "https://www.flipkart.com/"
+            "source": "https://www.flipkart.com"
         },
         {
             "title": "Floatplane",
             "hex": "00AEEF",
-            "source": "https://www.floatplane.com/"
+            "source": "https://www.floatplane.com"
         },
         {
             "title": "Flood",
             "hex": "4285F4",
-            "source": "https://flood.io/"
+            "source": "https://flood.io"
         },
         {
             "title": "Fluent Bit",
@@ -4093,7 +4093,7 @@
         {
             "title": "Fnac",
             "hex": "E1A925",
-            "source": "https://www.fnac.com/"
+            "source": "https://www.fnac.com"
         },
         {
             "title": "Folium",
@@ -4103,7 +4103,7 @@
         {
             "title": "Fonoma",
             "hex": "02B78F",
-            "source": "https://en.fonoma.com/"
+            "source": "https://en.fonoma.com"
         },
         {
             "title": "Font Awesome",
@@ -4113,7 +4113,7 @@
         {
             "title": "FontBase",
             "hex": "3D03A7",
-            "source": "https://fontba.se/"
+            "source": "https://fontba.se"
         },
         {
             "title": "FontForge",
@@ -4133,7 +4133,7 @@
         {
             "title": "Forestry",
             "hex": "343A40",
-            "source": "https://forestry.io/"
+            "source": "https://forestry.io"
         },
         {
             "title": "Formstack",
@@ -4143,7 +4143,7 @@
         {
             "title": "Fortinet",
             "hex": "EE3124",
-            "source": "https://www.fortinet.com/"
+            "source": "https://www.fortinet.com"
         },
         {
             "title": "Fortran",
@@ -4158,7 +4158,7 @@
         {
             "title": "Fossil SCM",
             "hex": "548294",
-            "source": "https://fossil-scm.org/"
+            "source": "https://fossil-scm.org"
         },
         {
             "title": "Foursquare",
@@ -4179,7 +4179,7 @@
         {
             "title": "Foxtel",
             "hex": "EB5205",
-            "source": "https://www.foxtel.com.au/"
+            "source": "https://www.foxtel.com.au"
         },
         {
             "title": "Fozzy",
@@ -4199,12 +4199,12 @@
         {
             "title": "Franprix",
             "hex": "EC6237",
-            "source": "https://www.franprix.fr/"
+            "source": "https://www.franprix.fr"
         },
         {
             "title": "Fraunhofer-Gesellschaft",
             "hex": "179C7D",
-            "source": "https://www.fraunhofer.de/"
+            "source": "https://www.fraunhofer.de"
         },
         {
             "title": "FreeBSD",
@@ -4214,8 +4214,8 @@
         {
             "title": "freeCodeCamp",
             "hex": "0A0A23",
-            "source": "https://design-style-guide.freecodecamp.org/",
-            "guidelines": "https://design-style-guide.freecodecamp.org/",
+            "source": "https://design-style-guide.freecodecamp.org",
+            "guidelines": "https://design-style-guide.freecodecamp.org",
             "license": {
                 "type": "CC-BY-SA-4.0",
                 "url": "https://github.com/freeCodeCamp/design-style-guide/blob/cc950c311c61574b6ecbd9e724b6631026e14bfa/LICENSE"
@@ -4229,7 +4229,7 @@
         {
             "title": "Freelancer",
             "hex": "29B2FE",
-            "source": "https://www.freelancer.com/"
+            "source": "https://www.freelancer.com"
         },
         {
             "title": "FreeNAS",
@@ -4265,13 +4265,13 @@
         {
             "title": "Funimation",
             "hex": "5B0BB5",
-            "source": "https://www.funimation.com/",
+            "source": "https://www.funimation.com",
             "guidelines": "https://brandpad.io/funimationstyleguide"
         },
         {
             "title": "Fur Affinity",
             "hex": "36566F",
-            "source": "https://www.furaffinity.net/"
+            "source": "https://www.furaffinity.net"
         },
         {
             "title": "Furry Network",
@@ -4281,7 +4281,7 @@
         {
             "title": "FutureLearn",
             "hex": "DE00A5",
-            "source": "https://www.futurelearn.com/"
+            "source": "https://www.futurelearn.com"
         },
         {
             "title": "G2",
@@ -4303,7 +4303,7 @@
         {
             "title": "Game Developer",
             "hex": "E60012",
-            "source": "https://www.gamedeveloper.com/",
+            "source": "https://www.gamedeveloper.com",
             "aliases": {
                 "aka": [
                     "Gamasutra"
@@ -4325,7 +4325,7 @@
         {
             "title": "Gatling",
             "hex": "FF9E2A",
-            "source": "https://gatling.io/"
+            "source": "https://gatling.io"
         },
         {
             "title": "Gatsby",
@@ -4336,12 +4336,12 @@
         {
             "title": "Géant",
             "hex": "DD1F26",
-            "source": "https://www.geantcasino.fr/"
+            "source": "https://www.geantcasino.fr"
         },
         {
             "title": "GeeksforGeeks",
             "hex": "2F8D46",
-            "source": "https://www.geeksforgeeks.org/"
+            "source": "https://www.geeksforgeeks.org"
         },
         {
             "title": "General Electric",
@@ -4387,7 +4387,7 @@
         {
             "title": "Ghostery",
             "hex": "00AEF0",
-            "source": "https://www.ghostery.com/",
+            "source": "https://www.ghostery.com",
             "guidelines": "https://www.ghostery.com/press/"
         },
         {
@@ -4420,7 +4420,7 @@
         {
             "title": "Git LFS",
             "hex": "F64935",
-            "source": "https://git-lfs.github.com/"
+            "source": "https://git-lfs.github.com"
         },
         {
             "title": "GitBook",
@@ -4451,7 +4451,7 @@
         {
             "title": "GitHub Pages",
             "hex": "222222",
-            "source": "https://pages.github.com/"
+            "source": "https://pages.github.com"
         },
         {
             "title": "GitHub Sponsors",
@@ -4466,7 +4466,7 @@
         {
             "title": "GitKraken",
             "hex": "179287",
-            "source": "https://www.gitkraken.com/"
+            "source": "https://www.gitkraken.com"
         },
         {
             "title": "GitLab",
@@ -4477,12 +4477,12 @@
         {
             "title": "Gitpod",
             "hex": "FFAE33",
-            "source": "https://www.gitpod.io/"
+            "source": "https://www.gitpod.io"
         },
         {
             "title": "Gitter",
             "hex": "ED1965",
-            "source": "https://gitter.im/"
+            "source": "https://gitter.im"
         },
         {
             "title": "Glassdoor",
@@ -4498,7 +4498,7 @@
         {
             "title": "Globus",
             "hex": "CA6201",
-            "source": "https://www.globus.de/"
+            "source": "https://www.globus.de"
         },
         {
             "title": "Gmail",
@@ -4572,8 +4572,8 @@
         {
             "title": "GoCD",
             "hex": "94399E",
-            "source": "https://www.gocd.org/",
-            "guidelines": "https://www.gocd.org/"
+            "source": "https://www.gocd.org",
+            "guidelines": "https://www.gocd.org"
         },
         {
             "title": "GoDaddy",
@@ -4593,7 +4593,7 @@
         {
             "title": "GoFundMe",
             "hex": "00B964",
-            "source": "https://www.gofundme.com/"
+            "source": "https://www.gofundme.com"
         },
         {
             "title": "GOG.com",
@@ -4619,7 +4619,7 @@
         {
             "title": "Google",
             "hex": "4285F4",
-            "source": "https://partnermarketinghub.withgoogle.com/",
+            "source": "https://partnermarketinghub.withgoogle.com",
             "guidelines": "https://about.google/brand-resource-center/brand-elements/"
         },
         {
@@ -4645,7 +4645,7 @@
         {
             "title": "Google Assistant",
             "hex": "4285F4",
-            "source": "https://assistant.google.com/"
+            "source": "https://assistant.google.com"
         },
         {
             "title": "Google Calendar",
@@ -4660,7 +4660,7 @@
         {
             "title": "Google Chat",
             "hex": "00AC47",
-            "source": "https://chat.google.com/"
+            "source": "https://chat.google.com"
         },
         {
             "title": "Google Chrome",
@@ -4670,12 +4670,12 @@
         {
             "title": "Google Classroom",
             "hex": "0F9D58",
-            "source": "https://classroom.google.com/"
+            "source": "https://classroom.google.com"
         },
         {
             "title": "Google Cloud",
             "hex": "4285F4",
-            "source": "https://cloud.google.com/"
+            "source": "https://cloud.google.com"
         },
         {
             "title": "Google Colab",
@@ -4685,7 +4685,7 @@
         {
             "title": "Google Domains",
             "hex": "4285F4",
-            "source": "https://domains.google/"
+            "source": "https://domains.google"
         },
         {
             "title": "Google Drive",
@@ -4705,7 +4705,7 @@
         {
             "title": "Google Fonts",
             "hex": "4285F4",
-            "source": "https://fonts.google.com/"
+            "source": "https://fonts.google.com"
         },
         {
             "title": "Google Hangouts",
@@ -4725,7 +4725,7 @@
         {
             "title": "Google Lens",
             "hex": "4285F4",
-            "source": "https://lens.google.com/"
+            "source": "https://lens.google.com"
         },
         {
             "title": "Google Maps",
@@ -4745,12 +4745,12 @@
         {
             "title": "Google Messages",
             "hex": "1A73E8",
-            "source": "https://messages.google.com/"
+            "source": "https://messages.google.com"
         },
         {
             "title": "Google My Business",
             "hex": "4285F4",
-            "source": "https://business.google.com/"
+            "source": "https://business.google.com"
         },
         {
             "title": "Google Nearby",
@@ -4803,7 +4803,7 @@
         {
             "title": "Google Sheets",
             "hex": "34A853",
-            "source": "https://sheets.google.com/"
+            "source": "https://sheets.google.com"
         },
         {
             "title": "Google Street View",
@@ -4824,7 +4824,7 @@
         {
             "title": "GoToMeeting",
             "hex": "F68D2E",
-            "source": "https://www.gotomeeting.com/",
+            "source": "https://www.gotomeeting.com",
             "aliases": {
                 "dup": [
                     {
@@ -4849,7 +4849,7 @@
         {
             "title": "Grafana",
             "hex": "F46800",
-            "source": "https://grafana.com/"
+            "source": "https://grafana.com"
         },
         {
             "title": "Grammarly",
@@ -4859,7 +4859,7 @@
         {
             "title": "Grand Frais",
             "hex": "ED2D2F",
-            "source": "https://www.grandfrais.com/"
+            "source": "https://www.grandfrais.com"
         },
         {
             "title": "GraphQL",
@@ -4891,7 +4891,7 @@
         {
             "title": "GreenSock",
             "hex": "88CE02",
-            "source": "https://greensock.com/"
+            "source": "https://greensock.com"
         },
         {
             "title": "Grid.ai",
@@ -4917,7 +4917,7 @@
         {
             "title": "Grubhub",
             "hex": "F63440",
-            "source": "https://www.grubhub.com/"
+            "source": "https://www.grubhub.com"
         },
         {
             "title": "Grunt",
@@ -4989,7 +4989,7 @@
         {
             "title": "Habr",
             "hex": "65A3BE",
-            "source": "https://kiosk.habr.com/"
+            "source": "https://kiosk.habr.com"
         },
         {
             "title": "Hack Club",
@@ -5005,7 +5005,7 @@
         {
             "title": "Hackaday",
             "hex": "1A1A1A",
-            "source": "https://hackaday.com/"
+            "source": "https://hackaday.com"
         },
         {
             "title": "Hacker Noon",
@@ -5048,7 +5048,7 @@
             "title": "Handshake",
             "slug": "handshake_protocol",
             "hex": "000000",
-            "source": "https://handshake.org/"
+            "source": "https://handshake.org"
         },
         {
             "title": "HappyCow",
@@ -5063,7 +5063,7 @@
         {
             "title": "HarmonyOS",
             "hex": "000000",
-            "source": "https://www.harmonyos.com/",
+            "source": "https://www.harmonyos.com",
             "aliases": {
                 "aka": [
                     "HMOS"
@@ -5093,7 +5093,7 @@
         {
             "title": "haveibeenpwned",
             "hex": "2A6379",
-            "source": "https://haveibeenpwned.com/"
+            "source": "https://haveibeenpwned.com"
         },
         {
             "title": "Haxe",
@@ -5104,7 +5104,7 @@
         {
             "title": "HBO",
             "hex": "000000",
-            "source": "https://www.hbo.com/"
+            "source": "https://www.hbo.com"
         },
         {
             "title": "HCL",
@@ -5115,7 +5115,7 @@
         {
             "title": "Headless UI",
             "hex": "66E3FF",
-            "source": "https://headlessui.dev/"
+            "source": "https://headlessui.dev"
         },
         {
             "title": "Headspace",
@@ -5136,7 +5136,7 @@
         {
             "title": "Helly Hansen",
             "hex": "DA2128",
-            "source": "https://www.hellyhansen.com/"
+            "source": "https://www.hellyhansen.com"
         },
         {
             "title": "Helm",
@@ -5151,8 +5151,8 @@
         {
             "title": "HelpDesk",
             "hex": "2FC774",
-            "source": "https://helpdesk.design/",
-            "guidelines": "https://helpdesk.design/"
+            "source": "https://helpdesk.design",
+            "guidelines": "https://helpdesk.design"
         },
         {
             "title": "HERE",
@@ -5162,28 +5162,28 @@
         {
             "title": "Heroku",
             "hex": "430098",
-            "source": "https://brand.heroku.com/",
-            "guidelines": "https://brand.heroku.com/"
+            "source": "https://brand.heroku.com",
+            "guidelines": "https://brand.heroku.com"
         },
         {
             "title": "Hetzner",
             "hex": "D50C2D",
-            "source": "https://www.hetzner.com/"
+            "source": "https://www.hetzner.com"
         },
         {
             "title": "Hexo",
             "hex": "0E83CD",
-            "source": "https://hexo.io/"
+            "source": "https://hexo.io"
         },
         {
             "title": "HEY",
             "hex": "5522FA",
-            "source": "https://hey.com/"
+            "source": "https://hey.com"
         },
         {
             "title": "Hi Bob",
             "hex": "E42C51",
-            "source": "https://www.hibob.com/",
+            "source": "https://www.hibob.com",
             "aliases": {
                 "aka": [
                     "Bob"
@@ -5193,7 +5193,7 @@
         {
             "title": "Hibernate",
             "hex": "59666C",
-            "source": "https://hibernate.org/"
+            "source": "https://hibernate.org"
         },
         {
             "title": "Hilton",
@@ -5208,7 +5208,7 @@
         {
             "title": "Hive",
             "hex": "FF7A00",
-            "source": "https://www.hivehome.com/"
+            "source": "https://www.hivehome.com"
         },
         {
             "title": "Hive",
@@ -5227,12 +5227,12 @@
         {
             "title": "Home Assistant Community Store",
             "hex": "41BDF5",
-            "source": "https://hacs.xyz/"
+            "source": "https://hacs.xyz"
         },
         {
             "title": "HomeAdvisor",
             "hex": "F68315",
-            "source": "https://www.homeadvisor.com/"
+            "source": "https://www.homeadvisor.com"
         },
         {
             "title": "Homebrew",
@@ -5252,12 +5252,12 @@
         {
             "title": "Honda",
             "hex": "E40521",
-            "source": "https://www.honda.ie/"
+            "source": "https://www.honda.ie"
         },
         {
             "title": "Honey",
             "hex": "FF6801",
-            "source": "https://www.joinhoney.com/"
+            "source": "https://www.joinhoney.com"
         },
         {
             "title": "Hootsuite",
@@ -5278,7 +5278,7 @@
         {
             "title": "Hotjar",
             "hex": "FD3A5C",
-            "source": "https://www.hotjar.com/"
+            "source": "https://www.hotjar.com"
         },
         {
             "title": "Houdini",
@@ -5299,7 +5299,7 @@
         {
             "title": "HTML Academy",
             "hex": "302683",
-            "source": "https://htmlacademy.ru/"
+            "source": "https://htmlacademy.ru"
         },
         {
             "title": "HTML5",
@@ -5326,13 +5326,13 @@
         {
             "title": "Hugo",
             "hex": "FF4088",
-            "source": "https://gohugo.io/"
+            "source": "https://gohugo.io"
         },
         {
             "title": "Hulu",
             "hex": "1CE783",
-            "source": "https://thisis.hulu.com/",
-            "guidelines": "https://thisis.hulu.com/"
+            "source": "https://thisis.hulu.com",
+            "guidelines": "https://thisis.hulu.com"
         },
         {
             "title": "Humble Bundle",
@@ -5342,7 +5342,7 @@
         {
             "title": "Hungry Jack's",
             "hex": "D0021B",
-            "source": "https://www.hungryjacks.com.au/"
+            "source": "https://www.hungryjacks.com.au"
         },
         {
             "title": "Hurriyetemlak",
@@ -5357,12 +5357,12 @@
         {
             "title": "Hyper",
             "hex": "000000",
-            "source": "https://hyper.is/"
+            "source": "https://hyper.is"
         },
         {
             "title": "Hyperledger",
             "hex": "2F3134",
-            "source": "https://www.hyperledger.org/"
+            "source": "https://www.hyperledger.org"
         },
         {
             "title": "Hypothesis",
@@ -5414,7 +5414,7 @@
         {
             "title": "Iceland",
             "hex": "CC092F",
-            "source": "https://www.iceland.co.uk/"
+            "source": "https://www.iceland.co.uk"
         },
         {
             "title": "Icinga",
@@ -5429,7 +5429,7 @@
         {
             "title": "IcoMoon",
             "hex": "825794",
-            "source": "https://icomoon.io/"
+            "source": "https://icomoon.io"
         },
         {
             "title": "ICON",
@@ -5444,17 +5444,17 @@
         {
             "title": "Iconify",
             "hex": "1769AA",
-            "source": "https://iconify.design/"
+            "source": "https://iconify.design"
         },
         {
             "title": "IconJar",
             "hex": "16A5F3",
-            "source": "https://geticonjar.com/"
+            "source": "https://geticonjar.com"
         },
         {
             "title": "Icons8",
             "hex": "1FB141",
-            "source": "https://icons8.com/"
+            "source": "https://icons8.com"
         },
         {
             "title": "ICQ",
@@ -5470,13 +5470,13 @@
         {
             "title": "iFixit",
             "hex": "0071CE",
-            "source": "https://www.ifixit.com/",
+            "source": "https://www.ifixit.com",
             "guidelines": "https://www.ifixit.com/Info/Media"
         },
         {
             "title": "iFood",
             "hex": "EA1D2C",
-            "source": "https://ifood.com.br/"
+            "source": "https://ifood.com.br"
         },
         {
             "title": "IFTTT",
@@ -5493,7 +5493,7 @@
         {
             "title": "IKEA",
             "hex": "0058A3",
-            "source": "https://www.ikea.com/"
+            "source": "https://www.ikea.com"
         },
         {
             "title": "Île-de-France Mobilités",
@@ -5546,7 +5546,7 @@
         {
             "title": "Informatica",
             "hex": "FF4D00",
-            "source": "https://www.informatica.com/"
+            "source": "https://www.informatica.com"
         },
         {
             "title": "Infosys",
@@ -5579,7 +5579,7 @@
         {
             "title": "Insomnia",
             "hex": "4000BF",
-            "source": "https://insomnia.rest/"
+            "source": "https://insomnia.rest"
         },
         {
             "title": "Instacart",
@@ -5595,12 +5595,12 @@
         {
             "title": "Instapaper",
             "hex": "1F1F1F",
-            "source": "https://www.instapaper.com/"
+            "source": "https://www.instapaper.com"
         },
         {
             "title": "Instatus",
             "hex": "4EE3C2",
-            "source": "https://www.instatus.com/"
+            "source": "https://www.instatus.com"
         },
         {
             "title": "Instructables",
@@ -5632,7 +5632,7 @@
         {
             "title": "Interaction Design Foundation",
             "hex": "2B2B2B",
-            "source": "https://www.interaction-design.org/"
+            "source": "https://www.interaction-design.org"
         },
         {
             "title": "InteractJS",
@@ -5648,12 +5648,12 @@
         {
             "title": "Intermarche",
             "hex": "E2001A",
-            "source": "https://www.intermarche.com/"
+            "source": "https://www.intermarche.com"
         },
         {
             "title": "Internet Archive",
             "hex": "666666",
-            "source": "https://archive.org/"
+            "source": "https://archive.org"
         },
         {
             "title": "Internet Explorer",
@@ -5663,7 +5663,7 @@
         {
             "title": "Intigriti",
             "hex": "161A36",
-            "source": "https://www.intigriti.com/"
+            "source": "https://www.intigriti.com"
         },
         {
             "title": "InVision",
@@ -5773,7 +5773,7 @@
         {
             "title": "Jameson",
             "hex": "004027",
-            "source": "https://www.jamesonwhiskey.com/"
+            "source": "https://www.jamesonwhiskey.com"
         },
         {
             "title": "Jamstack",
@@ -5796,7 +5796,7 @@
         {
             "title": "JBL",
             "hex": "FF3300",
-            "source": "https://www.jbl.com/"
+            "source": "https://www.jbl.com"
         },
         {
             "title": "JCB",
@@ -5841,7 +5841,7 @@
         {
             "title": "Jest",
             "hex": "C21325",
-            "source": "https://jestjs.io/"
+            "source": "https://jestjs.io"
         },
         {
             "title": "JET",
@@ -5868,7 +5868,7 @@
         {
             "title": "JFrog Bintray",
             "hex": "43A047",
-            "source": "https://bintray.com/"
+            "source": "https://bintray.com"
         },
         {
             "title": "Jinja",
@@ -5931,7 +5931,7 @@
         {
             "title": "JR Group",
             "hex": "000000",
-            "source": "https://www.jrhokkaido.co.jp/"
+            "source": "https://www.jrhokkaido.co.jp"
         },
         {
             "title": "jsDelivr",
@@ -5941,7 +5941,7 @@
         {
             "title": "JSFiddle",
             "hex": "0084FF",
-            "source": "https://jsfiddle.net/"
+            "source": "https://jsfiddle.net"
         },
         {
             "title": "JSON",
@@ -5951,17 +5951,17 @@
         {
             "title": "JSON Web Tokens",
             "hex": "000000",
-            "source": "https://jwt.io/"
+            "source": "https://jwt.io"
         },
         {
             "title": "JSS",
             "hex": "F7DF1E",
-            "source": "https://cssinjs.org/"
+            "source": "https://cssinjs.org"
         },
         {
             "title": "JUKE",
             "hex": "6CD74A",
-            "source": "https://juke.nl/"
+            "source": "https://juke.nl"
         },
         {
             "title": "Julia",
@@ -5998,7 +5998,7 @@
         {
             "title": "K3s",
             "hex": "FFC61C",
-            "source": "https://k3s.io/"
+            "source": "https://k3s.io"
         },
         {
             "title": "k6",
@@ -6061,7 +6061,7 @@
         {
             "title": "KashFlow",
             "hex": "E5426E",
-            "source": "https://www.kashflow.com/"
+            "source": "https://www.kashflow.com"
         },
         {
             "title": "Kaspersky",
@@ -6097,7 +6097,7 @@
         {
             "title": "Keep a Changelog",
             "hex": "E05735",
-            "source": "https://keepachangelog.com/"
+            "source": "https://keepachangelog.com"
         },
         {
             "title": "KeePassXC",
@@ -6112,7 +6112,7 @@
         {
             "title": "Keras",
             "hex": "D00000",
-            "source": "https://keras.io/"
+            "source": "https://keras.io"
         },
         {
             "title": "Keybase",
@@ -6127,7 +6127,7 @@
         {
             "title": "Keystone",
             "hex": "166BFF",
-            "source": "https://keystonejs.com/"
+            "source": "https://keystonejs.com"
         },
         {
             "title": "KFC",
@@ -6187,12 +6187,12 @@
                 ]
             },
             "hex": "000000",
-            "source": "https://www.kingston.com/"
+            "source": "https://www.kingston.com"
         },
         {
             "title": "KinoPoisk",
             "hex": "FF6600",
-            "source": "https://www.kinopoisk.ru/",
+            "source": "https://www.kinopoisk.ru",
             "aliases": {
                 "loc": {
                     "ru-RU": "КиноПоиск"
@@ -6207,12 +6207,12 @@
         {
             "title": "Kitsu",
             "hex": "FD755C",
-            "source": "https://kitsu.io/"
+            "source": "https://kitsu.io"
         },
         {
             "title": "Klarna",
             "hex": "FFB3C7",
-            "source": "https://klarna.design/"
+            "source": "https://klarna.design"
         },
         {
             "title": "KLM",
@@ -6250,7 +6250,7 @@
         {
             "title": "Koa",
             "hex": "33333D",
-            "source": "https://koajs.com/"
+            "source": "https://koajs.com"
         },
         {
             "title": "Koc",
@@ -6260,12 +6260,12 @@
         {
             "title": "Kodi",
             "hex": "17B2E7",
-            "source": "https://kodi.tv/"
+            "source": "https://kodi.tv"
         },
         {
             "title": "Kofax",
             "hex": "00558C",
-            "source": "https://www.kofax.com/"
+            "source": "https://www.kofax.com"
         },
         {
             "title": "Komoot",
@@ -6303,7 +6303,7 @@
         {
             "title": "Koyeb",
             "hex": "121212",
-            "source": "https://www.koyeb.com/"
+            "source": "https://www.koyeb.com"
         },
         {
             "title": "Krita",
@@ -6344,7 +6344,7 @@
         {
             "title": "Kyocera",
             "hex": "DF0522",
-            "source": "https://uk.kyocera.com/"
+            "source": "https://uk.kyocera.com"
         },
         {
             "title": "LabVIEW",
@@ -6375,7 +6375,7 @@
         {
             "title": "Laragon",
             "hex": "0E83CD",
-            "source": "https://laragon.org/"
+            "source": "https://laragon.org"
         },
         {
             "title": "Laravel",
@@ -6390,7 +6390,7 @@
         {
             "title": "Laravel Nova",
             "hex": "252D37",
-            "source": "https://nova.laravel.com/"
+            "source": "https://nova.laravel.com"
         },
         {
             "title": "Last.fm",
@@ -6477,7 +6477,7 @@
         {
             "title": "Leroy Merlin",
             "hex": "78BE20",
-            "source": "https://www.leroymerlin.fr/"
+            "source": "https://www.leroymerlin.fr"
         },
         {
             "title": "Less",
@@ -6512,7 +6512,7 @@
         {
             "title": "LGTM",
             "hex": "FFFFFF",
-            "source": "https://lgtm.com/"
+            "source": "https://lgtm.com"
         },
         {
             "title": "Liberapay",
@@ -6552,7 +6552,7 @@
         {
             "title": "Lidl",
             "hex": "0050AA",
-            "source": "https://www.lidl.de/"
+            "source": "https://www.lidl.de"
         },
         {
             "title": "LIFX",
@@ -6579,13 +6579,13 @@
         {
             "title": "LineageOS",
             "hex": "167C80",
-            "source": "https://www.lineageos.org/",
+            "source": "https://www.lineageos.org",
             "guidelines": "https://docs.google.com/presentation/d/1VmxFrVqkjtNMjZbAcrC4egp8C_So7gjJR3KuxdJfJDo/edit?usp=sharing"
         },
         {
             "title": "Linear",
             "hex": "5E6AD2",
-            "source": "https://linear.app/"
+            "source": "https://linear.app"
         },
         {
             "title": "LinkedIn",
@@ -6601,7 +6601,7 @@
         {
             "title": "Linkfire",
             "hex": "FF3850",
-            "source": "https://www.linkfire.com/"
+            "source": "https://www.linkfire.com"
         },
         {
             "title": "Linktree",
@@ -6654,13 +6654,13 @@
         {
             "title": "LITIENGINE",
             "hex": "00A5BC",
-            "source": "https://litiengine.com/"
+            "source": "https://litiengine.com"
         },
         {
             "title": "LiveChat",
             "hex": "FF5100",
-            "source": "https://livechat.design/",
-            "guidelines": "https://livechat.design/"
+            "source": "https://livechat.design",
+            "guidelines": "https://livechat.design"
         },
         {
             "title": "LiveJournal",
@@ -6670,7 +6670,7 @@
         {
             "title": "Livewire",
             "hex": "4E56A6",
-            "source": "https://laravel-livewire.com/"
+            "source": "https://laravel-livewire.com"
         },
         {
             "title": "LLVM",
@@ -6707,7 +6707,7 @@
         {
             "title": "Looker",
             "hex": "4285F4",
-            "source": "https://looker.com/"
+            "source": "https://looker.com"
         },
         {
             "title": "Loom",
@@ -6717,7 +6717,7 @@
         {
             "title": "Loop",
             "hex": "F29400",
-            "source": "https://loop.frontiersin.org/"
+            "source": "https://loop.frontiersin.org"
         },
         {
             "title": "LoopBack",
@@ -6744,7 +6744,7 @@
         {
             "title": "Lubuntu",
             "hex": "0068C8",
-            "source": "https://lubuntu.net/"
+            "source": "https://lubuntu.net"
         },
         {
             "title": "Ludwig",
@@ -6754,12 +6754,12 @@
         {
             "title": "Lufthansa",
             "hex": "05164D",
-            "source": "https://www.lufthansa.com/"
+            "source": "https://www.lufthansa.com"
         },
         {
             "title": "Lumen",
             "hex": "E74430",
-            "source": "https://lumen.laravel.com/"
+            "source": "https://lumen.laravel.com"
         },
         {
             "title": "Lunacy",
@@ -6850,7 +6850,7 @@
         {
             "title": "MAN",
             "hex": "E40045",
-            "source": "https://www.corporate.man.eu/"
+            "source": "https://www.corporate.man.eu"
         },
         {
             "title": "ManageIQ",
@@ -6860,7 +6860,7 @@
         {
             "title": "Manjaro",
             "hex": "35BF5C",
-            "source": "https://manjaro.org/"
+            "source": "https://manjaro.org"
         },
         {
             "title": "Mapbox",
@@ -6877,7 +6877,7 @@
         {
             "title": "MariaDB Foundation",
             "hex": "1F305F",
-            "source": "https://mariadb.org/"
+            "source": "https://mariadb.org"
         },
         {
             "title": "Markdown",
@@ -6891,7 +6891,7 @@
         {
             "title": "Marketo",
             "hex": "5C4C9F",
-            "source": "https://www.marketo.com/"
+            "source": "https://www.marketo.com"
         },
         {
             "title": "Marko",
@@ -6901,7 +6901,7 @@
         {
             "title": "Marriott",
             "hex": "A70023",
-            "source": "https://marriott-hotels.marriott.com/"
+            "source": "https://marriott-hotels.marriott.com"
         },
         {
             "title": "Maserati",
@@ -6966,7 +6966,7 @@
         {
             "title": "Max",
             "hex": "525252",
-            "source": "https://cycling74.com/"
+            "source": "https://cycling74.com"
         },
         {
             "title": "Max-Planck-Gesellschaft",
@@ -6996,7 +6996,7 @@
         {
             "title": "McLaren",
             "hex": "FF0000",
-            "source": "https://cars.mclaren.com/"
+            "source": "https://cars.mclaren.com"
         },
         {
             "title": "mdBook",
@@ -7022,7 +7022,7 @@
         {
             "title": "MediaMarkt",
             "hex": "DF0000",
-            "source": "https://www.mediamarkt.de/"
+            "source": "https://www.mediamarkt.de"
         },
         {
             "title": "MediaTek",
@@ -7032,7 +7032,7 @@
         {
             "title": "MediaTemple",
             "hex": "000000",
-            "source": "https://mediatemple.net/"
+            "source": "https://mediatemple.net"
         },
         {
             "title": "Medium",
@@ -7053,22 +7053,22 @@
         {
             "title": "Mendeley",
             "hex": "9D1620",
-            "source": "https://www.mendeley.com/"
+            "source": "https://www.mendeley.com"
         },
         {
             "title": "Mercado Pago",
             "hex": "00B1EA",
-            "source": "https://www.mercadopago.com/"
+            "source": "https://www.mercadopago.com"
         },
         {
             "title": "Mercedes",
             "hex": "242424",
-            "source": "https://www.mercedes-benz.com/"
+            "source": "https://www.mercedes-benz.com"
         },
         {
             "title": "Merck",
             "hex": "007A73",
-            "source": "https://www.merck.com/"
+            "source": "https://www.merck.com"
         },
         {
             "title": "Mercurial",
@@ -7094,7 +7094,7 @@
         {
             "title": "Metabase",
             "hex": "509EE3",
-            "source": "https://www.metabase.com/"
+            "source": "https://www.metabase.com"
         },
         {
             "title": "MetaFilter",
@@ -7104,7 +7104,7 @@
         {
             "title": "Meteor",
             "hex": "DE4F4F",
-            "source": "https://logo.meteorapp.com/"
+            "source": "https://logo.meteorapp.com"
         },
         {
             "title": "Metro",
@@ -7124,7 +7124,7 @@
         {
             "title": "Métro de Paris",
             "hex": "003E95",
-            "source": "https://www.ratp.fr/"
+            "source": "https://www.ratp.fr"
         },
         {
             "title": "MeWe",
@@ -7134,17 +7134,17 @@
         {
             "title": "micro:bit",
             "hex": "00ED00",
-            "source": "https://microbit.org/"
+            "source": "https://microbit.org"
         },
         {
             "title": "Micro.blog",
             "hex": "FF8800",
-            "source": "https://help.micro.blog/"
+            "source": "https://help.micro.blog"
         },
         {
             "title": "Microgenetics",
             "hex": "FF0000",
-            "source": "https://microgenetics.co.uk/"
+            "source": "https://microgenetics.co.uk"
         },
         {
             "title": "MicroPython",
@@ -7159,7 +7159,7 @@
         {
             "title": "Microsoft Academic",
             "hex": "2D9FD9",
-            "source": "https://academic.microsoft.com/"
+            "source": "https://academic.microsoft.com"
         },
         {
             "title": "Microsoft Access",
@@ -7273,7 +7273,7 @@
         {
             "title": "Minetest",
             "hex": "53AC56",
-            "source": "https://www.minetest.net/"
+            "source": "https://www.minetest.net"
         },
         {
             "title": "Mini",
@@ -7288,7 +7288,7 @@
         {
             "title": "Miro",
             "hex": "050038",
-            "source": "https://miro.com/"
+            "source": "https://miro.com"
         },
         {
             "title": "Misskey",
@@ -7301,7 +7301,7 @@
         {
             "title": "Mitsubishi",
             "hex": "E60012",
-            "source": "https://www.mitsubishi.com/"
+            "source": "https://www.mitsubishi.com"
         },
         {
             "title": "Mix",
@@ -7317,7 +7317,7 @@
         {
             "title": "MLB",
             "hex": "041E42",
-            "source": "https://www.mlb.com/",
+            "source": "https://www.mlb.com",
             "aliases": {
                 "aka": [
                     "Major League Baseball"
@@ -7342,12 +7342,12 @@
         {
             "title": "Mocha",
             "hex": "8D6748",
-            "source": "https://mochajs.org/"
+            "source": "https://mochajs.org"
         },
         {
             "title": "Modin",
             "hex": "001729",
-            "source": "https://modin.org/"
+            "source": "https://modin.org"
         },
         {
             "title": "Modrinth",
@@ -7357,7 +7357,7 @@
         {
             "title": "MODX",
             "hex": "102C53",
-            "source": "https://docs.modx.com/"
+            "source": "https://docs.modx.com"
         },
         {
             "title": "Mojang Studios",
@@ -7367,7 +7367,7 @@
         {
             "title": "Moleculer",
             "hex": "3CAFCE",
-            "source": "https://moleculer.services/"
+            "source": "https://moleculer.services"
         },
         {
             "title": "Momenteo",
@@ -7412,7 +7412,7 @@
         {
             "title": "Monoprix",
             "hex": "FB1911",
-            "source": "https://www.monoprix.fr/"
+            "source": "https://www.monoprix.fr"
         },
         {
             "title": "Monster",
@@ -7442,12 +7442,12 @@
         {
             "title": "Moscow Metro",
             "hex": "D9232E",
-            "source": "https://mosmetro.ru/"
+            "source": "https://mosmetro.ru"
         },
         {
             "title": "Motorola",
             "hex": "E1140A",
-            "source": "https://motorola-global-portal-de.custhelp.com/"
+            "source": "https://motorola-global-portal-de.custhelp.com"
         },
         {
             "title": "Mozilla",
@@ -7478,7 +7478,7 @@
         {
             "title": "MTA",
             "hex": "0039A6",
-            "source": "https://mta.info/"
+            "source": "https://mta.info"
         },
         {
             "title": "MTR",
@@ -7488,7 +7488,7 @@
         {
             "title": "MUBI",
             "hex": "000000",
-            "source": "https://mubi.com/"
+            "source": "https://mubi.com"
         },
         {
             "title": "MUI",
@@ -7509,7 +7509,7 @@
         {
             "title": "Müller",
             "hex": "F46519",
-            "source": "https://www.mueller.de/"
+            "source": "https://www.mueller.de"
         },
         {
             "title": "Mumble",
@@ -7548,7 +7548,7 @@
         {
             "title": "Myspace",
             "hex": "030303",
-            "source": "https://myspace.com/"
+            "source": "https://myspace.com"
         },
         {
             "title": "MySQL",
@@ -7559,17 +7559,17 @@
         {
             "title": "N26",
             "hex": "48AC98",
-            "source": "https://n26.com/"
+            "source": "https://n26.com"
         },
         {
             "title": "Namebase",
             "hex": "0068FF",
-            "source": "https://www.namebase.io/"
+            "source": "https://www.namebase.io"
         },
         {
             "title": "Namecheap",
             "hex": "DE3723",
-            "source": "https://www.namecheap.com/"
+            "source": "https://www.namecheap.com"
         },
         {
             "title": "Nano",
@@ -7586,12 +7586,12 @@
         {
             "title": "National Grid",
             "hex": "00148C",
-            "source": "https://www.nationalgrid.com/"
+            "source": "https://www.nationalgrid.com"
         },
         {
             "title": "NativeScript",
             "hex": "65ADF1",
-            "source": "https://docs.nativescript.org/"
+            "source": "https://docs.nativescript.org"
         },
         {
             "title": "Naver",
@@ -7608,7 +7608,7 @@
         {
             "title": "NBA",
             "hex": "253B73",
-            "source": "https://nba.com/"
+            "source": "https://nba.com"
         },
         {
             "title": "NBB",
@@ -7618,7 +7618,7 @@
         {
             "title": "NDR",
             "hex": "0C1754",
-            "source": "https://www.ndr.de/"
+            "source": "https://www.ndr.de"
         },
         {
             "title": "NEC",
@@ -7634,7 +7634,7 @@
         {
             "title": "Neovim",
             "hex": "57A143",
-            "source": "https://neovim.io/",
+            "source": "https://neovim.io",
             "license": {
                 "type": "CC-BY-SA-3.0"
             }
@@ -7642,12 +7642,12 @@
         {
             "title": "NestJS",
             "hex": "E0234E",
-            "source": "https://nestjs.com/"
+            "source": "https://nestjs.com"
         },
         {
             "title": "NetApp",
             "hex": "0067C5",
-            "source": "https://www.netapp.com/",
+            "source": "https://www.netapp.com",
             "guidelines": "https://www.netapp.com/company/legal/trademark-guidelines/"
         },
         {
@@ -7672,7 +7672,7 @@
                     {
                         "title": "Netlify CMS",
                         "hex": "C9FA4B",
-                        "source": "https://www.netlifycms.org/"
+                        "source": "https://www.netlifycms.org"
                     }
                 ]
             }
@@ -7710,7 +7710,7 @@
                     {
                         "title": "NJPW World",
                         "hex": "B79C65",
-                        "source": "https://njpwworld.com/"
+                        "source": "https://njpwworld.com"
                     }
                 ],
                 "loc": {
@@ -7727,12 +7727,12 @@
         {
             "title": "New York Times",
             "hex": "000000",
-            "source": "https://www.nytimes.com/"
+            "source": "https://www.nytimes.com"
         },
         {
             "title": "Next.js",
             "hex": "000000",
-            "source": "https://nextjs.org/"
+            "source": "https://nextjs.org"
         },
         {
             "title": "NextBillion.ai",
@@ -7765,17 +7765,17 @@
         {
             "title": "ngrok",
             "hex": "1F1E37",
-            "source": "https://ngrok.com/"
+            "source": "https://ngrok.com"
         },
         {
             "title": "niconico",
             "hex": "231815",
-            "source": "https://www.nicovideo.jp/"
+            "source": "https://www.nicovideo.jp"
         },
         {
             "title": "Nike",
             "hex": "111111",
-            "source": "https://www.nike.com/"
+            "source": "https://www.nike.com"
         },
         {
             "title": "Nim",
@@ -7790,7 +7790,7 @@
         {
             "title": "Nintendo 3DS",
             "hex": "D12228",
-            "source": "https://www.nintendo.de/"
+            "source": "https://www.nintendo.de"
         },
         {
             "title": "Nintendo GameCube",
@@ -7810,7 +7810,7 @@
         {
             "title": "Nissan",
             "hex": "C3002F",
-            "source": "https://www.nissan.ie/"
+            "source": "https://www.nissan.ie"
         },
         {
             "title": "NixOS",
@@ -7831,17 +7831,17 @@
         {
             "title": "Nodemon",
             "hex": "76D04B",
-            "source": "https://nodemon.io/"
+            "source": "https://nodemon.io"
         },
         {
             "title": "Nokia",
             "hex": "124191",
-            "source": "https://www.nokia.com/"
+            "source": "https://www.nokia.com"
         },
         {
             "title": "Norco",
             "hex": "00FF00",
-            "source": "https://www.norco.com/"
+            "source": "https://www.norco.com"
         },
         {
             "title": "NordVPN",
@@ -7867,12 +7867,12 @@
         {
             "title": "Notion",
             "hex": "000000",
-            "source": "https://www.notion.so/"
+            "source": "https://www.notion.so"
         },
         {
             "title": "Notist",
             "hex": "333333",
-            "source": "https://noti.st/"
+            "source": "https://noti.st"
         },
         {
             "title": "Noun Project",
@@ -7887,12 +7887,12 @@
         {
             "title": "NOW",
             "hex": "001211",
-            "source": "https://www.nowtv.com/"
+            "source": "https://www.nowtv.com"
         },
         {
             "title": "npm",
             "hex": "CB3837",
-            "source": "https://www.npmjs.com/",
+            "source": "https://www.npmjs.com",
             "guidelines": "https://www.npmjs.com/policies/trademark"
         },
         {
@@ -7908,7 +7908,7 @@
         {
             "title": "Nucleo",
             "hex": "252B2D",
-            "source": "https://nucleoapp.com/"
+            "source": "https://nucleoapp.com"
         },
         {
             "title": "NuGet",
@@ -7955,12 +7955,12 @@
         {
             "title": "Nx",
             "hex": "143055",
-            "source": "https://nx.dev/"
+            "source": "https://nx.dev"
         },
         {
             "title": "NZXT",
             "hex": "000000",
-            "source": "https://nzxt.com/",
+            "source": "https://nzxt.com",
             "guidelines": "https://nzxt.com/about/brand-guidelines"
         },
         {
@@ -7977,12 +7977,12 @@
         {
             "title": "Observable",
             "hex": "353E58",
-            "source": "https://observablehq.com/"
+            "source": "https://observablehq.com"
         },
         {
             "title": "Obsidian",
             "hex": "483699",
-            "source": "https://obsidian.md/"
+            "source": "https://obsidian.md"
         },
         {
             "title": "OCaml",
@@ -8075,7 +8075,7 @@
         {
             "title": "OnStar",
             "hex": "003D7D",
-            "source": "https://www.onstar.com/"
+            "source": "https://www.onstar.com"
         },
         {
             "title": "Opel",
@@ -8090,12 +8090,12 @@
         {
             "title": "Open Badges",
             "hex": "073B5A",
-            "source": "https://backpack.openbadges.org/"
+            "source": "https://backpack.openbadges.org"
         },
         {
             "title": "Open Bug Bounty",
             "hex": "F67909",
-            "source": "https://www.openbugbounty.org/"
+            "source": "https://www.openbugbounty.org"
         },
         {
             "title": "Open Collective",
@@ -8116,12 +8116,12 @@
         {
             "title": "OpenAI",
             "hex": "412991",
-            "source": "https://openai.com/"
+            "source": "https://openai.com"
         },
         {
             "title": "OpenAI Gym",
             "hex": "0081A5",
-            "source": "https://gym.openai.com/"
+            "source": "https://gym.openai.com"
         },
         {
             "title": "OpenAPI Initiative",
@@ -8143,7 +8143,7 @@
         {
             "title": "OpenFaaS",
             "hex": "3B5EE9",
-            "source": "https://docs.openfaas.com/"
+            "source": "https://docs.openfaas.com"
         },
         {
             "title": "OpenGL",
@@ -8168,8 +8168,8 @@
         {
             "title": "OpenMined",
             "hex": "ED986C",
-            "source": "https://www.openmined.org/",
-            "guidelines": "https://www.openmined.org/"
+            "source": "https://www.openmined.org",
+            "guidelines": "https://www.openmined.org"
         },
         {
             "title": "OpenNebula",
@@ -8195,7 +8195,7 @@
         {
             "title": "OpenSSL",
             "hex": "721412",
-            "source": "https://www.openssl.org/"
+            "source": "https://www.openssl.org"
         },
         {
             "title": "OpenStack",
@@ -8251,7 +8251,7 @@
         {
             "title": "OpenZeppelin",
             "hex": "4E5EE4",
-            "source": "https://openzeppelin.com/"
+            "source": "https://openzeppelin.com"
         },
         {
             "title": "OpenZFS",
@@ -8262,7 +8262,7 @@
             "title": "Opera",
             "hex": "FF1B2D",
             "source": "https://brand.opera.com/1472-2/opera-logos/",
-            "guidelines": "https://brand.opera.com/"
+            "guidelines": "https://brand.opera.com"
         },
         {
             "title": "OPNSense",
@@ -8278,7 +8278,7 @@
         {
             "title": "OpsLevel",
             "hex": "1890FF",
-            "source": "https://www.opslevel.com/"
+            "source": "https://www.opslevel.com"
         },
         {
             "title": "Oracle",
@@ -8310,7 +8310,7 @@
         {
             "title": "OSGeo",
             "hex": "5CAE58",
-            "source": "https://www.osgeo.org/"
+            "source": "https://www.osgeo.org"
         },
         {
             "title": "Oshkosh",
@@ -8359,13 +8359,13 @@
         {
             "title": "Oxygen",
             "hex": "3A209E",
-            "source": "https://oxygenbuilder.com/",
+            "source": "https://oxygenbuilder.com",
             "guidelines": "https://oxygenbuilder.com/trademark-policy/"
         },
         {
             "title": "OYO",
             "hex": "EE2E24",
-            "source": "https://www.oyorooms.com/"
+            "source": "https://www.oyorooms.com"
         },
         {
             "title": "p5.js",
@@ -8394,7 +8394,7 @@
         {
             "title": "Paddy Power",
             "hex": "004833",
-            "source": "https://www.paddypower.com/"
+            "source": "https://www.paddypower.com"
         },
         {
             "title": "Pagekit",
@@ -8416,7 +8416,7 @@
         {
             "title": "PagSeguro",
             "hex": "FFC801",
-            "source": "https://pagseguro.uol.com.br/"
+            "source": "https://pagseguro.uol.com.br"
         },
         {
             "title": "Palantir",
@@ -8437,7 +8437,7 @@
         {
             "title": "Pandora",
             "hex": "224099",
-            "source": "https://www.pandoraforbrands.com/"
+            "source": "https://www.pandoraforbrands.com"
         },
         {
             "title": "Pantheon",
@@ -8453,7 +8453,7 @@
         {
             "title": "Parity Substrate",
             "hex": "282828",
-            "source": "https://substrate.dev/"
+            "source": "https://substrate.dev"
         },
         {
             "title": "Parse.ly",
@@ -8464,12 +8464,12 @@
         {
             "title": "Passport",
             "hex": "34E27A",
-            "source": "https://www.passportjs.org/"
+            "source": "https://www.passportjs.org"
         },
         {
             "title": "Pastebin",
             "hex": "02456C",
-            "source": "https://pastebin.com/"
+            "source": "https://pastebin.com"
         },
         {
             "title": "Patreon",
@@ -8485,17 +8485,17 @@
         {
             "title": "Payoneer",
             "hex": "FF4800",
-            "source": "https://www.payoneer.com/"
+            "source": "https://www.payoneer.com"
         },
         {
             "title": "PayPal",
             "hex": "00457C",
-            "source": "https://www.paypal.com/"
+            "source": "https://www.paypal.com"
         },
         {
             "title": "Paytm",
             "hex": "20336B",
-            "source": "https://paytm.com/"
+            "source": "https://paytm.com"
         },
         {
             "title": "PCGamingWiki",
@@ -8505,12 +8505,12 @@
         {
             "title": "Peak Design",
             "hex": "1C1B1C",
-            "source": "https://www.peakdesign.com/"
+            "source": "https://www.peakdesign.com"
         },
         {
             "title": "PeerTube",
             "hex": "F1680D",
-            "source": "https://joinpeertube.org/"
+            "source": "https://joinpeertube.org"
         },
         {
             "title": "Pegasus Airlines",
@@ -8533,7 +8533,7 @@
         {
             "title": "Penny",
             "hex": "CD1414",
-            "source": "https://www.penny.de/"
+            "source": "https://www.penny.de"
         },
         {
             "title": "Penpot",
@@ -8549,7 +8549,7 @@
         {
             "title": "Percy",
             "hex": "9E66BF",
-            "source": "https://percy.io/"
+            "source": "https://percy.io"
         },
         {
             "title": "Perforce",
@@ -8570,7 +8570,7 @@
         {
             "title": "Personio",
             "hex": "FFFFFF",
-            "source": "https://www.personio.com/"
+            "source": "https://www.personio.com"
         },
         {
             "title": "Pets at Home",
@@ -8580,17 +8580,17 @@
         {
             "title": "Peugeot",
             "hex": "000000",
-            "source": "https://www.peugeot.co.uk/"
+            "source": "https://www.peugeot.co.uk"
         },
         {
             "title": "Pexels",
             "hex": "05A081",
-            "source": "https://www.pexels.com/"
+            "source": "https://www.pexels.com"
         },
         {
             "title": "pfSense",
             "hex": "212121",
-            "source": "https://www.pfsense.org/"
+            "source": "https://www.pfsense.org"
         },
         {
             "title": "Phabricator",
@@ -8611,12 +8611,12 @@
         {
             "title": "Photobucket",
             "hex": "0672CB",
-            "source": "https://photobucket.com/"
+            "source": "https://photobucket.com"
         },
         {
             "title": "Photocrowd",
             "hex": "3DAD4B",
-            "source": "https://www.photocrowd.com/"
+            "source": "https://www.photocrowd.com"
         },
         {
             "title": "Photopea",
@@ -8651,7 +8651,7 @@
         {
             "title": "Picard Surgelés",
             "hex": "2D4999",
-            "source": "https://www.picard.fr/"
+            "source": "https://www.picard.fr"
         },
         {
             "title": "Picarto.TV",
@@ -8694,7 +8694,7 @@
         {
             "title": "Pioneer DJ",
             "hex": "1A1928",
-            "source": "https://www.pioneerdj.com/"
+            "source": "https://www.pioneerdj.com"
         },
         {
             "title": "Pivotal Tracker",
@@ -8727,7 +8727,7 @@
         {
             "title": "pkgsrc",
             "hex": "FF6600",
-            "source": "https://pkgsrc.org/"
+            "source": "https://pkgsrc.org"
         },
         {
             "title": "Planet",
@@ -8737,12 +8737,12 @@
         {
             "title": "PlanetScale",
             "hex": "000000",
-            "source": "https://planetscale.com/"
+            "source": "https://planetscale.com"
         },
         {
             "title": "PlanGrid",
             "hex": "0085DE",
-            "source": "https://app.plangrid.com/"
+            "source": "https://app.plangrid.com"
         },
         {
             "title": "Platform.sh",
@@ -8762,12 +8762,12 @@
         {
             "title": "PlayCanvas",
             "hex": "E05F2C",
-            "source": "https://playcanvas.com/"
+            "source": "https://playcanvas.com"
         },
         {
             "title": "Player FM",
             "hex": "C8122A",
-            "source": "https://player.fm/"
+            "source": "https://player.fm"
         },
         {
             "title": "Player.me",
@@ -8812,7 +8812,7 @@
         {
             "title": "Pleroma",
             "hex": "FBA457",
-            "source": "https://pleroma.social/"
+            "source": "https://pleroma.social"
         },
         {
             "title": "Plesk",
@@ -8823,13 +8823,13 @@
         {
             "title": "Plex",
             "hex": "EBAF00",
-            "source": "https://brand.plex.tv/",
-            "guidelines": "https://brand.plex.tv/"
+            "source": "https://brand.plex.tv",
+            "guidelines": "https://brand.plex.tv"
         },
         {
             "title": "Plotly",
             "hex": "3F4F75",
-            "source": "https://plotly.com/"
+            "source": "https://plotly.com"
         },
         {
             "title": "Pluralsight",
@@ -8850,7 +8850,7 @@
         {
             "title": "PM2",
             "hex": "2B037A",
-            "source": "https://pm2.keymetrics.io/"
+            "source": "https://pm2.keymetrics.io"
         },
         {
             "title": "pnpm",
@@ -8880,7 +8880,7 @@
         {
             "title": "Podman",
             "hex": "892CA0",
-            "source": "https://podman.io/"
+            "source": "https://podman.io"
         },
         {
             "title": "Poe",
@@ -8890,7 +8890,7 @@
         {
             "title": "Poetry",
             "hex": "60A5FA",
-            "source": "https://python-poetry.org/"
+            "source": "https://python-poetry.org"
         },
         {
             "title": "Pointy",
@@ -8905,7 +8905,7 @@
         {
             "title": "Polars",
             "hex": "CD792C",
-            "source": "https://pola.rs/"
+            "source": "https://pola.rs"
         },
         {
             "title": "Polkadot",
@@ -8916,7 +8916,7 @@
         {
             "title": "Poly",
             "hex": "EB3C00",
-            "source": "https://www.poly.com/"
+            "source": "https://www.poly.com"
         },
         {
             "title": "Polymer Project",
@@ -8926,27 +8926,27 @@
         {
             "title": "Polywork",
             "hex": "543DE0",
-            "source": "https://www.polywork.com/"
+            "source": "https://www.polywork.com"
         },
         {
             "title": "Pop!_OS",
             "hex": "48B9C7",
-            "source": "https://pop.system76.com/"
+            "source": "https://pop.system76.com"
         },
         {
             "title": "Porsche",
             "hex": "B12B28",
-            "source": "https://www.porsche.com/"
+            "source": "https://www.porsche.com"
         },
         {
             "title": "Portainer",
             "hex": "13BEF9",
-            "source": "https://www.portainer.io/"
+            "source": "https://www.portainer.io"
         },
         {
             "title": "PostCSS",
             "hex": "DD3A0A",
-            "source": "https://postcss.org/"
+            "source": "https://postcss.org"
         },
         {
             "title": "PostgreSQL",
@@ -9037,7 +9037,7 @@
         {
             "title": "POWERS",
             "hex": "E74536",
-            "source": "https://www.powerswhiskey.com/"
+            "source": "https://www.powerswhiskey.com"
         },
         {
             "title": "PowerShell",
@@ -9104,7 +9104,7 @@
         {
             "title": "Printables",
             "hex": "FA6831",
-            "source": "https://printables.com/"
+            "source": "https://printables.com"
         },
         {
             "title": "Prisma",
@@ -9114,7 +9114,7 @@
         {
             "title": "Prismic",
             "hex": "5163BA",
-            "source": "https://prismic.io/"
+            "source": "https://prismic.io"
         },
         {
             "title": "Private Internet Access",
@@ -9134,12 +9134,12 @@
         {
             "title": "Processing Foundation",
             "hex": "006699",
-            "source": "https://processingfoundation.org/"
+            "source": "https://processingfoundation.org"
         },
         {
             "title": "ProcessWire",
             "hex": "2480E6",
-            "source": "https://processwire.com/"
+            "source": "https://processwire.com"
         },
         {
             "title": "Product Hunt",
@@ -9155,18 +9155,18 @@
         {
             "title": "Progress",
             "hex": "5CE500",
-            "source": "https://www.progress.com/",
+            "source": "https://www.progress.com",
             "guidelines": "https://www.progress.com/legal/trademarks/trademarks-use-policy"
         },
         {
             "title": "Prometheus",
             "hex": "E6522C",
-            "source": "https://prometheus.io/"
+            "source": "https://prometheus.io"
         },
         {
             "title": "ProSieben",
             "hex": "E6000F",
-            "source": "https://www.prosieben.de/"
+            "source": "https://www.prosieben.de"
         },
         {
             "title": "Proto.io",
@@ -9182,7 +9182,7 @@
         {
             "title": "ProtonDB",
             "hex": "F50057",
-            "source": "https://www.protondb.com/"
+            "source": "https://www.protondb.com"
         },
         {
             "title": "ProtonMail",
@@ -9219,7 +9219,7 @@
         {
             "title": "PubMed",
             "hex": "326599",
-            "source": "https://pubmed.ncbi.nlm.nih.gov/"
+            "source": "https://pubmed.ncbi.nlm.nih.gov"
         },
         {
             "title": "Pug",
@@ -9229,13 +9229,13 @@
         {
             "title": "Pulumi",
             "hex": "8A3391",
-            "source": "https://www.pulumi.com/",
+            "source": "https://www.pulumi.com",
             "guidelines": "https://www.pulumi.com/brand/"
         },
         {
             "title": "Puma",
             "hex": "242B2F",
-            "source": "https://us.puma.com/"
+            "source": "https://us.puma.com"
         },
         {
             "title": "Puppet",
@@ -9245,7 +9245,7 @@
         {
             "title": "Puppeteer",
             "hex": "40B5A4",
-            "source": "https://pptr.dev/"
+            "source": "https://pptr.dev"
         },
         {
             "title": "PureScript",
@@ -9268,7 +9268,7 @@
         {
             "title": "Pusher",
             "hex": "300D4F",
-            "source": "https://pusher.com/"
+            "source": "https://pusher.com"
         },
         {
             "title": "PWA",
@@ -9300,7 +9300,7 @@
         {
             "title": "PyPI",
             "hex": "3775A9",
-            "source": "https://pypi.org/"
+            "source": "https://pypi.org"
         },
         {
             "title": "PyPy",
@@ -9337,12 +9337,12 @@
         {
             "title": "PyUp",
             "hex": "9F55FF",
-            "source": "https://pyup.io/"
+            "source": "https://pyup.io"
         },
         {
             "title": "Qantas",
             "hex": "E40000",
-            "source": "https://freight.qantas.com/"
+            "source": "https://freight.qantas.com"
         },
         {
             "title": "Qatar Airways",
@@ -9380,7 +9380,7 @@
         {
             "title": "QIWI",
             "hex": "FF8C00",
-            "source": "https://qiwi.com/"
+            "source": "https://qiwi.com"
         },
         {
             "title": "QMK",
@@ -9407,13 +9407,13 @@
         {
             "title": "Qualys",
             "hex": "ED2E26",
-            "source": "https://www.qualys.com/",
+            "source": "https://www.qualys.com",
             "guidelines": "https://www.qualys.com/docs/qualys-logo-guidelines.pdf"
         },
         {
             "title": "Quantcast",
             "hex": "000000",
-            "source": "https://www.quantcast.com/"
+            "source": "https://www.quantcast.com"
         },
         {
             "title": "QuantConnect",
@@ -9441,8 +9441,8 @@
         {
             "title": "Quest",
             "hex": "FB4F14",
-            "source": "https://brand.quest.com/",
-            "guidelines": "https://brand.quest.com/"
+            "source": "https://brand.quest.com",
+            "guidelines": "https://brand.quest.com"
         },
         {
             "title": "QuickBooks",
@@ -9463,7 +9463,7 @@
         {
             "title": "Quip",
             "hex": "F27557",
-            "source": "https://quip.com/"
+            "source": "https://quip.com"
         },
         {
             "title": "Quora",
@@ -9478,7 +9478,7 @@
         {
             "title": "Qzone",
             "hex": "FECE00",
-            "source": "https://qzone.qq.com/"
+            "source": "https://qzone.qq.com"
         },
         {
             "title": "R",
@@ -9491,24 +9491,24 @@
         {
             "title": "R3",
             "hex": "EC1D24",
-            "source": "https://www.r3.com/",
+            "source": "https://www.r3.com",
             "guidelines": "https://www.r3.com/contact-press-media/"
         },
         {
             "title": "RabbitMQ",
             "hex": "FF6600",
-            "source": "https://www.rabbitmq.com/",
+            "source": "https://www.rabbitmq.com",
             "guidelines": "https://www.rabbitmq.com/trademark-guidelines.html"
         },
         {
             "title": "Racket",
             "hex": "9F1D20",
-            "source": "https://racket-lang.org/"
+            "source": "https://racket-lang.org"
         },
         {
             "title": "Radar",
             "hex": "007AFF",
-            "source": "https://radar.io/"
+            "source": "https://radar.io"
         },
         {
             "title": "RadioPublic",
@@ -9518,7 +9518,7 @@
         {
             "title": "Railway",
             "hex": "0B0D0E",
-            "source": "https://railway.app/"
+            "source": "https://railway.app"
         },
         {
             "title": "Rainmeter",
@@ -9546,12 +9546,12 @@
         {
             "title": "Rarible",
             "hex": "FEDA03",
-            "source": "https://rarible.com/"
+            "source": "https://rarible.com"
         },
         {
             "title": "Rasa",
             "hex": "5A17EE",
-            "source": "https://rasa.com/"
+            "source": "https://rasa.com"
         },
         {
             "title": "Raspberry Pi",
@@ -9573,7 +9573,7 @@
         {
             "title": "Razer",
             "hex": "00FF00",
-            "source": "https://press.razer.com/"
+            "source": "https://press.razer.com"
         },
         {
             "title": "Razorpay",
@@ -9589,7 +9589,7 @@
                 "dup": [
                     {
                         "title": "React Native",
-                        "source": "https://reactnative.dev/"
+                        "source": "https://reactnative.dev"
                     }
                 ]
             }
@@ -9645,7 +9645,7 @@
         {
             "title": "Realm",
             "hex": "39477F",
-            "source": "https://realm.io/"
+            "source": "https://realm.io"
         },
         {
             "title": "Reason",
@@ -9671,7 +9671,7 @@
         {
             "title": "Red Hat Open Shift",
             "hex": "EE0000",
-            "source": "https://www.openshift.com/"
+            "source": "https://www.openshift.com"
         },
         {
             "title": "Redbubble",
@@ -9728,7 +9728,7 @@
         {
             "title": "Relay",
             "hex": "F26B00",
-            "source": "https://relay.dev/"
+            "source": "https://relay.dev"
         },
         {
             "title": "Reliance Industries Limited",
@@ -9753,7 +9753,7 @@
         {
             "title": "Render",
             "hex": "46E3B7",
-            "source": "https://render.com/"
+            "source": "https://render.com"
         },
         {
             "title": "RenovateBot",
@@ -9768,7 +9768,7 @@
         {
             "title": "Replit",
             "hex": "F26207",
-            "source": "https://repl.it/"
+            "source": "https://repl.it"
         },
         {
             "title": "Republic of Gamers",
@@ -9820,7 +9820,7 @@
         {
             "title": "reveal.js",
             "hex": "F2E142",
-            "source": "https://revealjs.com/"
+            "source": "https://revealjs.com"
         },
         {
             "title": "ReverbNation",
@@ -9840,22 +9840,22 @@
         {
             "title": "Revolut",
             "hex": "0075EB",
-            "source": "https://www.revolut.com/"
+            "source": "https://www.revolut.com"
         },
         {
             "title": "Revue",
             "hex": "E15718",
-            "source": "https://www.getrevue.co/"
+            "source": "https://www.getrevue.co"
         },
         {
             "title": "REWE",
             "hex": "CC071E",
-            "source": "https://www.rewe.de/"
+            "source": "https://www.rewe.de"
         },
         {
             "title": "Rezgo",
             "hex": "F76C00",
-            "source": "https://www.rezgo.com/"
+            "source": "https://www.rezgo.com"
         },
         {
             "title": "Rhinoceros",
@@ -9945,18 +9945,18 @@
         {
             "title": "Roku",
             "hex": "662D91",
-            "source": "https://www.roku.com/",
+            "source": "https://www.roku.com",
             "guidelines": "https://docs.roku.com/published/trademarkguidelines/en/ca"
         },
         {
             "title": "Rolls-Royce",
             "hex": "281432",
-            "source": "https://www.rolls-roycemotorcars.com/"
+            "source": "https://www.rolls-roycemotorcars.com"
         },
         {
             "title": "rollup.js",
             "hex": "EC4A3F",
-            "source": "https://rollupjs.org/"
+            "source": "https://rollupjs.org"
         },
         {
             "title": "Rome",
@@ -10008,7 +10008,7 @@
         {
             "title": "Roundcube",
             "hex": "37BEFF",
-            "source": "https://roundcube.net/"
+            "source": "https://roundcube.net"
         },
         {
             "title": "RSocket",
@@ -10039,7 +10039,7 @@
         {
             "title": "RTLZWEI",
             "hex": "00BCF6",
-            "source": "https://www.rtl2.de/"
+            "source": "https://www.rtl2.de"
         },
         {
             "title": "RuboCop",
@@ -10060,7 +10060,7 @@
         {
             "title": "Ruby on Rails",
             "hex": "CC0000",
-            "source": "https://rubyonrails.org/",
+            "source": "https://rubyonrails.org",
             "guidelines": "https://rubyonrails.org/trademarks/"
         },
         {
@@ -10092,7 +10092,7 @@
         {
             "title": "Rust",
             "hex": "000000",
-            "source": "https://www.rust-lang.org/",
+            "source": "https://www.rust-lang.org",
             "guidelines": "https://www.rust-lang.org/policies/media-guide",
             "license": {
                 "type": "CC-BY-SA-4.0"
@@ -10143,7 +10143,7 @@
         {
             "title": "Salt Project",
             "hex": "57BCAD",
-            "source": "https://saltproject.io/",
+            "source": "https://saltproject.io",
             "guidelines": "https://gitlab.com/saltstack/open/salt-branding-guide/-/blob/37bbc3a8577be2f44895310c092439472491a8f4/README.md",
             "license": {
                 "type": "Apache-2.0"
@@ -10169,7 +10169,7 @@
         {
             "title": "SanDisk",
             "hex": "ED1C24",
-            "source": "https://kb.sandisk.com/"
+            "source": "https://kb.sandisk.com"
         },
         {
             "title": "São Paulo Metro",
@@ -10179,7 +10179,7 @@
         {
             "title": "SAP",
             "hex": "0FAAFF",
-            "source": "https://www.sap.com/"
+            "source": "https://www.sap.com"
         },
         {
             "title": "Sass",
@@ -10199,17 +10199,17 @@
         {
             "title": "Saturn",
             "hex": "EB680B",
-            "source": "https://www.saturn.de/"
+            "source": "https://www.saturn.de"
         },
         {
             "title": "Sauce Labs",
             "hex": "E2231A",
-            "source": "https://saucelabs.com/"
+            "source": "https://saucelabs.com"
         },
         {
             "title": "Scala",
             "hex": "DC322F",
-            "source": "https://www.scala-lang.org/"
+            "source": "https://www.scala-lang.org"
         },
         {
             "title": "Scaleway",
@@ -10241,12 +10241,12 @@
         {
             "title": "Scopus",
             "hex": "E9711C",
-            "source": "https://www.scopus.com/"
+            "source": "https://www.scopus.com"
         },
         {
             "title": "SCP Foundation",
             "hex": "FFFFFF",
-            "source": "https://scp-wiki.wikidot.com/"
+            "source": "https://scp-wiki.wikidot.com"
         },
         {
             "title": "Scratch",
@@ -10256,7 +10256,7 @@
         {
             "title": "Screencastify",
             "hex": "FF8282",
-            "source": "https://www.screencastify.com/"
+            "source": "https://www.screencastify.com"
         },
         {
             "title": "Scribd",
@@ -10267,12 +10267,12 @@
         {
             "title": "Scrimba",
             "hex": "2B283A",
-            "source": "https://scrimba.com/"
+            "source": "https://scrimba.com"
         },
         {
             "title": "ScrollReveal",
             "hex": "FFCB36",
-            "source": "https://scrollrevealjs.org/"
+            "source": "https://scrollrevealjs.org"
         },
         {
             "title": "Scrum Alliance",
@@ -10293,12 +10293,12 @@
         {
             "title": "SEAT",
             "hex": "33302E",
-            "source": "https://www.seat.es/"
+            "source": "https://www.seat.es"
         },
         {
             "title": "SecurityScorecard",
             "hex": "7033FD",
-            "source": "https://securityscorecard.com/"
+            "source": "https://securityscorecard.com"
         },
         {
             "title": "Sefaria",
@@ -10343,7 +10343,7 @@
         {
             "title": "Semaphore CI",
             "hex": "19A974",
-            "source": "https://semaphoreci.com/"
+            "source": "https://semaphoreci.com"
         },
         {
             "title": "SemVer",
@@ -10353,7 +10353,7 @@
         {
             "title": "Sencha",
             "hex": "86BC40",
-            "source": "https://design.sencha.com/",
+            "source": "https://design.sencha.com",
             "guidelines": "https://design.sencha.com/productlogo.html"
         },
         {
@@ -10396,7 +10396,7 @@
         {
             "title": "Serverless",
             "hex": "FD5750",
-            "source": "https://serverless.com/"
+            "source": "https://serverless.com"
         },
         {
             "title": "Sessionize",
@@ -10416,7 +10416,7 @@
         {
             "title": "Shadow",
             "hex": "0A0C0D",
-            "source": "https://shadow.tech/"
+            "source": "https://shadow.tech"
         },
         {
             "title": "Shanghai Metro",
@@ -10431,7 +10431,7 @@
         {
             "title": "Shazam",
             "hex": "0088FF",
-            "source": "https://www.shazam.com/"
+            "source": "https://www.shazam.com"
         },
         {
             "title": "Shell",
@@ -10441,7 +10441,7 @@
         {
             "title": "Shelly",
             "hex": "4495D1",
-            "source": "https://shelly.cloud/"
+            "source": "https://shelly.cloud"
         },
         {
             "title": "Shenzhen Metro",
@@ -10482,7 +10482,7 @@
         {
             "title": "Showpad",
             "hex": "2D2E83",
-            "source": "https://www.showpad.com/"
+            "source": "https://www.showpad.com"
         },
         {
             "title": "Showtime",
@@ -10498,7 +10498,7 @@
         {
             "title": "Siemens",
             "hex": "009999",
-            "source": "https://siemens.com/"
+            "source": "https://siemens.com"
         },
         {
             "title": "Signal",
@@ -10518,13 +10518,13 @@
         {
             "title": "Simple Analytics",
             "hex": "FF4F64",
-            "source": "https://simpleanalytics.com/",
+            "source": "https://simpleanalytics.com",
             "guidelines": "https://simpleanalytics.com/press"
         },
         {
             "title": "Simple Icons",
             "hex": "111111",
-            "source": "https://simpleicons.org/",
+            "source": "https://simpleicons.org",
             "license": {
                 "type": "CC0-1.0"
             }
@@ -10578,7 +10578,7 @@
         {
             "title": "Sky",
             "hex": "0072C9",
-            "source": "https://www.skysports.com/"
+            "source": "https://www.skysports.com"
         },
         {
             "title": "Skynet",
@@ -10620,7 +10620,7 @@
         {
             "title": "SlickPic",
             "hex": "FF880F",
-            "source": "https://www.slickpic.com/"
+            "source": "https://www.slickpic.com"
         },
         {
             "title": "Slides",
@@ -10652,7 +10652,7 @@
         {
             "title": "Smashing Magazine",
             "hex": "E85C33",
-            "source": "https://www.smashingmagazine.com/"
+            "source": "https://www.smashingmagazine.com"
         },
         {
             "title": "SMRT",
@@ -10681,7 +10681,7 @@
         {
             "title": "SNCF",
             "hex": "CA0939",
-            "source": "https://www.sncf.com/",
+            "source": "https://www.sncf.com",
             "guidelines": "https://www.sncf.com/fr/groupe/marques/sncf/identite"
         },
         {
@@ -10693,7 +10693,7 @@
         {
             "title": "Snowpack",
             "hex": "2E5E82",
-            "source": "https://www.snowpack.dev/"
+            "source": "https://www.snowpack.dev"
         },
         {
             "title": "Snyk",
@@ -10718,7 +10718,7 @@
         {
             "title": "Sogou",
             "hex": "FB6022",
-            "source": "https://www.sogou.com/"
+            "source": "https://www.sogou.com"
         },
         {
             "title": "Solid",
@@ -10737,7 +10737,7 @@
         {
             "title": "Sololearn",
             "hex": "149EF2",
-            "source": "https://www.sololearn.com/",
+            "source": "https://www.sololearn.com",
             "aliases": {
                 "aka": [
                     "SoloLearn"
@@ -10752,7 +10752,7 @@
         {
             "title": "Sonar",
             "hex": "FD3456",
-            "source": "https://www.sonarsource.com/"
+            "source": "https://www.sonarsource.com"
         },
         {
             "title": "SonarCloud",
@@ -10822,7 +10822,7 @@
         {
             "title": "SourceForge",
             "hex": "FF6600",
-            "source": "https://sourceforge.net/"
+            "source": "https://sourceforge.net"
         },
         {
             "title": "Sourcegraph",
@@ -10839,12 +10839,12 @@
         {
             "title": "Southwest Airlines",
             "hex": "304CB2",
-            "source": "https://www.southwest.com/"
+            "source": "https://www.southwest.com"
         },
         {
             "title": "Spacemacs",
             "hex": "9266CC",
-            "source": "https://spacemacs.org/",
+            "source": "https://spacemacs.org",
             "license": {
                 "type": "CC-BY-SA-4.0"
             }
@@ -10852,7 +10852,7 @@
         {
             "title": "SpaceX",
             "hex": "000000",
-            "source": "https://www.spacex.com/"
+            "source": "https://www.spacex.com"
         },
         {
             "title": "spaCy",
@@ -10862,12 +10862,12 @@
         {
             "title": "Spark AR",
             "hex": "FF5C83",
-            "source": "https://sparkar.facebook.com/"
+            "source": "https://sparkar.facebook.com"
         },
         {
             "title": "Sparkasse",
             "hex": "FF0000",
-            "source": "https://www.sparkasse.de/",
+            "source": "https://www.sparkasse.de",
             "guidelines": "https://www.sparkasse.de/nutzungshinweise.html"
         },
         {
@@ -10890,7 +10890,7 @@
         {
             "title": "Speaker Deck",
             "hex": "009287",
-            "source": "https://speakerdeck.com/"
+            "source": "https://speakerdeck.com"
         },
         {
             "title": "Spectrum",
@@ -10900,7 +10900,7 @@
         {
             "title": "Speedtest",
             "hex": "141526",
-            "source": "https://www.speedtest.net/"
+            "source": "https://www.speedtest.net"
         },
         {
             "title": "Spinnaker",
@@ -10915,12 +10915,12 @@
         {
             "title": "Splunk",
             "hex": "000000",
-            "source": "https://www.splunk.com/"
+            "source": "https://www.splunk.com"
         },
         {
             "title": "Spond",
             "hex": "EE4353",
-            "source": "https://spond.com/"
+            "source": "https://spond.com"
         },
         {
             "title": "Spotify",
@@ -10931,18 +10931,18 @@
         {
             "title": "Spotlight",
             "hex": "352A71",
-            "source": "https://www.spotlight.com/"
+            "source": "https://www.spotlight.com"
         },
         {
             "title": "Spreadshirt",
             "hex": "00B2A5",
-            "source": "https://www.spreadshirt.ie/",
+            "source": "https://www.spreadshirt.ie",
             "aliases": {
                 "dup": [
                     {
                         "title": "Spreadshop",
                         "hex": "FF9343",
-                        "source": "https://www.spreadshop.com/"
+                        "source": "https://www.spreadshop.com"
                     }
                 ]
             }
@@ -10950,7 +10950,7 @@
         {
             "title": "Spreaker",
             "hex": "F5C300",
-            "source": "https://www.spreaker.com/"
+            "source": "https://www.spreaker.com"
         },
         {
             "title": "Spring",
@@ -10961,7 +10961,7 @@
             "title": "Spring",
             "slug": "spring_creators",
             "hex": "000000",
-            "source": "https://www.spri.ng/"
+            "source": "https://www.spri.ng"
         },
         {
             "title": "Spring Boot",
@@ -10976,7 +10976,7 @@
         {
             "title": "Spyder IDE",
             "hex": "FF0000",
-            "source": "https://www.spyder-ide.org/"
+            "source": "https://www.spyder-ide.org"
         },
         {
             "title": "SQLite",
@@ -10986,12 +10986,12 @@
         {
             "title": "Square",
             "hex": "3E4348",
-            "source": "https://squareup.com/"
+            "source": "https://squareup.com"
         },
         {
             "title": "Square Enix",
             "hex": "ED1C24",
-            "source": "https://www.square-enix.com/"
+            "source": "https://www.square-enix.com"
         },
         {
             "title": "Squarespace",
@@ -11066,13 +11066,13 @@
         {
             "title": "Star Trek",
             "hex": "FFE200",
-            "source": "https://intl.startrek.com/"
+            "source": "https://intl.startrek.com"
         },
         {
             "title": "Starbucks",
             "hex": "006241",
-            "source": "https://starbucks.com/",
-            "guidelines": "https://creative.starbucks.com/"
+            "source": "https://starbucks.com",
+            "guidelines": "https://creative.starbucks.com"
         },
         {
             "title": "Stardock",
@@ -11088,7 +11088,7 @@
         {
             "title": "Starship",
             "hex": "DD0B78",
-            "source": "https://starship.rs/"
+            "source": "https://starship.rs"
         },
         {
             "title": "STARZ",
@@ -11109,7 +11109,7 @@
         {
             "title": "Statuspal",
             "hex": "4934BF",
-            "source": "https://statuspal.io/"
+            "source": "https://statuspal.io"
         },
         {
             "title": "Steam",
@@ -11126,12 +11126,12 @@
         {
             "title": "SteamDB",
             "hex": "000000",
-            "source": "https://steamdb.info/"
+            "source": "https://steamdb.info"
         },
         {
             "title": "Steamworks",
             "hex": "1E1E1E",
-            "source": "https://partner.steamgames.com/"
+            "source": "https://partner.steamgames.com"
         },
         {
             "title": "Steelseries",
@@ -11146,7 +11146,7 @@
         {
             "title": "Steemit",
             "hex": "06D6A9",
-            "source": "https://steemit.com/"
+            "source": "https://steemit.com"
         },
         {
             "title": "Steinberg",
@@ -11166,17 +11166,17 @@
         {
             "title": "Stimulus",
             "hex": "77E8B9",
-            "source": "https://stimulus.hotwire.dev/"
+            "source": "https://stimulus.hotwire.dev"
         },
         {
             "title": "Stitcher",
             "hex": "000000",
-            "source": "https://partners.stitcher.com/"
+            "source": "https://partners.stitcher.com"
         },
         {
             "title": "STMicroelectronics",
             "hex": "03234B",
-            "source": "https://www.st.com/"
+            "source": "https://www.st.com"
         },
         {
             "title": "StopStalk",
@@ -11234,7 +11234,7 @@
         {
             "title": "styled-components",
             "hex": "DB7093",
-            "source": "https://www.styled-components.com/"
+            "source": "https://www.styled-components.com"
         },
         {
             "title": "stylelint",
@@ -11244,7 +11244,7 @@
         {
             "title": "StyleShare",
             "hex": "212121",
-            "source": "https://www.stylesha.re/"
+            "source": "https://www.stylesha.re"
         },
         {
             "title": "Stylus",
@@ -11259,12 +11259,12 @@
         {
             "title": "Sublime Text",
             "hex": "FF9800",
-            "source": "https://www.sublimetext.com/"
+            "source": "https://www.sublimetext.com"
         },
         {
             "title": "Substack",
             "hex": "FF6719",
-            "source": "https://on.substack.com/"
+            "source": "https://on.substack.com"
         },
         {
             "title": "Subversion",
@@ -11312,13 +11312,13 @@
         {
             "title": "SUSE",
             "hex": "0C322C",
-            "source": "https://brand.suse.com/",
-            "guidelines": "https://brand.suse.com/"
+            "source": "https://brand.suse.com",
+            "guidelines": "https://brand.suse.com"
         },
         {
             "title": "Suzuki",
             "hex": "E30613",
-            "source": "https://www.suzuki.ie/"
+            "source": "https://www.suzuki.ie"
         },
         {
             "title": "Svelte",
@@ -11329,7 +11329,7 @@
                     {
                         "title": "Sapper",
                         "hex": "159497",
-                        "source": "https://sapper.svelte.dev/"
+                        "source": "https://sapper.svelte.dev"
                     }
                 ]
             }
@@ -11372,12 +11372,12 @@
         {
             "title": "Swiggy",
             "hex": "FC8019",
-            "source": "https://www.swiggy.com/"
+            "source": "https://www.swiggy.com"
         },
         {
             "title": "Swiper",
             "hex": "6332F6",
-            "source": "https://swiperjs.com/"
+            "source": "https://swiperjs.com"
         },
         {
             "title": "Symantec",
@@ -11398,7 +11398,7 @@
         {
             "title": "Symphony",
             "hex": "0098FF",
-            "source": "https://symphony.com/"
+            "source": "https://symphony.com"
         },
         {
             "title": "SymPy",
@@ -11471,7 +11471,7 @@
         {
             "title": "Talenthouse",
             "hex": "FFFFFF",
-            "source": "https://www.talenthouse.com/"
+            "source": "https://www.talenthouse.com"
         },
         {
             "title": "Tamiya",
@@ -11496,7 +11496,7 @@
         {
             "title": "Target",
             "hex": "CC0000",
-            "source": "https://www.target.com/"
+            "source": "https://www.target.com"
         },
         {
             "title": "Task",
@@ -11526,7 +11526,7 @@
         {
             "title": "TaxBuzz",
             "hex": "ED8B0B",
-            "source": "https://www.taxbuzz.com/"
+            "source": "https://www.taxbuzz.com"
         },
         {
             "title": "TeamCity",
@@ -11573,7 +11573,7 @@
         {
             "title": "Telegraph",
             "hex": "FAFAFA",
-            "source": "https://telegra.ph/"
+            "source": "https://telegra.ph"
         },
         {
             "title": "Temporal",
@@ -11598,7 +11598,7 @@
         {
             "title": "teratail",
             "hex": "F4C51C",
-            "source": "https://teratail.com/"
+            "source": "https://teratail.com"
         },
         {
             "title": "Terraform",
@@ -11624,12 +11624,12 @@
         {
             "title": "Testin",
             "hex": "007DD7",
-            "source": "https://www.testin.cn/"
+            "source": "https://www.testin.cn"
         },
         {
             "title": "Testing Library",
             "hex": "E33332",
-            "source": "https://testing-library.com/"
+            "source": "https://testing-library.com"
         },
         {
             "title": "Tether",
@@ -11645,7 +11645,7 @@
         {
             "title": "Textpattern",
             "hex": "FFDA44",
-            "source": "https://textpattern.com/"
+            "source": "https://textpattern.com"
         },
         {
             "title": "TGA",
@@ -11670,17 +11670,17 @@
         {
             "title": "The Irish Times",
             "hex": "000000",
-            "source": "https://www.irishtimes.com/"
+            "source": "https://www.irishtimes.com"
         },
         {
             "title": "The Mighty",
             "hex": "D0072A",
-            "source": "https://themighty.com/"
+            "source": "https://themighty.com"
         },
         {
             "title": "The Models Resource",
             "hex": "3A75BD",
-            "source": "https://www.models-resource.com/"
+            "source": "https://www.models-resource.com"
         },
         {
             "title": "The Movie Database",
@@ -11695,22 +11695,22 @@
         {
             "title": "The North Face",
             "hex": "000000",
-            "source": "https://www.thenorthface.com/"
+            "source": "https://www.thenorthface.com"
         },
         {
             "title": "The Register",
             "hex": "FF0000",
-            "source": "https://www.theregister.co.uk/"
+            "source": "https://www.theregister.co.uk"
         },
         {
             "title": "The Sounds Resource",
             "hex": "39BE6B",
-            "source": "https://www.sounds-resource.com/"
+            "source": "https://www.sounds-resource.com"
         },
         {
             "title": "The Spriters Resource",
             "hex": "BE3939",
-            "source": "https://www.spriters-resource.com/"
+            "source": "https://www.spriters-resource.com"
         },
         {
             "title": "The Washington Post",
@@ -11720,7 +11720,7 @@
         {
             "title": "Thingiverse",
             "hex": "248BFB",
-            "source": "https://www.thingiverse.com/"
+            "source": "https://www.thingiverse.com"
         },
         {
             "title": "ThinkPad",
@@ -11790,12 +11790,12 @@
         {
             "title": "Tile",
             "hex": "000000",
-            "source": "https://www.thetileapp.com/"
+            "source": "https://www.thetileapp.com"
         },
         {
             "title": "Timescale",
             "hex": "FDB515",
-            "source": "https://www.timescale.com/"
+            "source": "https://www.timescale.com"
         },
         {
             "title": "Tinder",
@@ -11810,7 +11810,7 @@
         {
             "title": "Tistory",
             "hex": "000000",
-            "source": "https://tistory.com/",
+            "source": "https://tistory.com",
             "aliases": {
                 "loc": {
                     "ko-KR": "티스토리"
@@ -11850,7 +11850,7 @@
         {
             "title": "Tomorrowland",
             "hex": "000000",
-            "source": "https://global.tomorrowland.com/"
+            "source": "https://global.tomorrowland.com"
         },
         {
             "title": "Topcoder",
@@ -11887,7 +11887,7 @@
         {
             "title": "TP-Link",
             "hex": "4ACBD6",
-            "source": "https://www.tp-link.com/"
+            "source": "https://www.tp-link.com"
         },
         {
             "title": "tqdm",
@@ -11924,12 +11924,12 @@
         {
             "title": "Transport for Ireland",
             "hex": "00B274",
-            "source": "https://www.transportforireland.ie/"
+            "source": "https://www.transportforireland.ie"
         },
         {
             "title": "Transport for London",
             "hex": "113B92",
-            "source": "https://tfl.gov.uk/"
+            "source": "https://tfl.gov.uk"
         },
         {
             "title": "Travis CI",
@@ -11950,7 +11950,7 @@
         {
             "title": "Trend Micro",
             "hex": "D71921",
-            "source": "https://www.trendmicro.com/"
+            "source": "https://www.trendmicro.com"
         },
         {
             "title": "Treyarch",
@@ -11970,7 +11970,7 @@
         {
             "title": "Trip.com",
             "hex": "287DFA",
-            "source": "https://careers.trip.com/"
+            "source": "https://careers.trip.com"
         },
         {
             "title": "Tripadvisor",
@@ -11991,7 +11991,7 @@
         {
             "title": "TrueNAS",
             "hex": "0095D5",
-            "source": "https://www.truenas.com/"
+            "source": "https://www.truenas.com"
         },
         {
             "title": "trulia",
@@ -12012,7 +12012,7 @@
         {
             "title": "Try It Online",
             "hex": "303030",
-            "source": "https://tio.run/"
+            "source": "https://tio.run"
         },
         {
             "title": "TryHackMe",
@@ -12054,7 +12054,7 @@
             "title": "TurboSquid",
             "hex": "FF8135",
             "source": "https://www.brand.turbosquid.com/turbosquidicons",
-            "guidelines": "https://www.brand.turbosquid.com/"
+            "guidelines": "https://www.brand.turbosquid.com"
         },
         {
             "title": "Turkish Airlines",
@@ -12069,7 +12069,7 @@
         {
             "title": "TV Time",
             "hex": "FFD400",
-            "source": "https://www.tvtime.com/"
+            "source": "https://www.tvtime.com"
         },
         {
             "title": "Twilio",
@@ -12166,12 +12166,12 @@
         {
             "title": "Umbraco",
             "hex": "3544B1",
-            "source": "https://umbraco.com/"
+            "source": "https://umbraco.com"
         },
         {
             "title": "Unacademy",
             "hex": "08BD80",
-            "source": "https://unacademy.com/"
+            "source": "https://unacademy.com"
         },
         {
             "title": "Under Armour",
@@ -12186,7 +12186,7 @@
         {
             "title": "Undertale",
             "hex": "E71D29",
-            "source": "https://undertale.com/"
+            "source": "https://undertale.com"
         },
         {
             "title": "Unicode",
@@ -12206,8 +12206,8 @@
         {
             "title": "Unity",
             "hex": "FFFFFF",
-            "source": "https://brand.unity.com/",
-            "guidelines": "https://brand.unity.com/"
+            "source": "https://brand.unity.com",
+            "guidelines": "https://brand.unity.com"
         },
         {
             "title": "Unlicense",
@@ -12222,7 +12222,7 @@
         {
             "title": "Unraid",
             "hex": "F15A2C",
-            "source": "https://unraid.net/"
+            "source": "https://unraid.net"
         },
         {
             "title": "Unreal Engine",
@@ -12233,7 +12233,7 @@
         {
             "title": "Unsplash",
             "hex": "000000",
-            "source": "https://unsplash.com/"
+            "source": "https://unsplash.com"
         },
         {
             "title": "Untangle",
@@ -12244,7 +12244,7 @@
         {
             "title": "Untappd",
             "hex": "FFC000",
-            "source": "https://untappd.com/"
+            "source": "https://untappd.com"
         },
         {
             "title": "UpCloud",
@@ -12255,7 +12255,7 @@
         {
             "title": "UpLabs",
             "hex": "3930D8",
-            "source": "https://www.uplabs.com/"
+            "source": "https://www.uplabs.com"
         },
         {
             "title": "Uploaded",
@@ -12265,22 +12265,22 @@
         {
             "title": "UPS",
             "hex": "150400",
-            "source": "https://www.ups.com/"
+            "source": "https://www.ups.com"
         },
         {
             "title": "Upstash",
             "hex": "00E9A3",
-            "source": "https://upstash.com/"
+            "source": "https://upstash.com"
         },
         {
             "title": "Uptime Kuma",
             "hex": "5CDD8B",
-            "source": "https://uptime.kuma.pet/"
+            "source": "https://uptime.kuma.pet"
         },
         {
             "title": "Uptobox",
             "hex": "5CE1E6",
-            "source": "https://uptoboxpremium.org/"
+            "source": "https://uptoboxpremium.org"
         },
         {
             "title": "Upwork",
@@ -12290,7 +12290,7 @@
         {
             "title": "USPS",
             "hex": "333366",
-            "source": "https://www.usps.com/"
+            "source": "https://www.usps.com"
         },
         {
             "title": "V",
@@ -12339,12 +12339,12 @@
         {
             "title": "Valve",
             "hex": "F74843",
-            "source": "https://www.valvesoftware.com/"
+            "source": "https://www.valvesoftware.com"
         },
         {
             "title": "Vapor",
             "hex": "0D0D0D",
-            "source": "https://vapor.codes/"
+            "source": "https://vapor.codes"
         },
         {
             "title": "Vault",
@@ -12365,7 +12365,7 @@
         {
             "title": "Vector Logo Zone",
             "hex": "184D66",
-            "source": "https://www.vectorlogo.zone/"
+            "source": "https://www.vectorlogo.zone"
         },
         {
             "title": "Vectorworks",
@@ -12380,7 +12380,7 @@
         {
             "title": "Veepee",
             "hex": "EC008C",
-            "source": "https://www.veepee.fr/"
+            "source": "https://www.veepee.fr"
         },
         {
             "title": "Velog",
@@ -12420,12 +12420,12 @@
         {
             "title": "vFairs",
             "hex": "EF4678",
-            "source": "https://www.vfairs.com/"
+            "source": "https://www.vfairs.com"
         },
         {
             "title": "Viadeo",
             "hex": "F07355",
-            "source": "https://viadeo.journaldunet.com/"
+            "source": "https://viadeo.journaldunet.com"
         },
         {
             "title": "Viber",
@@ -12470,7 +12470,7 @@
         {
             "title": "VirusTotal",
             "hex": "394EFF",
-            "source": "https://www.virustotal.com/"
+            "source": "https://www.virustotal.com"
         },
         {
             "title": "Visa",
@@ -12480,7 +12480,7 @@
         {
             "title": "Visual Studio",
             "hex": "5C2D91",
-            "source": "https://visualstudio.microsoft.com/"
+            "source": "https://visualstudio.microsoft.com"
         },
         {
             "title": "Visual Studio Code",
@@ -12490,7 +12490,7 @@
         {
             "title": "Vite",
             "hex": "646CFF",
-            "source": "https://vitejs.dev/"
+            "source": "https://vitejs.dev"
         },
         {
             "title": "Vitess",
@@ -12500,7 +12500,7 @@
         {
             "title": "Vitest",
             "hex": "6E9F18",
-            "source": "https://vitest.dev/"
+            "source": "https://vitest.dev"
         },
         {
             "title": "Vivaldi",
@@ -12526,17 +12526,17 @@
         {
             "title": "VMware",
             "hex": "607078",
-            "source": "https://myvmware.workspaceair.com/"
+            "source": "https://myvmware.workspaceair.com"
         },
         {
             "title": "Vodafone",
             "hex": "E60000",
-            "source": "https://web.vodafone.com.eg/"
+            "source": "https://web.vodafone.com.eg"
         },
         {
             "title": "Volkswagen",
             "hex": "151F5D",
-            "source": "https://www.volkswagen.ie/"
+            "source": "https://www.volkswagen.ie"
         },
         {
             "title": "Volvo",
@@ -12585,7 +12585,7 @@
         {
             "title": "Vuetify",
             "hex": "1867C0",
-            "source": "https://vuetifyjs.com/"
+            "source": "https://vuetifyjs.com"
         },
         {
             "title": "Vulkan",
@@ -12619,7 +12619,7 @@
         {
             "title": "Wails",
             "hex": "DF0000",
-            "source": "https://wails.io/"
+            "source": "https://wails.io"
         },
         {
             "title": "WakaTime",
@@ -12652,13 +12652,13 @@
         {
             "title": "Wappalyzer",
             "hex": "32067C",
-            "source": "https://www.wappalyzer.com/"
+            "source": "https://www.wappalyzer.com"
         },
         {
             "title": "Warner Bros.",
             "slug": "warnerbros",
             "hex": "004DB4",
-            "source": "https://www.warnerbros.com/"
+            "source": "https://www.warnerbros.com"
         },
         {
             "title": "Warp",
@@ -12693,7 +12693,7 @@
         {
             "title": "Waze",
             "hex": "33CCFF",
-            "source": "https://www.waze.com/"
+            "source": "https://www.waze.com"
         },
         {
             "title": "Wear OS",
@@ -12703,7 +12703,7 @@
         {
             "title": "Weasyl",
             "hex": "990000",
-            "source": "https://www.weasyl.com/"
+            "source": "https://www.weasyl.com"
         },
         {
             "title": "Web3.js",
@@ -12713,7 +12713,7 @@
         {
             "title": "WebAssembly",
             "hex": "654FF0",
-            "source": "https://webassembly.org/"
+            "source": "https://webassembly.org"
         },
         {
             "title": "WebAuthn",
@@ -12724,7 +12724,7 @@
         {
             "title": "webcomponents.org",
             "hex": "29ABE2",
-            "source": "https://www.webcomponents.org/"
+            "source": "https://www.webcomponents.org"
         },
         {
             "title": "WebdriverIO",
@@ -12734,7 +12734,7 @@
         {
             "title": "Webflow",
             "hex": "4353FF",
-            "source": "https://webflow.com/"
+            "source": "https://webflow.com"
         },
         {
             "title": "WebGL",
@@ -12773,7 +12773,7 @@
         {
             "title": "WebRTC",
             "hex": "333333",
-            "source": "https://webrtc.org/"
+            "source": "https://webrtc.org"
         },
         {
             "title": "WebStorm",
@@ -12784,7 +12784,7 @@
         {
             "title": "WEBTOON",
             "hex": "00D564",
-            "source": "https://webtoons.com/"
+            "source": "https://webtoons.com"
         },
         {
             "title": "WeChat",
@@ -12800,7 +12800,7 @@
         {
             "title": "Weights & Biases",
             "hex": "FFBE00",
-            "source": "https://wandb.ai/"
+            "source": "https://wandb.ai"
         },
         {
             "title": "Welcome to the Jungle",
@@ -12810,7 +12810,7 @@
                 ]
             },
             "hex": "FFCD00",
-            "source": "https://www.welcometothejungle.com/"
+            "source": "https://www.welcometothejungle.com"
         },
         {
             "title": "WEMO",
@@ -12830,7 +12830,7 @@
         {
             "title": "WeTransfer",
             "hex": "409FFF",
-            "source": "https://wetransfer.com/"
+            "source": "https://wetransfer.com"
         },
         {
             "title": "WhatsApp",
@@ -12841,7 +12841,7 @@
         {
             "title": "When I Work",
             "hex": "51A33D",
-            "source": "https://wheniwork.com/"
+            "source": "https://wheniwork.com"
         },
         {
             "title": "WhiteSource",
@@ -12938,12 +12938,12 @@
             "title": "Wire",
             "hex": "000000",
             "source": "https://brand.wire.com",
-            "guidelines": "https://brand.wire.com/"
+            "guidelines": "https://brand.wire.com"
         },
         {
             "title": "WireGuard",
             "hex": "88171A",
-            "source": "https://www.wireguard.com/"
+            "source": "https://www.wireguard.com"
         },
         {
             "title": "Wireshark",
@@ -12959,7 +12959,7 @@
         {
             "title": "Wish",
             "hex": "2FB7EC",
-            "source": "https://wish.com/"
+            "source": "https://wish.com"
         },
         {
             "title": "Wistia",
@@ -13012,13 +13012,13 @@
         {
             "title": "Workplace",
             "hex": "4326C4",
-            "source": "https://en.facebookbrand.com/",
-            "guidelines": "https://en.facebookbrand.com/"
+            "source": "https://en.facebookbrand.com",
+            "guidelines": "https://en.facebookbrand.com"
         },
         {
             "title": "World Health Organization",
             "hex": "0093D5",
-            "source": "https://www.who.int/"
+            "source": "https://www.who.int"
         },
         {
             "title": "WP Engine",
@@ -13028,7 +13028,7 @@
         {
             "title": "WP Rocket",
             "hex": "F56640",
-            "source": "https://wp-rocket.me/"
+            "source": "https://wp-rocket.me"
         },
         {
             "title": "WPExplorer",
@@ -13085,7 +13085,7 @@
         {
             "title": "XDA Developers",
             "hex": "EA7100",
-            "source": "https://www.xda-developers.com/"
+            "source": "https://www.xda-developers.com"
         },
         {
             "title": "Xero",
@@ -13125,7 +13125,7 @@
         {
             "title": "XRP",
             "hex": "25A768",
-            "source": "https://xrpl.org/"
+            "source": "https://xrpl.org"
         },
         {
             "title": "XSplit",
@@ -13145,7 +13145,7 @@
         {
             "title": "Yahoo!",
             "hex": "6001D2",
-            "source": "https://yahoo.com/"
+            "source": "https://yahoo.com"
         },
         {
             "title": "Yale",
@@ -13206,7 +13206,7 @@
         {
             "title": "YouTube Gaming",
             "hex": "FF0000",
-            "source": "https://gaming.youtube.com/"
+            "source": "https://gaming.youtube.com"
         },
         {
             "title": "YouTube Music",
@@ -13216,7 +13216,7 @@
         {
             "title": "YouTube Studio",
             "hex": "FF0000",
-            "source": "https://www.youtube.com/"
+            "source": "https://www.youtube.com"
         },
         {
             "title": "YouTube TV",
@@ -13231,22 +13231,22 @@
         {
             "title": "Z-Wave",
             "hex": "1B365D",
-            "source": "https://www.z-wave.com/"
+            "source": "https://www.z-wave.com"
         },
         {
             "title": "Żabka",
             "hex": "006420",
-            "source": "https://www.zabka.pl/"
+            "source": "https://www.zabka.pl"
         },
         {
             "title": "Zalando",
             "hex": "FF6900",
-            "source": "https://www.zalando.co.uk/"
+            "source": "https://www.zalando.co.uk"
         },
         {
             "title": "Zalo",
             "hex": "0068FF",
-            "source": "https://zalo.me/"
+            "source": "https://zalo.me"
         },
         {
             "title": "Zapier",
@@ -13256,7 +13256,7 @@
         {
             "title": "Zara",
             "hex": "000000",
-            "source": "https://www.zara.com/"
+            "source": "https://www.zara.com"
         },
         {
             "title": "Zazzle",
@@ -13278,32 +13278,32 @@
         {
             "title": "ZDF",
             "hex": "FA7D19",
-            "source": "https://www.zdf.de/"
+            "source": "https://www.zdf.de"
         },
         {
             "title": "Zebra Technologies",
             "hex": "000000",
-            "source": "https://www.zebra.com/"
+            "source": "https://www.zebra.com"
         },
         {
             "title": "Zelle",
             "hex": "6D1ED4",
-            "source": "https://www.zellepay.com/"
+            "source": "https://www.zellepay.com"
         },
         {
             "title": "Zend",
             "hex": "0679EA",
-            "source": "https://www.zend.com/"
+            "source": "https://www.zend.com"
         },
         {
             "title": "Zend Framework",
             "hex": "68B604",
-            "source": "https://framework.zend.com/"
+            "source": "https://framework.zend.com"
         },
         {
             "title": "Zendesk",
             "hex": "03363D",
-            "source": "https://brandland.zendesk.com/"
+            "source": "https://brandland.zendesk.com"
         },
         {
             "title": "Zenn",
@@ -13334,13 +13334,13 @@
         {
             "title": "Zettlr",
             "hex": "1CB27E",
-            "source": "https://www.zettlr.com/",
+            "source": "https://www.zettlr.com",
             "guidelines": "https://www.zettlr.com/press"
         },
         {
             "title": "Zhihu",
             "hex": "0084FF",
-            "source": "https://www.zhihu.com/"
+            "source": "https://www.zhihu.com"
         },
         {
             "title": "Zig",
@@ -13358,17 +13358,17 @@
         {
             "title": "Zilch",
             "hex": "00D287",
-            "source": "https://www.zilch.com/"
+            "source": "https://www.zilch.com"
         },
         {
             "title": "Zillow",
             "hex": "006AFF",
-            "source": "https://www.zillow.com/"
+            "source": "https://www.zillow.com"
         },
         {
             "title": "ZincSearch",
             "hex": "5BA37F",
-            "source": "https://zincsearch.com/"
+            "source": "https://zincsearch.com"
         },
         {
             "title": "Zingat",
@@ -13413,7 +13413,7 @@
         {
             "title": "Zyte",
             "hex": "B02CCE",
-            "source": "https://www.zyte.com/"
+            "source": "https://www.zyte.com"
         }
     ]
 }

--- a/scripts/lint/ourlint.js
+++ b/scripts/lint/ourlint.js
@@ -57,9 +57,9 @@ const TESTS = {
     }
   },
 
-  /* Check redundant slash suffix in URL */
+  /* Check redundant trailing slash in URL */
   checkUrl: (data) => {
-    const hasRedundantSlashSuffix = (url) => {
+    const hasRedundantTrailingSlash = (url) => {
       const origin = new URL(url).origin;
       return url.replace(origin, '') === '/';
     };
@@ -74,11 +74,11 @@ const TESTS = {
     ];
 
     const invalidUrls = allUrlFields.filter((url) =>
-      hasRedundantSlashSuffix(url),
+      hasRedundantTrailingSlash(url),
     );
 
     if (invalidUrls.length > 0) {
-      return `Some URLs have a redundant slash suffix:\n\n${invalidUrls.join(
+      return `Some URLs have a redundant trailing slash:\n\n${invalidUrls.join(
         '\n',
       )}`;
     }

--- a/scripts/lint/ourlint.js
+++ b/scripts/lint/ourlint.js
@@ -5,6 +5,7 @@
  * linters (e.g. jsonlint/svglint).
  */
 
+import { URL } from 'node:url';
 import fakeDiff from 'fake-diff';
 import { getIconsDataString, normalizeNewlines, collator } from '../../sdk.mjs';
 
@@ -53,6 +54,33 @@ const TESTS = {
     if (normalizedDataString !== dataPretty) {
       const dataDiff = fakeDiff(normalizedDataString, dataPretty);
       return `Data file is formatted incorrectly:\n\n${dataDiff}`;
+    }
+  },
+
+  /* Check redundant slash suffix in URL */
+  checkUrl: (data) => {
+    const hasRedundantSlashSuffix = (url) => {
+      const origin = new URL(url).origin;
+      return url.replace(origin, '') === '/';
+    };
+
+    const allUrlFields = [
+      ...new Set(
+        data.icons
+          .map((icon) => [icon.source, icon.guidelines, icon.license?.url])
+          .flat()
+          .filter(Boolean),
+      ),
+    ];
+
+    const invalidUrls = allUrlFields.filter((url) =>
+      hasRedundantSlashSuffix(url),
+    );
+
+    if (invalidUrls.length > 0) {
+      return `Some URLs have a redundant slash suffix:\n\n${invalidUrls.join(
+        '\n',
+      )}`;
     }
   },
 };

--- a/scripts/lint/ourlint.js
+++ b/scripts/lint/ourlint.js
@@ -61,7 +61,7 @@ const TESTS = {
   checkUrl: (data) => {
     const hasRedundantTrailingSlash = (url) => {
       const origin = new URL(url).origin;
-      return /^\/+$/.test(url.repalce(origin, ''));
+      return /^\/+$/.test(url.replace(origin, ''));
     };
 
     const allUrlFields = [

--- a/scripts/lint/ourlint.js
+++ b/scripts/lint/ourlint.js
@@ -61,7 +61,7 @@ const TESTS = {
   checkUrl: (data) => {
     const hasRedundantTrailingSlash = (url) => {
       const origin = new URL(url).origin;
-      return url.replace(origin, '') === '/';
+      return /^\/+$/.test(url.repalce(origin, ''));
     };
 
     const allUrlFields = [


### PR DESCRIPTION
We have tons of URLs that have a redundant trailing slash. For example:

```diff
-https://www.1001tracklists.com
+https://www.1001tracklists.com/
```

For these domain-only URLs, we can safely remove the trailing slash.

### How do I remove those trailing slashes

The VS Code has a performance bug when I try to find all incorrect URLs with regex. So I used Sublime Text to replace texts on my local.

Here is my regex pattern:

|Find|Replace|
|:--|:--|
|`(https://([0-9a-z-]\.?)*)(/)"`|`$1"`|

### Bundle size

||Before|After|
|:--|:--|:--|
|index.js|35,434.13 KB|35,428.42 KB|