### PR TITLE
Autocloser: Only trigger on `opened` & fix issue number param

### DIFF
--- a/.github/workflows/autoclose-issues.yml
+++ b/.github/workflows/autoclose-issues.yml
@@ -1,7 +1,8 @@
 name: Autocloser
 on:
   issues:
-    types: [opened, edited]
+    # we allow 'reopend' and 'edited' in case the issue was closed by accident
+    types: [opened]
 
 jobs:
   run:
@@ -20,7 +21,7 @@ jobs:
       - id: get-labels
         name: Get labels
         run: |
-          labels="$(curl --retry 5 -s https://api.github.com/repos/simple-icons/simple-icons/pulls/${{ github.event.pull_request.number }} | jq '.labels[].name' | tr '\n' ',' | sed -e 's/"//g' -e 's/,$//')"
+          labels="$(curl --retry 5 -s https://api.github.com/repos/simple-icons/simple-icons/pulls/${{ github.event.issue.number }} | jq '.labels[].name' | tr '\n' ',' | sed -e 's/"//g' -e 's/,$//')"
           echo "labels=$labels" >> $GITHUB_OUTPUT
 
       # if the issue is labeled as a 'new icon' and it matches Java, we


### PR DESCRIPTION
Documentations:

- [GitHub Actions Contexts](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)
- [Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)