### PR TITLE
Add Pond5

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -10291,6 +10291,11 @@
             "source": "https://www.polywork.com"
         },
         {
+            "title": "Pond5",
+            "hex": "14ADF0",
+            "source": "https://cdn-explore.pond5.com/uploads/sites/4/2019/10/PON.logo_.mark-white.png"
+        },
+        {
             "title": "Pop!_OS",
             "hex": "48B9C7",
             "source": "https://pop.system76.com"

--- a/icons/pond5.svg
+++ b/icons/pond5.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Pond5</title><path d="M8.492 0v11.765H2.316V24H8.98V12.235h12.705V0H8.492m12.705.487v11.278H8.98V.487h12.218M8.492 12.235v11.278h-5.69V12.235h5.69Z"/></svg>


### PR DESCRIPTION

![pond5](https://github.com/simple-icons/simple-icons/assets/61133303/8beb8f64-49b9-4b21-9c0f-246b11ccf852)

**Similarweb rank:** [17,991](https://www.similarweb.com/website/pond5.com/#overview)

### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description
Logo is vectorized from [PNG](https://cdn-explore.pond5.com/uploads/sites/4/2019/10/PON.logo_.mark-white.png) using Inkscape. Colour `#14ADF0` picked from a [blog article](https://blog.pond5.com/3461-our-brand/) about their brand colours. 
