### PR TITLE
amazon-aws-to-just-aws

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -647,12 +647,12 @@
             }
         },
         {
-            "title": "Amazon AWS",
+            "title": "AWS",
             "hex": "232F3E",
             "source": "https://commons.wikimedia.org/wiki/File:Amazon_Web_Services_Logo.svg",
             "aliases": {
                 "aka": [
-                    "AWS"
+                    "Amazon Web Services"
                 ]
             }
         },


### PR DESCRIPTION
### Description
Changed Amazon AWS to just AWS and switched it's alias to Amazon Web Service

(I don't know if I edited the json file properly, so it may be incorrect)

