### PR TITLE
Add skaffold

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -12652,6 +12652,11 @@
             "source": "https://www.sitepoint.com"
         },
         {
+            "title": "Skaffold",
+            "hex": "2AA2D6",
+            "source": "https://github.com/GoogleContainerTools/skaffold/blob/9376dc047aded2adb188f599267fbb829a327dfd/logo/skaffold.eps"
+        },
+        {
             "title": "Sketch",
             "hex": "F7B500",
             "source": "https://www.sketch.com/about-us/#press",

--- a/icons/skaffold.svg
+++ b/icons/skaffold.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Skaffold</title><path d="M6.602 20.097H24v3.836H6.602v-3.836zm-2.766-6.692h13.562v3.837H0V6.714h3.836v6.691zm13.562-9.502H0V.067h17.398v3.836zm2.766 6.692H6.602V6.758H24v10.528h-3.836v-6.691z"/></svg>


### PR DESCRIPTION

![skaffold](https://github.com/simple-icons/simple-icons/assets/35000807/6ee2dac9-a0e6-4909-9a96-ccaddb7f043a)

**Issue:** closes #9138 

**GitHub Stars:** 14.3K. See https://github.com/GoogleContainerTools/skaffold/tree/main

### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description
SVG: Extracted from here https://github.com/GoogleContainerTools/skaffold/blob/main/logo/skaffold.eps
Color: Taken from logo `#2aa2d6`
