### PR TITLE
Add Orange Icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -10300,6 +10300,12 @@
             "guidelines": "https://www.oracle.com/legal/logos.html"
         },
         {
+            "title": "Orange",
+            "hex": "FF7900",
+            "source": "https://brand.orange.com",
+            "guidelines": "https://system.design.orange.com/0c1af118d/p/494474-guidelines"
+        },
+        {
             "title": "ORCID",
             "hex": "A6CE39",
             "source": "https://orcid.figshare.com/articles/figure/ORCID_iD_icon_graphics/5008697",

--- a/icons/orange.svg
+++ b/icons/orange.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Orange</title><path d="M0 0h24v24H0V0Zm3.43 20.572h17.143v-3.429H3.43v3.429Z"/></svg>


### PR DESCRIPTION
![orange](https://github.com/simple-icons/simple-icons/assets/54018894/71d0c2ec-4ae3-49d6-8b05-c3689f95631b)

**Issue:** closes #8423

**Similarweb rank:** [45,619](https://www.similarweb.com/website/orange.com/#overview)

### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description

There are two different logos in use Master and small logo. The master logo has trademark symbol (™) so i'm going with small logo which is used as a replacement for the Master logo.

[Svg](https://brand.orange.com/obrAssets/img/orange-logo.svg) taken from brand page header, **Hex** taken from [guidelines](https://system.design.orange.com/0c1af118d/p/76371f-master-and-small-logo) page