### PR TITLE
Freeze dependencies and bump svglint

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "url": "https://opencollective.com/simple-icons"
   },
   "devDependencies": {
-    "@inquirer/prompts": "^1.0.0",
+    "@inquirer/prompts": "1.0.0",
     "chalk": "5.2.0",
     "editorconfig-checker": "5.0.1",
     "esbuild": "0.17.19",

--- a/package.json
+++ b/package.json
@@ -76,10 +76,10 @@
     "rimraf": "5.0.1",
     "svg-path-bbox": "1.2.4",
     "svg-path-segments": "1.0.0",
-    "svglint": "2.3.1",
+    "svglint": "2.4.0",
     "svgo": "3.0.2",
     "svgpath": "2.6.0",
-    "typescript": "^5.1.6"
+    "typescript": "5.1.6"
   },
   "scripts": {
     "build": "node scripts/build/package.js",


### PR DESCRIPTION
- From #9218, freeze typescript.
- From #8592, freeze @inquirer/prompts.
- Address high severity issue on svglint, see [v2.4.0](https://github.com/birjj/svglint/releases/tag/v2.4.0).