### PR TITLE
amazon-aws-to-amazon-web-services

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -647,7 +647,7 @@
             }
         },
         {
-            "title": "Amazon AWS",
+            "title": "Amazon Web Services",
             "hex": "232F3E",
             "source": "https://commons.wikimedia.org/wiki/File:Amazon_Web_Services_Logo.svg",
             "aliases": {


### PR DESCRIPTION

### Description
I changed the title of Amazon AWS to Amazon Web Services as requested in https://github.com/simple-icons/simple-icons/issues/10282#removals.

(This is my first real contribution, so I may have done something incorrectly or misunderstood what that page meant.)

