### PR TITLE
Use `git add -u` in pre-commit hook and fix assign-to-project GHA workflow

### DIFF
--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -20,6 +20,9 @@ jobs:
     env:
       MY_GITHUB_TOKEN: ${{ secrets.AUTO_ASSIGN_WORKFLOW_TOKEN }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - id: get-labels
         uses: ./.github/actions/get-labels
         with:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname $0)/_/husky.sh"
 
 npm run format
-git add .
+git add -u


### PR DESCRIPTION
`git add -u` does not include new untracked files as `git add .` does. Before the pre-commit hook, we've previosuly added the files in our manual `git add <whatever>` execution, but husky is including all the new files, even those that we hadn't tracked it.

To replicate this problem, create a new file *foobar.baz*, make a formatting change in a JS file like *svgo.config.mjs*, run `git add svgo.config.mjs`, create a commit and the new file *foobar.baz* will be added. After this change, only the format of *svgo.config.mjs* is updated but the new file is not added. Much more convenient.

Also includes a missing checkout step in CI.