### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,7 +23,7 @@ jobs:
       did-create-pr: ${{ steps.release.outputs.did-create-pr }}
       new-version: ${{ steps.release.outputs.new-version }}
     steps:
-      - uses: LitoMore/simlpe-icons-release-action@d256798422e9eb6c0b2ffefcae70edf54f5e52f9
+      - uses: LitoMore/simple-icons-release-action@d256798422e9eb6c0b2ffefcae70edf54f5e52f9
         id: release
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,7 +23,7 @@ jobs:
       did-create-pr: ${{ steps.release.outputs.did-create-pr }}
       new-version: ${{ steps.release.outputs.new-version }}
     steps:
-      - uses: simple-icons/release-action@5edfadcb9d0fcced712defd84c26d8fd3913beb9
+      - uses: LitoMore/simlpe-icons-release-action@d256798422e9eb6c0b2ffefcae70edf54f5e52f9
         id: release
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #8734

This is a quick fix to continue releases.

I added a new logic that can skip those PRs with `[skip]` prefix.

`release-actions` changes: https://github.com/LitoMore/simple-icons-release-action/commit/d256798422e9eb6c0b2ffefcae70edf54f5e52f9