### PR TITLE
Update Proton VPN color

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -9458,7 +9458,7 @@
         },
         {
             "title": "ProtonVPN",
-            "hex": "6D4AFF",
+            "hex": "66DEB1",
             "source": "https://proton.me/media/kit"
         },
         {


### PR DESCRIPTION

![protonvpn](https://github.com/simple-icons/simple-icons/assets/35000807/23aec16c-16b6-4397-9d66-3e38670fbd1d)

Updating to this color `#66DEB1` as it is mentioned in blog post that 

> In addition to the new brand color and palette, we have introduced colors specific to each service: green for Proton VPN, blue for Proton Calendar, and red for Proton Drive.
