### PR TITLE
Use permanent README icons links in releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,10 +48,15 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+      - name: Get release version
+        id: get-version
+        run: |
+          export PACKAGE_VERSION=$(cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//')
+          echo "version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
       - name: Install dependencies
         run: npm i
       - name: Replace CDN theme image links from README
-        run: npm run strip-theme-link
+        run: node ./scripts/release/strip-theme-links.js "${{ steps.get-version.outputs.version }}"
       - name: Update SDK Typescript definitions
         run: node ./scripts/release/update-sdk-ts-defs.js
       - name: Build NodeJS package
@@ -74,9 +79,9 @@ jobs:
         id: get-version
         run: |
           export PACKAGE_VERSION=$(cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//')
-          echo "::set-output name=version::$PACKAGE_VERSION"
+          echo "version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
       - name: Replace CDN theme image links from README
-        run: npm run strip-theme-link
+        run: node ./scripts/release/strip-theme-links.js "${{ steps.get-version.outputs.version }}"
       - name: Configure GIT credentials
         run: |
           git config user.name "${GITHUB_ACTOR}"

--- a/package.json
+++ b/package.json
@@ -123,8 +123,7 @@
     "pretest": "npm run prepublishOnly",
     "posttest": "npm run postpublish",
     "get-filename": "node scripts/get-filename.js",
-    "add-icon-data": "node scripts/add-icon-data.js",
-    "strip-theme-link": "node scripts/build/strip-theme-link.js"
+    "add-icon-data": "node scripts/add-icon-data.js"
   },
   "engines": {
     "node": ">=0.12.18"

--- a/scripts/release/strip-theme-links.js
+++ b/scripts/release/strip-theme-links.js
@@ -7,7 +7,7 @@ import path from 'node:path';
 import { writeFile, readFile } from 'node:fs/promises';
 import { getDirnameFromImportMeta } from '../../sdk.mjs';
 
-const LINK_BRANCH = process.argv[2] || 'develop';
+const LINKS_BRANCH = process.argv[2] || 'develop';
 
 const __dirname = getDirnameFromImportMeta(import.meta.url);
 
@@ -19,6 +19,6 @@ await writeFile(
   readmeFile,
   readme.replace(
     /https:\/\/cdn.simpleicons.org\/(.+)\/000\/fff/g,
-    `https://raw.githubusercontent.com/simple-icons/simple-icons/${LINK_BRANCH}/icons/$1.svg`,
+    `https://raw.githubusercontent.com/simple-icons/simple-icons/${LINKS_BRANCH}/icons/$1.svg`,
   ),
 );

--- a/scripts/release/strip-theme-links.js
+++ b/scripts/release/strip-theme-links.js
@@ -7,6 +7,8 @@ import path from 'node:path';
 import { writeFile, readFile } from 'node:fs/promises';
 import { getDirnameFromImportMeta } from '../../sdk.mjs';
 
+const LINK_BRANCH = process.argv[2] || 'develop';
+
 const __dirname = getDirnameFromImportMeta(import.meta.url);
 
 const rootDir = path.resolve(__dirname, '..', '..');
@@ -17,6 +19,6 @@ await writeFile(
   readmeFile,
   readme.replace(
     /https:\/\/cdn.simpleicons.org\/(.+)\/000\/fff/g,
-    'https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/$1.svg',
+    `https://raw.githubusercontent.com/simple-icons/simple-icons/${LINK_BRANCH}/icons/$1.svg`,
   ),
 );


### PR DESCRIPTION
Currently the README icons links on released versions are not persistent, which could lead to 404 errors requesting links from *README.md* in the future or display updated versions of icons, which are not the ones for that version.