### PR TITLE
Memoize functions in SVG linting

### DIFF
--- a/.svglintrc.mjs
+++ b/.svglintrc.mjs
@@ -31,6 +31,7 @@ const negativeZerosRegexp = /-0(?=[^\.]|[\s\d\w]|$)/g;
 const svgPathRegexp = /^[Mm][MmZzLlHhVvCcSsQqTtAaEe0-9\-,. ]+$/;
 
 const iconSize = 24;
+const iconTargetCenter = iconSize / 2;
 const iconFloatPrecision = 3;
 const iconMaxFloatPrecision = 5;
 const iconTolerance = 0.001;
@@ -147,6 +148,40 @@ const ignoreIcon = (linterName, path, $) => {
 
   iconIgnored[linterName][path] = iconName;
 };
+
+/**
+ * Cache for SVG icons.
+ *
+ * Used to avoid parsing the same data for each icon multiple times.
+ */
+class IconsCache {
+  static content = {
+    path: {},
+    segments: {},
+    bbox: {},
+  };
+
+  static getOrSetPath($icon, filepath) {
+    if (!this.content.path[filepath]) {
+      this.content.path[filepath] = $icon.find('path').attr('d');
+    }
+    return this.content.path[filepath];
+  }
+
+  static getOrSetSegments(iconPath) {
+    if (!this.content.segments[iconPath]) {
+      this.content.segments[iconPath] = parsePath(iconPath);
+    }
+    return this.content.segments[iconPath];
+  }
+
+  static getOrSetBbox(iconPath) {
+    if (!this.content.bbox[iconPath]) {
+      this.content.bbox[iconPath] = svgPathBbox(iconPath);
+    }
+    return this.content.bbox[iconPath];
+  }
+}
 
 export default {
   rules: {
@@ -345,15 +380,15 @@ export default {
           }
         }
       },
-      (reporter, $) => {
+      (reporter, $, ast, filepath) => {
         reporter.name = 'icon-size';
 
-        const iconPath = $.find('path').attr('d');
+        const iconPath = IconsCache.getOrSetPath($, filepath);
         if (!updateIgnoreFile && isIgnored(reporter.name, iconPath)) {
           return;
         }
 
-        const [minX, minY, maxX, maxY] = svgPathBbox(iconPath);
+        const [minX, minY, maxX, maxY] = IconsCache.getOrSetBbox(iconPath);
         const width = +(maxX - minX).toFixed(iconFloatPrecision);
         const height = +(maxY - minY).toFixed(iconFloatPrecision);
 
@@ -374,11 +409,11 @@ export default {
           }
         }
       },
