### PR TITLE
Update Nintendo hex

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -9751,7 +9751,7 @@
         },
         {
             "title": "Nintendo",
-            "hex": "E60013",
+            "hex": "E60012",
             "source": "https://www.nintendo.com"
         },
         {


### PR DESCRIPTION
I was a bit hasty in merging #10263 and didn't spot that the hex was _slightly_ off; it should be `#e60012` rather than `#e60013`.