### PR TITLE
Deduplicate `get-labels` and `get-version` steps in GHA workflows

### DIFF
--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -21,10 +21,9 @@ jobs:
       MY_GITHUB_TOKEN: ${{ secrets.AUTO_ASSIGN_WORKFLOW_TOKEN }}
     steps:
       - id: get-labels
-        name: Get labels
-        run: |
-          labels="$(curl --retry 5 -s https://api.github.com/repos/simple-icons/simple-icons/pulls/${{ github.event.pull_request.number }} | jq '.labels[].name' | tr '\n' ',' | sed -e 's/"//g' -e 's/,$//')"
-          echo "labels=$labels" >> $GITHUB_OUTPUT
+        uses: ./.github/workflows/get-labels.yml
+        with:
+          issue_number: ${{ github.event.pull_request.number }}
 
       - id: get-si-members
         name: Get simple-icons members

--- a/.github/workflows/autoclose-issues.yml
+++ b/.github/workflows/autoclose-issues.yml
@@ -19,10 +19,9 @@ jobs:
           fi
 
       - id: get-labels
-        name: Get labels
-        run: |
-          labels="$(curl --retry 5 -s https://api.github.com/repos/simple-icons/simple-icons/issues/${{ github.event.issue.number }} | jq '.labels[].name' | tr '\n' ',' | sed -e 's/"//g' -e 's/,$//')"
-          echo "labels=$labels" >> $GITHUB_OUTPUT
+        uses: ./.github/workflows/get-labels.yml
+        with:
+          issue_number: ${{ github.event.issue.number }}
 
       # if the issue is labeled as a 'new icon' and it matches Java, we
       # - add a comment referring to the removal request

--- a/.github/workflows/get-labels.yml
+++ b/.github/workflows/get-labels.yml
@@ -1,0 +1,27 @@
+# Get the current labels of an issue or pull request through the GitHub API
+name: Get issue/pull request labels
+
+on:
+  workflow_call:
+    inputs:
+      issue_number:
+        description: Issue or pull request number to get labels from
+        required: true
+        type: number
+    outputs:
+      labels:
+        description: Labels of the issue or pull request
+        value: ${{ jobs.get-labels.outputs.labels }}
+
+jobs:
+  get-labels:
+    name: Get labels
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.get-labels.outputs.labels }}
+    steps:
+      - id: get-labels
+        name: Get labels using GitHub API
+        run: |
+          labels="$(gh api 'repos/simple-icons/simple-icons/issues/${{ inputs.issue_number }}' --jq '.labels.[].name')"
+          echo "labels=$labels" >> $GITHUB_OUTPUT

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
-      - name: Get version
+      - name: Get version from package.json
         id: get-version
         run: |
           version="$(grep version -m 1 -i package.json | sed 's/[ \",:version]//g')"

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -1,0 +1,22 @@
+# Get the current version
+name: Get version
+
+on:
+  workflow_call:
+    outputs:
+      version:
+        description: The version of the project
+        value: ${{ jobs.get-version.outputs.version }}
+
+jobs:
+  get-version:
+    name: Get version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+      - name: Get version
+        id: get-version
+        run: |
+          version="$(grep version -m 1 -i package.json | sed 's/[ \",:version]//g')"
+          echo "version=$version" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,8 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+      - id: get-version
+        uses: ./.github/workflows/get-version.yml
       - name: Install dependencies
         run: npm i
       - name: Replace CDN theme image links from README
@@ -70,11 +72,8 @@ jobs:
       - name: Get commit message (for release title and body)
         id: commit
         uses: kceb/git-message-action@v2
-      - name: Get release version
-        id: get-version
-        run: |
-          export PACKAGE_VERSION=$(cat package.json | grep 'version' | sed 's/[ \",:]//g' | sed 's/version//')
-          echo "::set-output name=version::$PACKAGE_VERSION"
+      - id: get-version
+        uses: ./.github/workflows/get-version.yml
       - name: Replace CDN theme image links from README
         run: npm run strip-theme-link
       - name: Configure GIT credentials


### PR DESCRIPTION
See [Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) in Github documentation.