-      (reporter, $, ast) => {
+      (reporter, $, ast, filepath) => {
         reporter.name = 'icon-precision';
 
-        const iconPath = $.find('path').attr('d');
-        const segments = parsePath(iconPath);
+        const iconPath = IconsCache.getOrSetPath($, filepath);
+        const segments = IconsCache.getOrSetSegments(iconPath);
 
         for (const segment of segments) {
           const precisionMax = Math.max(
@@ -404,12 +439,11 @@ export default {
           }
         }
       },
-      (reporter, $, ast) => {
+      (reporter, $, ast, filepath) => {
         reporter.name = 'ineffective-segments';
 
-        const iconPath = $.find('path').attr('d');
-
-        const segments = parsePath(iconPath);
+        const iconPath = IconsCache.getOrSetPath($, filepath);
+        const segments = IconsCache.getOrSetSegments(iconPath);
         const absSegments = svgpath(iconPath).abs().unshort().segments;
 
         const lowerMovementCommands = ['m', 'l'];
@@ -625,17 +659,15 @@ export default {
           }
         }
       },
-      (reporter, $, ast) => {
+      (reporter, $, ast, filepath) => {
         reporter.name = 'collinear-segments';
-
-        const iconPath = $.find('path').attr('d');
 
         /**
          * Extracts collinear coordinates from SVG path straight lines
          *   (does not extracts collinear coordinates from curves).
          **/
         const getCollinearSegments = (iconPath) => {
-          const segments = parsePath(iconPath),
+          const segments = IconsCache.getOrSetSegments(iconPath),
             collinearSegments = [],
             straightLineCommands = 'HhVvLlMm';
 
@@ -792,8 +824,12 @@ export default {
           return collinearSegments;
         };
 
-        const collinearSegments = getCollinearSegments(iconPath),
-          pathDIndex = getPathDIndex(ast.source);
+        const iconPath = IconsCache.getOrSetPath($, filepath),
+          collinearSegments = getCollinearSegments(iconPath);
+        if (collinearSegments.length === 0) {
+          return;
+        }
+        const pathDIndex = getPathDIndex(ast.source);
         for (const segment of collinearSegments) {
           let errorMsg = `Collinear segment "${iconPath.substring(
             segment.start,
@@ -827,10 +863,10 @@ export default {
           }
         }
       },
-      (reporter, $, ast) => {
+      (reporter, $, ast, filepath) => {
         reporter.name = 'negative-zeros';
 
-        const iconPath = $.find('path').attr('d');
+        const iconPath = IconsCache.getOrSetPath($, filepath);
 
         // Find negative zeros inside path
         const negativeZeroMatches = Array.from(
@@ -853,27 +889,26 @@ export default {
           }
         }
       },
-      (reporter, $) => {
+      (reporter, $, ast, filepath) => {
         reporter.name = 'icon-centered';
 
-        const iconPath = $.find('path').attr('d');
+        const iconPath = IconsCache.getOrSetPath($, filepath);
         if (!updateIgnoreFile && isIgnored(reporter.name, iconPath)) {
           return;
         }
 
-        const [minX, minY, maxX, maxY] = svgPathBbox(iconPath);
-        const targetCenter = iconSize / 2;
+        const [minX, minY, maxX, maxY] = IconsCache.getOrSetBbox(iconPath);
         const centerX = +((minX + maxX) / 2).toFixed(iconFloatPrecision);
-        const devianceX = centerX - targetCenter;
+        const devianceX = centerX - iconTargetCenter;
         const centerY = +((minY + maxY) / 2).toFixed(iconFloatPrecision);
-        const devianceY = centerY - targetCenter;
+        const devianceY = centerY - iconTargetCenter;
 
         if (
           Math.abs(devianceX) > iconTolerance ||
           Math.abs(devianceY) > iconTolerance
         ) {
           reporter.error(
-            `<path> must be centered at (${targetCenter}, ${targetCenter});` +
+            `<path> must be centered at (${iconTargetCenter}, ${iconTargetCenter});` +
               ` the center is currently (${centerX}, ${centerY})`,
           );
           if (updateIgnoreFile) {
@@ -881,16 +916,16 @@ export default {
           }
         }
       },
-      (reporter, $, ast) => {
+      (reporter, $, ast, filepath) => {
         reporter.name = 'path-format';
 
-        const iconPath = $.find('path').attr('d');
+        const iconPath = IconsCache.getOrSetPath($, filepath);
 
         if (!svgPathRegexp.test(iconPath)) {
           let errorMsg = 'Invalid path format',
             reason;
 
-          if (!/^[Mm]/.test(iconPath)) {
+          if (!iconPath.startsWith('M') && !iconPath.startsWith('m')) {
             // doesn't start with moveto
             reason =
               'should start with "moveto" command ("M" or "m"),' +
@@ -917,8 +952,7 @@ export default {
           if (invalidCharactersMsgs.length > 0) {
             reason = `unexpected character${
               invalidCharactersMsgs.length > 1 ? 's' : ''
-            } found`;
-            reason += ` (${invalidCharactersMsgs.join(', ')})`;
+            } found (${invalidCharactersMsgs.join(', ')})`;
             reporter.error(`${errorMsg}: ${reason}`);
           }
         }

--- a/.svglintrc.mjs
+++ b/.svglintrc.mjs
@@ -118,6 +118,29 @@ const maybeShortenedWithEllipsis = (str) => {
   return str.length > 20 ? `${str.substring(0, 20)}...` : str;
 };
 
+/**
+ * Memoize a function that accept a single argument.
+ * A second argument can be passed to be used as key.
+ * @param {*} func
+ * @returns
+ */
+const memoize = (func) => {
+  const results = {};
+
+  return (arg, defaultKey = null) => {
+    const key = defaultKey || arg;
+
+    if (!results[key]) {
+      results[key] = func(arg);
+    }
+    return results[key];
+  };
+};
+
+const getIconPath = memoize(($icon, filepath) => $icon.find('path').attr('d'));
+const getIconPathSegments = memoize((iconPath) => parsePath(iconPath));
+const getIconPathBbox = memoize((iconPath) => svgPathBbox(iconPath));
+
 if (updateIgnoreFile) {
   process.on('exit', () => {
     // ensure object output order is consistent due to async svglint processing
@@ -148,29 +171,6 @@ const ignoreIcon = (linterName, path, $) => {
 
   iconIgnored[linterName][path] = iconName;
 };
-
-/**
- * Memoize a function that accept a single argument.
- * A second argument can be passed to be used as key.
- * @param {*} func
- * @returns
- */
-const memoize = (func) => {
-  const results = {};
-
-  return (arg, defaultKey = null) => {
-    const key = defaultKey || arg;
-
-    if (!results[key]) {
-      results[key] = func(arg);
-    }
-    return results[key];
-  };
-};
-
-const getIconPath = memoize(($icon, filepath) => $icon.find('path').attr('d'));
-const getIconPathSegments = memoize((iconPath) => parsePath(iconPath));
-const getIconPathBbox = memoize((iconPath) => svgPathBbox(iconPath));
 
 export default {
   rules: {

--- a/.svglintrc.mjs
+++ b/.svglintrc.mjs
@@ -119,7 +119,7 @@ const maybeShortenedWithEllipsis = (str) => {
 };
 
 /**
- * Memoize a function that accept a single argument.
+ * Memoize a function which accepts a single argument.
  * A second argument can be passed to be used as key.
  */
 const memoize = (func) => {

--- a/.svglintrc.mjs
+++ b/.svglintrc.mjs
@@ -121,8 +121,6 @@ const maybeShortenedWithEllipsis = (str) => {
 /**
  * Memoize a function that accept a single argument.
  * A second argument can be passed to be used as key.
- * @param {*} func
- * @returns
  */
 const memoize = (func) => {
   const results = {};


### PR DESCRIPTION
This PR improves performance of `svglint` script ~30% on my local machine, from ~7 seconds to ~4.5. 
