### PR TITLE
Add `[Icon request]` to bot ignore.

### DIFF
--- a/.github/workflows/potential-duplicates.yml
+++ b/.github/workflows/potential-duplicates.yml
@@ -34,6 +34,7 @@ jobs:
             assets
             for
             from
+            [Icon request]
           state: all
           threshold: 0.7
           comment: |


### PR DESCRIPTION
Adds `[Icon request]` to the duplicate detection rules, ensuring requests starting with that string don't get confused by the bot.