### PR TITLE
fix: npmjs brand guidline url

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -8490,7 +8490,7 @@
             "title": "npm",
             "hex": "CB3837",
             "source": "https://www.npmjs.com",
-            "guidelines": "https://www.npmjs.com/policies/trademark"
+            "guidelines": "https://docs.npmjs.com/policies/logos-and-usage"
         },
         {
             "title": "Nrwl",


### PR DESCRIPTION
### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] <del>I optimized the icon with SVGO or SVGOMG
  - [ ] <del>The SVG `viewbox` is `0 0 24 24`

### Description
The brand guideline URL for NPM lead to a 404
