### PR TITLE
Allow skipping release note with `skip release note` label

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,7 +23,7 @@ jobs:
       did-create-pr: ${{ steps.release.outputs.did-create-pr }}
       new-version: ${{ steps.release.outputs.new-version }}
     steps:
-      - uses: LitoMore/simple-icons-release-action@9969e1266c9e470fe015dbd825a2897423e9270e
+      - uses: LitoMore/simple-icons-release-action@1a0c7bb3a4a694ba3877d92e340c01a7a56cc730
         id: release
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Related to https://github.com/simple-icons/simple-icons/pull/9300#issuecomment-1688461364.

Related commit: https://github.com/LitoMore/simple-icons-release-action/commit/1a0c7bb3a4a694ba3877d92e340c01a7a56cc730