### PR TITLE
Fix GitHub built-in highlight styles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to Simple Icons
 
-> **Note** We ask that all users read our [legal disclaimer](./DISCLAIMER.md) before contributing to Simple Icons.
+> **Note**\
+> We ask that all users read our [legal disclaimer](./DISCLAIMER.md) before contributing to Simple Icons.
 
 Simple Icons welcomes contributions and corrections. Before contributing, please make sure you have read the guidelines below. If you decide to contribute anything, please follow the steps below. If you're new to _git_ and/or _GitHub_, we suggest you go through [the GitHub Guides](https://guides.github.com/introduction/flow/).
 

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -11,10 +11,10 @@ Simple Icons asks that its users read this disclaimer fully before including an 
 
 ## Licenses, Copyrights & Trademarks
 
-> **Note**
->  The addition of licenses to Simple Icons is an ongoing project. Hence, the absence of licence data for a particular icon does not imply that the icon is not released under a license.
+> **Note**\
+> The addition of licenses to Simple Icons is an ongoing project. Hence, the absence of licence data for a particular icon does not imply that the icon is not released under a license.
 
-> **Note**
+> **Note**\
 > Simple Icons is released under CC0 - though that doesn't mean to imply that all icons within the project are also CC0. Please see individual licenses where available.
 
 Simple Icons provides data on the license under which icons are available. We ask users to carefully consider this when using an icon. As licenses are subject to change we also ask our users to regularly check if the license of the icons they use have been changed.
@@ -29,8 +29,8 @@ Simple Icons cannot be held responsible for any legal activity raised by a brand
 
 ## Brand Guidelines
 
-> **Note**
->  The addition of guidelines to Simple Icons is an ongoing project. In the meantime, users of Simple Icons are instead encouraged to check the `source` URL as, in some cases, the icon will have been sourced from official guidelines. The lack of a `guidelines` entry for a particular brand does not imply that the brand has no guidelines.
+> **Note**\
+> The addition of guidelines to Simple Icons is an ongoing project. In the meantime, users of Simple Icons are instead encouraged to check the `source` URL as, in some cases, the icon will have been sourced from official guidelines. The lack of a `guidelines` entry for a particular brand does not imply that the brand has no guidelines.
 
 Simple Icons provides a link to a brand's _branding guidelines_ (or similar) if the brand provides one. We ask our users read these guidelines and ensure their usage of the brand's icon is in accordance with them. As guidelines are subject to change we also ask our users to regularly check if the brand guidelines of the icons they use have been updated.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Over 2600 Free SVG icons for popular brands. See them all on one page at <a href
 
 ## Usage
 
-> **Note** We ask that all users read our [legal disclaimer](./DISCLAIMER.md) before using icons from Simple Icons.
+> **Note**\
+> We ask that all users read our [legal disclaimer](./DISCLAIMER.md) before using icons from Simple Icons.
 
 ### General Usage
 


### PR DESCRIPTION
According to their latest documentation https://github.com/orgs/community/discussions/16925. The format should be:

```markdown
> **Note**\
> Foo bar
```

> **Note**\
> Foo bar

