### PR TITLE
Update Webex icon color

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -14963,7 +14963,7 @@
         },
         {
             "title": "Webex",
-            "hex": "FFFFFF",
+            "hex": "000000",
             "source": "https://github.com/momentum-design/momentum-ui/blob/970c5bec962a3f72e17e0b7ed69f2c38d298c405/icons-rebrand/svg/webex-helix-filled.svg",
             "guidelines": "https://resources.webex.com/webex/brand-exchange-collection",
             "license": {


### PR DESCRIPTION
Use black instead of white as the brand color for a better default visual.