### PR TITLE
Autocloser: Specify `state_reason` when closing

### DIFF
--- a/.github/workflows/autoclose-issues.yml
+++ b/.github/workflows/autoclose-issues.yml
@@ -51,5 +51,6 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              state: 'closed'
+              state: 'closed',
+              state_reason: 'not_planned'
             });


### PR DESCRIPTION
I added `state_reason` parameter with `not_planned` when closing the issue.

Here is the difference:

<img width="321" alt="2023-06-02 at 19 54 49@2x" src="https://github.com/simple-icons/simple-icons/assets/8186898/dc5e57a8-4529-4bef-b38e-c3e9e1b295e6">


### Documentation

https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#update-an-issue

