### PR TITLE
Drop `trailingComma` setting from Prettier config

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,3 @@
 {
-  "trailingComma": "all",
   "singleQuote": true
 }


### PR DESCRIPTION
Starting from v3 Prettier has the default value of `'all'` for `trailingComma` setting, see https://prettier.io/blog/2023/07/05/3.0.0