### PR TITLE
Add `new` to Potential Duplicates workflow

### DIFF
--- a/.github/workflows/potential-duplicates.yml
+++ b/.github/workflows/potential-duplicates.yml
@@ -24,6 +24,7 @@ jobs:
             miss
             needing
             need
+            new
             please
             requesting
             request


### PR DESCRIPTION
The word new is recently used often in icon request. It should be part of the ignored list of the Potential Duplicates workflow.