### PR TITLE
Fix get-labels action when returning multiple labels

### DIFF
--- a/.github/actions/get-labels/action.yml
+++ b/.github/actions/get-labels/action.yml
@@ -16,5 +16,5 @@ runs:
     - id: get-labels
       shell: sh
       run: |
-        labels="$(gh api 'repos/simple-icons/simple-icons/issues/${{ inputs.issue_number }}' --jq '.labels.[].name')"
+        labels="$(gh api 'repos/simple-icons/simple-icons/issues/${{ inputs.issue_number }}' --jq '.labels.[].name' | tr '\n' ',')"
         echo "labels=$labels" >> $GITHUB_OUTPUT


### PR DESCRIPTION
When a contributor adds multiple labels to a PR before the get-labels action is executed, the `labels` output is formatted in multiple lines, which raises the error:

```
Error: Unable to process file command 'output' successfully.
Error: Invalid format '<first-label>'
```

After this PR the labels in output are separated by commas instead of newlines.

Happened at https://github.com/simple-icons/simple-icons/pull/9846