### PR TITLE
Update Hono

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -6469,7 +6469,7 @@
         },
         {
             "title": "Hono",
-            "hex": "FF612B",
+            "hex": "E36002",
             "source": "https://github.com/honojs/hono/blob/76dbc74407329c46870af6aa4fab0c04036d8ae2/docs/images/hono-logo.svg"
         },
         {


### PR DESCRIPTION
![image](https://github.com/simple-icons/simple-icons/assets/114303361/c82da6de-617d-4c17-ba49-f667d0a1c625)
**Similarweb rank:** [454,247](https://www.similarweb.com/website/hono.dev/#overview)
**GitHub star:** [9,418](https://github.com/honojs/hono)

<!--
The Similarweb rank can be retrieved at https://www.similarweb.com
Please see our contributing guidelines for more details on how we assess a brand's popularity.
-->

### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [ ] I optimized the icon with SVGO or SVGOMG
- [ ] The SVG `viewbox` is `0 0 24 24`

### Description
Pull request to add Hono icon(#10140 ) was just integrated, but please allow to me change the color.
After reconsidering theme color, author of Hono contacted me and asked us to use `#E36002`, which is used on the website.
I created this pr to fulfill that request.