### PR TITLE
Remove Trailing Slashes from URLs

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -455,7 +455,7 @@
         {
             "title": "AirPlay Video",
             "hex": "000000",
-            "source": "https://developer.apple.com/design/human-interface-guidelines/airplay/overview/icons/",
+            "source": "https://developer.apple.com/design/human-interface-guidelines/airplay/overview/icons",
             "guidelines": "https://www.apple.com/legal/intellectual-property/guidelinesfor3rdparties.html"
         },
         {
@@ -792,8 +792,8 @@
         {
             "title": "Amazon Route 53",
             "hex": "8C4FFF",
-            "source": "https://aws.amazon.com/architecture/icons/",
-            "guidelines": "https://aws.amazon.com/architecture/icons/",
+            "source": "https://aws.amazon.com/architecture/icons",
+            "guidelines": "https://aws.amazon.com/architecture/icons",
             "aliases": {
                 "aka": [
                     "AWS Route53"
@@ -2440,13 +2440,13 @@
         {
             "title": "Campaign Monitor",
             "hex": "111324",
-            "source": "https://www.campaignmonitor.com/company/brand/"
+            "source": "https://www.campaignmonitor.com/company/brand"
         },
         {
             "title": "Canonical",
             "hex": "E95420",
             "source": "https://design.ubuntu.com/resources",
-            "guidelines": "https://design.ubuntu.com/brand/",
+            "guidelines": "https://design.ubuntu.com/brand",
             "license": {
                 "type": "CC-BY-SA-3.0"
             }
@@ -2475,7 +2475,7 @@
         {
             "title": "Cardano",
             "hex": "0133AD",
-            "source": "https://cardano.org/brand-assets/"
+            "source": "https://cardano.org/brand-assets"
         },
         {
             "title": "Carlsberg Group",
@@ -2496,7 +2496,7 @@
         {
             "title": "Carto",
             "hex": "EB1510",
-            "source": "https://carto.com/brand/"
+            "source": "https://carto.com/brand"
         },
         {
             "title": "Cash App",
@@ -2506,7 +2506,7 @@
         {
             "title": "Castbox",
             "hex": "F55B23",
-            "source": "https://castbox.fm/newsroom/"
+            "source": "https://castbox.fm/newsroom"
         },
         {
             "title": "Castorama",
@@ -2516,7 +2516,7 @@
         {
             "title": "Castro",
             "hex": "00B265",
-            "source": "https://supertop.co/castro/press/"
+            "source": "https://supertop.co/castro/press"
         },
         {
             "title": "Caterpillar",
@@ -2556,7 +2556,7 @@
         {
             "title": "CD Projekt",
             "hex": "DC0D15",
-            "source": "https://www.cdprojekt.com/en/media/logotypes/"
+            "source": "https://www.cdprojekt.com/en/media/logotypes"
         },
         {
             "title": "Celery",
@@ -2581,7 +2581,7 @@
         {
             "title": "Cesium",
             "hex": "6CADDF",
-            "source": "https://cesium.com/press/"
+            "source": "https://cesium.com/press"
         },
         {
             "title": "Chai",
@@ -2622,7 +2622,7 @@
         {
             "title": "ChartMogul",
             "hex": "13324B",
-            "source": "https://chartmogul.com/company/"
+            "source": "https://chartmogul.com/company"
         },
         {
             "title": "Chase",
@@ -2643,12 +2643,12 @@
         {
             "title": "CheckiO",
             "hex": "008DB6",
-            "source": "https://py.checkio.org/blog/"
+            "source": "https://py.checkio.org/blog"
         },
         {
             "title": "Checkmarx",
             "hex": "54B848",
-            "source": "https://www.checkmarx.com/resources/datasheets/"
+            "source": "https://www.checkmarx.com/resources/datasheets"
         },
         {
             "title": "Checkmk",
@@ -2668,7 +2668,7 @@
         {
             "title": "Chemex",
             "hex": "4D2B1A",
-            "source": "https://vtlogo.com/chemex-coffeemaker-vector-logo-svg/"
+            "source": "https://vtlogo.com/chemex-coffeemaker-vector-logo-svg"
         },
         {
             "title": "Chevrolet",
@@ -2678,7 +2678,7 @@
         {
             "title": "Chia Network",
             "hex": "5ECE71",
-            "source": "https://www.chia.net/branding/",
+            "source": "https://www.chia.net/branding",
             "guidelines": "https://www.chia.net/wp-content/uploads/2022/08/Guidelines-for-Using-Chia-Network.pdf",
             "license": {
                 "type": "custom",
@@ -2693,7 +2693,7 @@
         {
             "title": "China Southern Airlines",
             "hex": "008BCB",
-            "source": "https://www.csair.com/en/about/investor/yejibaogao/2020/"
+            "source": "https://www.csair.com/en/about/investor/yejibaogao/2020"
         },
         {
             "title": "Chocolatey",
@@ -2708,7 +2708,7 @@
         {
             "title": "Chromecast",
             "hex": "999999",
-            "source": "https://www.google.com/intl/en_us/chromecast/built-in/",
+            "source": "https://www.google.com/intl/en_us/chromecast/built-in",
             "aliases": {
                 "aka": [
                     "Google Cast"
@@ -2824,8 +2824,8 @@
         {
             "title": "CLion",
             "hex": "000000",
-            "source": "https://www.jetbrains.com/company/brand/logos/",
-            "guidelines": "https://www.jetbrains.com/company/brand/"
+            "source": "https://www.jetbrains.com/company/brand/logos",
+            "guidelines": "https://www.jetbrains.com/company/brand"
         },
         {
             "title": "Cliqz",
@@ -2851,7 +2851,7 @@
             "title": "Cloud Foundry",
             "hex": "0C9ED5",
             "source": "https://www.cloudfoundry.org",
-            "guidelines": "https://www.cloudfoundry.org/logo/"
+            "guidelines": "https://www.cloudfoundry.org/logo"
         },
         {
             "title": "CloudBees",
@@ -2871,14 +2871,14 @@
         {
             "title": "Cloudflare",
             "hex": "F38020",
-            "source": "https://www.cloudflare.com/logo/",
-            "guidelines": "https://www.cloudflare.com/trademark/"
+            "source": "https://www.cloudflare.com/logo",
+            "guidelines": "https://www.cloudflare.com/trademark"
         },
         {
             "title": "Cloudflare Pages",
             "hex": "F38020",
             "source": "https://pages.cloudflare.com",
-            "guidelines": "https://www.cloudflare.com/trademark/"
+            "guidelines": "https://www.cloudflare.com/trademark"
         },
         {
             "title": "Cloudinary",
@@ -2888,8 +2888,8 @@
         {
             "title": "Cloudsmith",
             "hex": "2A6FE1",
-            "source": "https://cloudsmith.com/company/brand/",
-            "guidelines": "https://cloudsmith.com/company/brand/"
+            "source": "https://cloudsmith.com/company/brand",
+            "guidelines": "https://cloudsmith.com/company/brand"
         },
         {
             "title": "Cloudways",
@@ -2909,13 +2909,13 @@
         {
             "title": "CMake",
             "hex": "064F8C",
-            "source": "https://www.kitware.com/platforms/"
+            "source": "https://www.kitware.com/platforms"
         },
         {
             "title": "CNCF",
             "hex": "231F20",
             "source": "https://github.com/cncf/artwork/blob/d2ed716cc0769e6c65d2e58f9a503fca02b60a56/examples/other.md#cncf-logos",
-            "guidelines": "https://www.cncf.io/brand-guidelines/"
+            "guidelines": "https://www.cncf.io/brand-guidelines"
         },
         {
             "title": "CNET",
@@ -2958,7 +2958,7 @@
         {
             "title": "Cocos",
             "hex": "55C2E1",
-            "source": "https://www.cocos.com/en/"
+            "source": "https://www.cocos.com/en"
         },
         {
             "title": "Coda",
@@ -2968,12 +2968,12 @@
         {
             "title": "Codacy",
             "hex": "222F29",
-            "source": "https://www.codacy.com/blog/"
+            "source": "https://www.codacy.com/blog"
         },
         {
             "title": "Code Climate",
             "hex": "000000",
-            "source": "https://codeclimate.com/github/codeclimate/python-test-reporter/badges/"
+            "source": "https://codeclimate.com/github/codeclimate/python-test-reporter/badges"
         },
         {
             "title": "Code::Blocks",
@@ -3053,7 +3053,7 @@
         {
             "title": "CodePen",
             "hex": "000000",
-            "source": "https://blog.codepen.io/documentation/brand-assets/logos/"
+            "source": "https://blog.codepen.io/documentation/brand-assets/logos"
         },
         {
             "title": "CodeProject",
@@ -3103,7 +3103,7 @@
         {
             "title": "CodinGame",
             "hex": "F2BB13",
-            "source": "https://www.codingame.com/work/press/press-kit/"
+            "source": "https://www.codingame.com/work/press/press-kit"
         },
         {
             "title": "Codio",
@@ -3232,7 +3232,7 @@
         {
             "title": "containerd",
             "hex": "575757",
-            "source": "https://cncf-branding.netlify.app/projects/containerd/"
+            "source": "https://cncf-branding.netlify.app/projects/containerd"
         },
         {
             "title": "Contao",
@@ -3333,7 +3333,7 @@
         {
             "title": "cPanel",
             "hex": "FF6C2C",
-            "source": "https://cpanel.net/company/cpanel-brand-guide/"
+            "source": "https://cpanel.net/company/cpanel-brand-guide"
         },
         {
             "title": "Craft CMS",
@@ -3398,12 +3398,12 @@
         {
             "title": "Crowdin",
             "hex": "2E3340",
-            "source": "https://support.crowdin.com/using-logo/"
+            "source": "https://support.crowdin.com/using-logo"
         },
         {
             "title": "Crowdsource",
             "hex": "4285F4",
-            "source": "https://crowdsource.google.com/about/"
+            "source": "https://crowdsource.google.com/about"
         },
         {
             "title": "Crunchbase",
@@ -3423,7 +3423,7 @@
         {
             "title": "Crystal",
             "hex": "000000",
-            "source": "https://crystal-lang.org/media/"
+            "source": "https://crystal-lang.org/media"
         },
         {
             "title": "CSS Modules",
@@ -3438,7 +3438,7 @@
         {
             "title": "CSS3",
             "hex": "1572B6",
-            "source": "https://www.w3.org/html/logo/"
+            "source": "https://www.w3.org/html/logo"
         },
         {
             "title": "CTS",
@@ -3463,7 +3463,7 @@
         {
             "title": "curl",
             "hex": "073551",
-            "source": "https://curl.haxx.se/logo/"
+            "source": "https://curl.haxx.se/logo"
         },
         {
             "title": "CurseForge",
@@ -3575,8 +3575,8 @@
         {
             "title": "Dash",
             "hex": "008DE4",
-            "source": "https://www.dash.org/brand-assets/",
-            "guidelines": "https://www.dash.org/brand-guidelines/"
+            "source": "https://www.dash.org/brand-assets",
+            "guidelines": "https://www.dash.org/brand-guidelines"
         },
         {
             "title": "Dashlane",
@@ -3604,13 +3604,13 @@
         {
             "title": "data.ai",
             "hex": "000000",
-            "source": "https://www.data.ai/en/about/press/"
+            "source": "https://www.data.ai/en/about/press"
         },
         {
             "title": "Databricks",
             "hex": "FF3621",
             "source": "https://www.databricks.com",
-            "guidelines": "https://brand.databricks.com/Styleguide/Guide/"
+            "guidelines": "https://brand.databricks.com/Styleguide/Guide"
         },
         {
             "title": "DataCamp",
@@ -3621,18 +3621,18 @@
             "title": "Datadog",
             "hex": "632CA6",
             "source": "https://www.datadoghq.com/about/resources",
-            "guidelines": "https://www.datadoghq.com/about/resources/"
+            "guidelines": "https://www.datadoghq.com/about/resources"
         },
         {
             "title": "DataGrip",
             "hex": "000000",
-            "source": "https://www.jetbrains.com/company/brand/logos/",
-            "guidelines": "https://www.jetbrains.com/company/brand/"
+            "source": "https://www.jetbrains.com/company/brand/logos",
+            "guidelines": "https://www.jetbrains.com/company/brand"
         },
         {
             "title": "Dataiku",
             "hex": "2AB1AC",
-            "source": "https://www.dataiku.com/company/media-kit/"
+            "source": "https://www.dataiku.com/company/media-kit"
         },
         {
             "title": "DataStax",
@@ -3675,7 +3675,7 @@
         {
             "title": "DAZN",
             "hex": "F8F8F5",
-            "source": "https://media.dazn.com/en/assets/"
+            "source": "https://media.dazn.com/en/assets"
         },
         {
             "title": "DBeaver",
@@ -3706,7 +3706,7 @@
             "title": "Debian",
             "hex": "A81D33",
             "source": "https://www.debian.org/logos",
-            "guidelines": "https://www.debian.org/logos/",
+            "guidelines": "https://www.debian.org/logos",
             "license": {
                 "type": "CC-BY-SA-3.0"
             }
@@ -3762,7 +3762,7 @@
             "title": "Dell",
             "hex": "007DB8",
             "source": "https://www.dell.com",
-            "guidelines": "https://brand.delltechnologies.com/logos/"
+            "guidelines": "https://brand.delltechnologies.com/logos"
         },
         {
             "title": "Delphi",
@@ -3841,7 +3841,7 @@
         {
             "title": "DevExpress",
             "hex": "FF7200",
-            "source": "https://www.devexpress.com/aboutus/"
+            "source": "https://www.devexpress.com/aboutus"
         },
         {
             "title": "DeviantArt",
@@ -3902,8 +3902,8 @@
         {
             "title": "DigitalOcean",
             "hex": "0080FF",
-            "source": "https://www.digitalocean.com/press/",
-            "guidelines": "https://www.digitalocean.com/press/"
+            "source": "https://www.digitalocean.com/press",
+            "guidelines": "https://www.digitalocean.com/press"
         },
         {
             "title": "Diners Club",
@@ -3959,7 +3959,7 @@
         {
             "title": "Django",
             "hex": "092E20",
-            "source": "https://www.djangoproject.com/community/logos/"
+            "source": "https://www.djangoproject.com/community/logos"
         },
         {
             "title": "DJI",
@@ -4025,7 +4025,7 @@
         {
             "title": "DoorDash",
             "hex": "FF3008",
-            "source": "https://www.doordash.com/about/"
+            "source": "https://www.doordash.com/about"
         },
         {
             "title": "Douban",
@@ -4068,7 +4068,7 @@
         {
             "title": "Draugiem.lv",
             "hex": "FF6600",
-            "source": "https://www.frype.com/applications/dev/docs/logos/"
+            "source": "https://www.frype.com/applications/dev/docs/logos"
         },
         {
             "title": "Dreamstime",
@@ -4093,7 +4093,7 @@
         {
             "title": "Drooble",
             "hex": "19C4BE",
-            "source": "https://blog.drooble.com/press/"
+            "source": "https://blog.drooble.com/press"
         },
         {
             "title": "Dropbox",
@@ -4113,8 +4113,8 @@
         {
             "title": "DTS",
             "hex": "F98B2B",
-            "source": "https://xperi.com/brands/dts/",
-            "guidelines": "https://xperi.com/terms-conditions/"
+            "source": "https://xperi.com/brands/dts",
+            "guidelines": "https://xperi.com/terms-conditions"
         },
         {
             "title": "DTube",
@@ -4171,8 +4171,8 @@
                 ]
             },
             "hex": "13ADC7",
-            "source": "https://iterative.ai/brand/",
-            "guidelines": "https://iterative.ai/brand/"
+            "source": "https://iterative.ai/brand",
+            "guidelines": "https://iterative.ai/brand"
         },
         {
             "title": "dwm",
@@ -4192,7 +4192,7 @@
         {
             "title": "Dynatrace",
             "hex": "1496FF",
-            "source": "https://www.dynatrace.com/company/press-kit/"
+            "source": "https://www.dynatrace.com/company/press-kit"
         },
         {
             "title": "E.Leclerc",
@@ -4242,18 +4242,18 @@
         {
             "title": "Eclipse Adoptium",
             "hex": "FF1464",
-            "source": "https://www.eclipse.org/org/artwork/",
+            "source": "https://www.eclipse.org/org/artwork",
             "guidelines": "https://www.eclipse.org/legal/logo_guidelines.php"
         },
         {
             "title": "Eclipse Che",
             "hex": "525C86",
-            "source": "https://www.eclipse.org/che/"
+            "source": "https://www.eclipse.org/che"
         },
         {
             "title": "Eclipse IDE",
             "hex": "2C2255",
-            "source": "https://www.eclipse.org/artwork/"
+            "source": "https://www.eclipse.org/artwork"
         },
         {
             "title": "Eclipse Jetty",
@@ -4309,7 +4309,7 @@
         {
             "title": "Eight Sleep",
             "hex": "262729",
-            "source": "https://www.eightsleep.com/press/"
+            "source": "https://www.eightsleep.com/press"
         },
         {
             "title": "EJS",
@@ -4374,8 +4374,8 @@
         {
             "title": "Elementor",
             "hex": "92003B",
-            "source": "https://elementor.com/logos/",
-            "guidelines": "https://elementor.com/logos/"
+            "source": "https://elementor.com/logos",
+            "guidelines": "https://elementor.com/logos"
         },
         {
             "title": "Eleventy",
@@ -4420,8 +4420,8 @@
         {
             "title": "Ember.js",
             "hex": "E04E39",
-            "source": "https://emberjs.com/logos/",
-            "guidelines": "https://emberjs.com/logos/"
+            "source": "https://emberjs.com/logos",
+            "guidelines": "https://emberjs.com/logos"
         },
         {
             "title": "Emby",
@@ -4431,12 +4431,12 @@
         {
             "title": "Emirates",
             "hex": "D71921",
-            "source": "https://www.emirates.com/ie/english/"
+            "source": "https://www.emirates.com/ie/english"
         },
         {
             "title": "Emlakjet",
             "hex": "0AE524",
-            "source": "https://www.emlakjet.com/kurumsal-materyaller/"
+            "source": "https://www.emlakjet.com/kurumsal-materyaller"
         },
         {
             "title": "Empire Kred",
@@ -4452,7 +4452,7 @@
         {
             "title": "Enpass",
             "hex": "0D47A1",
-            "source": "https://www.enpass.io/press/"
+            "source": "https://www.enpass.io/press"
         },
         {
             "title": "EnterpriseDB",
@@ -4483,7 +4483,7 @@
         {
             "title": "Epson",
             "hex": "003399",
-            "source": "https://global.epson.com/IR/library/"
+            "source": "https://global.epson.com/IR/library"
         },
         {
             "title": "Equinix Metal",
@@ -4551,12 +4551,12 @@
         {
             "title": "etcd",
             "hex": "419EDA",
-            "source": "https://cncf-branding.netlify.app/projects/etcd/"
+            "source": "https://cncf-branding.netlify.app/projects/etcd"
         },
         {
             "title": "Ethereum",
             "hex": "3C3C3D",
-            "source": "https://ethereum.org/en/assets/"
+            "source": "https://ethereum.org/en/assets"
         },
         {
             "title": "Ethiopian Airlines",
@@ -4581,7 +4581,7 @@
         {
             "title": "Eventbrite",
             "hex": "F05537",
-            "source": "https://www.eventbrite.com/signin/"
+            "source": "https://www.eventbrite.com/signin"
         },
         {
             "title": "Evernote",
@@ -4605,8 +4605,8 @@
         {
             "title": "Exoscale",
             "hex": "DA291C",
-            "source": "https://www.exoscale.com/press/",
-            "guidelines": "https://www.exoscale.com/press/"
+            "source": "https://www.exoscale.com/press",
+            "guidelines": "https://www.exoscale.com/press"
         },
         {
             "title": "Expedia",
@@ -4628,7 +4628,7 @@
         {
             "title": "Expo",
             "hex": "000020",
-            "source": "https://expo.io/brand/"
+            "source": "https://expo.io/brand"
         },
         {
             "title": "Express",
@@ -4690,7 +4690,7 @@
         {
             "title": "Facebook Gaming",
             "hex": "005FED",
-            "source": "https://www.facebook.com/fbgaminghome/"
+            "source": "https://www.facebook.com/fbgaminghome"
         },
         {
             "title": "Facebook Live",
@@ -4700,7 +4700,7 @@
         {
             "title": "FACEIT",
             "hex": "FF5500",
-            "source": "https://corporate.faceit.com/branding/"
+            "source": "https://corporate.faceit.com/branding"
         },
         {
             "title": "Facepunch",
@@ -4777,7 +4777,7 @@
         {
             "title": "Fastly",
             "hex": "FF282D",
-            "source": "https://assets.fastly.com/style-guide/docs/"
+            "source": "https://assets.fastly.com/style-guide/docs"
         },
         {
             "title": "Fathom",
@@ -4807,7 +4807,7 @@
         {
             "title": "Fedora",
             "hex": "51A2DA",
-            "source": "https://docs.fedoraproject.org/en-US/project/brand/",
+            "source": "https://docs.fedoraproject.org/en-US/project/brand",
             "guidelines": "https://fedoraproject.org/wiki/Legal:Trademark_guidelines",
             "license": {
                 "type": "custom",
@@ -4859,8 +4859,8 @@
         {
             "title": "Fido Alliance",
             "hex": "FFBF3B",
-            "source": "https://fidoalliance.org/overview/legal/logo-usage/",
-            "guidelines": "https://fidoalliance.org/overview/legal/fido-trademark-and-service-mark-usage-agreement-for-websites/"
+            "source": "https://fidoalliance.org/overview/legal/logo-usage",
+            "guidelines": "https://fidoalliance.org/overview/legal/fido-trademark-and-service-mark-usage-agreement-for-websites"
         },
         {
             "title": "FIFA",
@@ -4875,8 +4875,8 @@
         {
             "title": "Figma",
             "hex": "F24E1E",
-            "source": "https://www.figma.com/using-the-figma-brand/",
-            "guidelines": "https://www.figma.com/using-the-figma-brand/"
+            "source": "https://www.figma.com/using-the-figma-brand",
+            "guidelines": "https://www.figma.com/using-the-figma-brand"
         },
         {
             "title": "figshare",
@@ -4911,8 +4911,8 @@
         {
             "title": "Firebase",
             "hex": "FFCA28",
-            "source": "https://firebase.google.com/brand-guidelines/",
-            "guidelines": "https://firebase.google.com/brand-guidelines/"
+            "source": "https://firebase.google.com/brand-guidelines",
+            "guidelines": "https://firebase.google.com/brand-guidelines"
         },
         {
             "title": "Firefish",
@@ -4928,13 +4928,13 @@
         {
             "title": "Firefox",
             "hex": "FF7139",
-            "source": "https://mozilla.design/firefox/logos-usage/",
-            "guidelines": "https://mozilla.design/firefox/logos-usage/"
+            "source": "https://mozilla.design/firefox/logos-usage",
+            "guidelines": "https://mozilla.design/firefox/logos-usage"
         },
         {
             "title": "Firefox Browser",
             "hex": "FF7139",
-            "source": "https://mozilla.design/firefox/logos-usage/"
+            "source": "https://mozilla.design/firefox/logos-usage"
         },
         {
             "title": "Fireship",
@@ -5064,7 +5064,7 @@
             "title": "Flux",
             "hex": "5468FF",
             "source": "https://github.com/cncf/artwork/blob/c2e619cdf85e8bac090ceca7c0834c5cfedf9426/projects/flux/icon/black/flux-icon-black.svg",
-            "guidelines": "https://www.cncf.io/brand-guidelines/",
+            "guidelines": "https://www.cncf.io/brand-guidelines",
             "license": {
                 "type": "custom",
                 "url": "https://www.linuxfoundation.org/legal/trademark-usage"
@@ -5094,7 +5094,7 @@
         {
             "title": "Folium",
             "hex": "77B829",
-            "source": "https://python-visualization.github.io/folium/"
+            "source": "https://python-visualization.github.io/folium"
         },
         {
             "title": "Fonoma",
@@ -5124,7 +5124,7 @@
         {
             "title": "Ford",
             "hex": "00274E",
-            "source": "https://secure.ford.com/brochures/"
+            "source": "https://secure.ford.com/brochures"
         },
         {
             "title": "Forgejo",
@@ -5153,7 +5153,7 @@
         {
             "title": "Fossa",
             "hex": "289E6D",
-            "source": "https://fossa.com/press/"
+            "source": "https://fossa.com/press"
         },
         {
             "title": "Fossil SCM",
@@ -5163,8 +5163,8 @@
         {
             "title": "Foursquare",
             "hex": "3333FF",
-            "source": "https://foursquare.com/brand/",
-            "guidelines": "https://foursquare.com/brand/"
+            "source": "https://foursquare.com/brand",
+            "guidelines": "https://foursquare.com/brand"
         },
         {
             "title": "Foursquare City Guide",
@@ -5219,7 +5219,7 @@
         {
             "title": "FreeBSD",
             "hex": "AB2B28",
-            "source": "https://www.freebsdfoundation.org/about/project/"
+            "source": "https://www.freebsdfoundation.org/about/project"
         },
         {
             "title": "freeCodeCamp",
@@ -5270,7 +5270,7 @@
             "title": "Fuga Cloud",
             "hex": "242F4B",
             "source": "https://fuga.cloud",
-            "guidelines": "https://fuga.cloud/media/"
+            "guidelines": "https://fuga.cloud/media"
         },
         {
             "title": "Fujifilm",
@@ -5281,7 +5281,7 @@
         {
             "title": "Fujitsu",
             "hex": "FF0000",
-            "source": "https://www.fujitsu.com/global/about/brandmanagement/logo/"
+            "source": "https://www.fujitsu.com/global/about/brandmanagement/logo"
         },
         {
             "title": "Funimation",
@@ -5313,8 +5313,8 @@
         {
             "title": "G2A",
             "hex": "F05F00",
-            "source": "https://www.g2a.co/documents/",
-            "guidelines": "https://www.g2a.co/documents/"
+            "source": "https://www.g2a.co/documents",
+            "guidelines": "https://www.g2a.co/documents"
         },
         {
             "title": "Galaxus",
@@ -5364,8 +5364,8 @@
         {
             "title": "Garmin",
             "hex": "000000",
-            "source": "https://creative.garmin.com/styleguide/logo/",
-            "guidelines": "https://creative.garmin.com/styleguide/brand/"
+            "source": "https://creative.garmin.com/styleguide/logo",
+            "guidelines": "https://creative.garmin.com/styleguide/brand"
         },
         {
             "title": "Gatling",
@@ -5381,7 +5381,7 @@
         {
             "title": "GDAL",
             "hex": "5CAE58",
-            "source": "https://www.osgeo.org/projects/gdal/"
+            "source": "https://www.osgeo.org/projects/gdal"
         },
         {
             "title": "Géant",
@@ -5396,7 +5396,7 @@
         {
             "title": "General Electric",
             "hex": "0870D8",
-            "source": "https://www.ge.com/brand/"
+            "source": "https://www.ge.com/brand"
         },
         {
             "title": "General Motors",
@@ -5426,7 +5426,7 @@
         {
             "title": "Gerrit",
             "hex": "EEEEEE",
-            "source": "https://gerrit-review.googlesource.com/c/75842/"
+            "source": "https://gerrit-review.googlesource.com/c/75842"
         },
         {
             "title": "GetX",
@@ -5437,13 +5437,13 @@
             "title": "Ghost",
             "hex": "15171A",
             "source": "https://github.com/TryGhost/Admin/blob/e3e1fa3353767c3729b1658ad42cc35f883470c5/public/assets/icons/icon.svg",
-            "guidelines": "https://ghost.org/docs/logos/"
+            "guidelines": "https://ghost.org/docs/logos"
         },
         {
             "title": "Ghostery",
             "hex": "00AEF0",
             "source": "https://www.ghostery.com",
-            "guidelines": "https://www.ghostery.com/press/"
+            "guidelines": "https://www.ghostery.com/press"
         },
         {
             "title": "GIMP",
@@ -5547,8 +5547,8 @@
         {
             "title": "GitLab",
             "hex": "FC6D26",
-            "source": "https://about.gitlab.com/press/press-kit/",
-            "guidelines": "https://about.gitlab.com/handbook/marketing/corporate-marketing/brand-activation/trademark-guidelines/"
+            "source": "https://about.gitlab.com/press/press-kit",
+            "guidelines": "https://about.gitlab.com/handbook/marketing/corporate-marketing/brand-activation/trademark-guidelines"
         },
         {
             "title": "Gitpod",
@@ -5569,7 +5569,7 @@
         {
             "title": "Glitch",
             "hex": "3333FF",
-            "source": "https://glitch.com/about/press/"
+            "source": "https://glitch.com/about/press"
         },
         {
             "title": "Globus",
@@ -5659,8 +5659,8 @@
         {
             "title": "GoDaddy",
             "hex": "1BDBDB",
-            "source": "https://godaddy.design/the-go/",
-            "guidelines": "https://godaddy.design/the-go/"
+            "source": "https://godaddy.design/the-go",
+            "guidelines": "https://godaddy.design/the-go"
         },
         {
             "title": "Godot Engine",
@@ -5679,7 +5679,7 @@
         {
             "title": "GOG.com",
             "hex": "86328A",
-            "source": "https://www.cdprojekt.com/en/media/logotypes/"
+            "source": "https://www.cdprojekt.com/en/media/logotypes"
         },
         {
             "title": "GoLand",
@@ -5712,7 +5712,7 @@
             },
             "hex": "4285F4",
             "source": "https://partnermarketinghub.withgoogle.com",
-            "guidelines": "https://about.google/brand-resource-center/brand-elements/"
+            "guidelines": "https://about.google/brand-resource-center/brand-elements"
         },
         {
             "title": "Google AdMob",
@@ -5722,17 +5722,17 @@
         {
             "title": "Google Ads",
             "hex": "4285F4",
-            "source": "https://ads.google.com/home/"
+            "source": "https://ads.google.com/home"
         },
         {
             "title": "Google AdSense",
             "hex": "4285F4",
-            "source": "https://www.google.com/adsense/"
+            "source": "https://www.google.com/adsense"
         },
         {
             "title": "Google Analytics",
             "hex": "E37400",
-            "source": "https://marketingplatform.google.com/intl/en_uk/about/analytics/"
+            "source": "https://marketingplatform.google.com/intl/en_uk/about/analytics"
         },
         {
             "title": "Google Apps Script",
@@ -5824,7 +5824,7 @@
             "title": "Google Container Optimized OS",
             "hex": "4285F4",
             "source": "https://cloud.google.com/icons",
-            "guidelines": "https://cloud.google.com/terms/"
+            "guidelines": "https://cloud.google.com/terms"
         },
         {
             "title": "Google Data Studio",
@@ -5862,7 +5862,7 @@
         {
             "title": "Google Earth",
             "hex": "4285F4",
-            "source": "https://earth.google.com/web/"
+            "source": "https://earth.google.com/web"
         },
         {
             "title": "Google Earth Engine",
@@ -5872,7 +5872,7 @@
         {
             "title": "Google Fit",
             "hex": "4285F4",
-            "source": "https://partnermarketinghub.withgoogle.com/brands/google-fit/"
+            "source": "https://partnermarketinghub.withgoogle.com/brands/google-fit"
         },
         {
             "title": "Google Fonts",
@@ -5892,12 +5892,12 @@
         {
             "title": "Google Home",
             "hex": "4285F4",
-            "source": "https://home.google.com/welcome/"
+            "source": "https://home.google.com/welcome"
         },
         {
             "title": "Google Keep",
             "hex": "FFBB00",
-            "source": "https://about.google/brand-resource-center/logos-list/"
+            "source": "https://about.google/brand-resource-center/logos-list"
         },
         {
             "title": "Google Lens",
@@ -5912,12 +5912,12 @@
         {
             "title": "Google Marketing Platform",
             "hex": "4285F4",
-            "source": "https://about.google/brand-resource-center/logos-list/"
+            "source": "https://about.google/brand-resource-center/logos-list"
         },
         {
             "title": "Google Meet",
             "hex": "00897B",
-            "source": "https://about.google/brand-resource-center/logos-list/"
+            "source": "https://about.google/brand-resource-center/logos-list"
         },
         {
             "title": "Google Messages",
@@ -5937,30 +5937,30 @@
         {
             "title": "Google News",
             "hex": "174EA6",
-            "source": "https://partnermarketinghub.withgoogle.com/brands/google-news/",
-            "guidelines": "https://partnermarketinghub.withgoogle.com/brands/google-news/legal-and-trademarks/legal-requirements/"
+            "source": "https://partnermarketinghub.withgoogle.com/brands/google-news",
+            "guidelines": "https://partnermarketinghub.withgoogle.com/brands/google-news/legal-and-trademarks/legal-requirements"
         },
         {
             "title": "Google Optimize",
             "hex": "B366F6",
-            "source": "https://marketingplatform.google.com/about/optimize/"
+            "source": "https://marketingplatform.google.com/about/optimize"
         },
         {
             "title": "Google Pay",
             "hex": "4285F4",
-            "source": "https://pay.google.com/intl/en_us/about/"
+            "source": "https://pay.google.com/intl/en_us/about"
         },
         {
             "title": "Google Photos",
             "hex": "4285F4",
-            "source": "https://partnermarketinghub.withgoogle.com/brands/google-photos/visual-identity/visual-identity/icon/",
-            "guidelines": "https://partnermarketinghub.withgoogle.com/brands/google-photos/visual-identity/visual-identity/icon/"
+            "source": "https://partnermarketinghub.withgoogle.com/brands/google-photos/visual-identity/visual-identity/icon",
+            "guidelines": "https://partnermarketinghub.withgoogle.com/brands/google-photos/visual-identity/visual-identity/icon"
         },
         {
             "title": "Google Play",
             "hex": "414141",
-            "source": "https://partnermarketinghub.withgoogle.com/brands/google-play/visual-identity/primary-logos/",
-            "guidelines": "https://partnermarketinghub.withgoogle.com/brands/google-play/visual-identity/primary-logos/"
+            "source": "https://partnermarketinghub.withgoogle.com/brands/google-play/visual-identity/primary-logos",
+            "guidelines": "https://partnermarketinghub.withgoogle.com/brands/google-play/visual-identity/primary-logos"
         },
         {
             "title": "Google Podcasts",
@@ -6094,7 +6094,7 @@
         {
             "title": "Gravatar",
             "hex": "1E8CBE",
-            "source": "https://automattic.com/press/brand-materials/"
+            "source": "https://automattic.com/press/brand-materials"
         },
         {
             "title": "Graylog",
@@ -6133,7 +6133,7 @@
         {
             "title": "Gridsome",
             "hex": "00A672",
-            "source": "https://gridsome.org/logo/"
+            "source": "https://gridsome.org/logo"
         },
         {
             "title": "GroupMe",
@@ -6143,8 +6143,8 @@
         {
             "title": "Groupon",
             "hex": "53A318",
-            "source": "https://about.groupon.com/press/",
-            "guidelines": "https://about.groupon.com/press/"
+            "source": "https://about.groupon.com/press",
+            "guidelines": "https://about.groupon.com/press"
         },
         {
             "title": "Grubhub",
@@ -6271,7 +6271,7 @@
         {
             "title": "HackerEarth",
             "hex": "2C3454",
-            "source": "https://www.hackerearth.com/logo/"
+            "source": "https://www.hackerearth.com/logo"
         },
         {
             "title": "HackerOne",
@@ -6282,7 +6282,7 @@
         {
             "title": "HackerRank",
             "hex": "00EA64",
-            "source": "https://www.hackerrank.com/about-us/"
+            "source": "https://www.hackerrank.com/about-us"
         },
         {
             "title": "Hackster",
@@ -6294,7 +6294,7 @@
             "title": "HAL",
             "hex": "B03532",
             "source": "https://www.ccsd.cnrs.fr/en/brand-guidelines",
-            "guidelines": "https://www.ccsd.cnrs.fr/en/brand-guidelines/"
+            "guidelines": "https://www.ccsd.cnrs.fr/en/brand-guidelines"
         },
         {
             "title": "Handlebars.js",
@@ -6628,7 +6628,7 @@
         {
             "title": "Houdini",
             "hex": "FF4713",
-            "source": "https://www.sidefx.com/products/houdini/"
+            "source": "https://www.sidefx.com/products/houdini"
         },
         {
             "title": "Houzz",
@@ -6656,7 +6656,7 @@
         {
             "title": "HTML5",
             "hex": "E34F26",
-            "source": "https://www.w3.org/html/logo/"
+            "source": "https://www.w3.org/html/logo"
         },
         {
             "title": "htop",
@@ -6713,7 +6713,7 @@
         {
             "title": "Hypothesis",
             "hex": "BD1C2B",
-            "source": "https://web.hypothes.is/brand/"
+            "source": "https://web.hypothes.is/brand"
         },
         {
             "title": "Hyundai",
@@ -6738,13 +6738,13 @@
         {
             "title": "iBeacon",
             "hex": "3D7EBB",
-            "source": "https://developer.apple.com/ibeacon/"
+            "source": "https://developer.apple.com/ibeacon"
         },
         {
             "title": "IBM",
             "hex": "052FAD",
-            "source": "https://www.ibm.com/design/language/ibm-logos/8-bar/",
-            "guidelines": "https://www.ibm.com/design/language/ibm-logos/8-bar/"
+            "source": "https://www.ibm.com/design/language/ibm-logos/8-bar",
+            "guidelines": "https://www.ibm.com/design/language/ibm-logos/8-bar"
         },
         {
             "title": "IBM Cloud",
@@ -6754,7 +6754,7 @@
         {
             "title": "IBM Watson",
             "hex": "BE95FF",
-            "source": "https://www.ibm.com/brand/systems/watson/brand/"
+            "source": "https://www.ibm.com/brand/systems/watson/brand"
         },
         {
             "title": "Iced",
@@ -6819,8 +6819,8 @@
         {
             "title": "IEEE",
             "hex": "00629B",
-            "source": "https://brand-experience.ieee.org/templates-tools-resources/resources/master-brand-and-logos/",
-            "guidelines": "https://brand-experience.ieee.org/guidelines/brand-identity/"
+            "source": "https://brand-experience.ieee.org/templates-tools-resources/resources/master-brand-and-logos",
+            "guidelines": "https://brand-experience.ieee.org/guidelines/brand-identity"
         },
         {
             "title": "iFixit",
@@ -6920,8 +6920,8 @@
         {
             "title": "InfluxDB",
             "hex": "22ADF6",
-            "source": "https://influxdata.github.io/branding/logo/downloads/",
-            "guidelines": "https://influxdata.github.io/branding/logo/usage/"
+            "source": "https://influxdata.github.io/branding/logo/downloads",
+            "guidelines": "https://influxdata.github.io/branding/logo/usage"
         },
         {
             "title": "InfoQ",
@@ -6957,7 +6957,7 @@
         {
             "title": "Inkscape",
             "hex": "000000",
-            "source": "https://inkscape.org/gallery/=inkscape-branding/inkscape-brand-assets/",
+            "source": "https://inkscape.org/gallery/=inkscape-branding/inkscape-brand-assets",
             "license": {
                 "type": "CC-BY-SA-3.0"
             }
@@ -7002,7 +7002,7 @@
         {
             "title": "Instructables",
             "hex": "FABF15",
-            "source": "https://www.instructables.com/community/Official-Instructables-Logos-1/"
+            "source": "https://www.instructables.com/community/Official-Instructables-Logos-1"
         },
         {
             "title": "Instructure",
@@ -7023,8 +7023,8 @@
         {
             "title": "IntelliJ IDEA",
             "hex": "000000",
-            "source": "https://www.jetbrains.com/idea/",
-            "guidelines": "https://www.jetbrains.com/company/brand/"
+            "source": "https://www.jetbrains.com/idea",
+            "guidelines": "https://www.jetbrains.com/company/brand"
         },
         {
             "title": "Interaction Design Foundation",
@@ -7243,7 +7243,7 @@
         {
             "title": "JCB",
             "hex": "0B4EA2",
-            "source": "https://www.global.jcb/en/about-us/brand-concept/"
+            "source": "https://www.global.jcb/en/about-us/brand-concept"
         },
         {
             "title": "Jeep",
@@ -7268,8 +7268,8 @@
         {
             "title": "Jenkins",
             "hex": "D24939",
-            "source": "https://get.jenkins.io/art/",
-            "guidelines": "https://www.jenkins.io/press/",
+            "source": "https://get.jenkins.io/art",
+            "guidelines": "https://www.jenkins.io/press",
             "license": {
                 "type": "CC-BY-SA-3.0"
             }
@@ -7292,13 +7292,13 @@
         {
             "title": "JetBrains",
             "hex": "000000",
-            "source": "https://www.jetbrains.com/company/brand/logos/",
-            "guidelines": "https://www.jetbrains.com/company/brand/"
+            "source": "https://www.jetbrains.com/company/brand/logos",
+            "guidelines": "https://www.jetbrains.com/company/brand"
         },
         {
             "title": "Jetpack Compose",
             "hex": "4285F4",
-            "source": "https://developer.android.com/jetpack/compose/"
+            "source": "https://developer.android.com/jetpack/compose"
         },
         {
             "title": "JFrog",
@@ -7309,8 +7309,8 @@
         {
             "title": "JFrog Pipelines",
             "hex": "40BE46",
-            "source": "https://jfrog.com/pipelines/",
-            "guidelines": "https://jfrog.com/brand-guidelines/"
+            "source": "https://jfrog.com/pipelines",
+            "guidelines": "https://jfrog.com/brand-guidelines"
         },
         {
             "title": "Jinja",
@@ -7321,13 +7321,13 @@
             "title": "Jira",
             "hex": "0052CC",
             "source": "https://atlassian.design/resources/logo-library",
-            "guidelines": "https://atlassian.design/foundations/logos/"
+            "guidelines": "https://atlassian.design/foundations/logos"
         },
         {
             "title": "Jira Software",
             "hex": "0052CC",
             "source": "https://www.atlassian.com/company/news/press-kit",
-            "guidelines": "https://atlassian.design/foundations/logos/"
+            "guidelines": "https://atlassian.design/foundations/logos"
         },
         {
             "title": "JitPack",
@@ -7377,8 +7377,8 @@
         {
             "title": "jQuery",
             "hex": "0769AD",
-            "source": "https://brand.jquery.org/logos/",
-            "guidelines": "https://brand.jquery.org/logos/"
+            "source": "https://brand.jquery.org/logos",
+            "guidelines": "https://brand.jquery.org/logos"
         },
         {
             "title": "JR Group",
@@ -7433,8 +7433,8 @@
         {
             "title": "Juniper Networks",
             "hex": "84B135",
-            "source": "https://www.juniper.net/us/en/company/press-center/images/image-library/logos/",
-            "guidelines": "https://www.juniper.net/us/en/company/press-center/images/image-library/logos/"
+            "source": "https://www.juniper.net/us/en/company/press-center/images/image-library/logos",
+            "guidelines": "https://www.juniper.net/us/en/company/press-center/images/image-library/logos"
         },
         {
             "title": "JUnit5",
@@ -7450,7 +7450,7 @@
         {
             "title": "Just Eat",
             "hex": "F36D00",
-            "source": "https://www.justeattakeaway.com/media/media-kit/"
+            "source": "https://www.justeattakeaway.com/media/media-kit"
         },
         {
             "title": "JustGiving",
@@ -7481,8 +7481,8 @@
         {
             "title": "Kahoot!",
             "hex": "46178F",
-            "source": "https://kahoot.com/library/kahoot-logo/",
-            "guidelines": "https://kahoot.com/library/kahoot-logo/"
+            "source": "https://kahoot.com/library/kahoot-logo",
+            "guidelines": "https://kahoot.com/library/kahoot-logo"
         },
         {
             "title": "KaiOS",
@@ -7512,8 +7512,8 @@
         {
             "title": "Kali Linux",
             "hex": "557C94",
-            "source": "https://www.kali.org/docs/policy/trademark/",
-            "guidelines": "https://www.kali.org/docs/policy/trademark/"
+            "source": "https://www.kali.org/docs/policy/trademark",
+            "guidelines": "https://www.kali.org/docs/policy/trademark"
         },
         {
             "title": "Kamailio",
@@ -7533,7 +7533,7 @@
         {
             "title": "Kasa Smart",
             "hex": "4ACBD6",
-            "source": "https://www.tp-link.com/us/support/download/hs200/"
+            "source": "https://www.tp-link.com/us/support/download/hs200"
         },
         {
             "title": "KashFlow",
@@ -7563,13 +7563,13 @@
         {
             "title": "KDE",
             "hex": "1D99F3",
-            "source": "https://kde.org/stuff/clipart/"
+            "source": "https://kde.org/stuff/clipart"
         },
         {
             "title": "Kdenlive",
             "hex": "527EB2",
-            "source": "https://kdenlive.org/en/trademark-logo/",
-            "guidelines": "https://kdenlive.org/en/trademark-logo/"
+            "source": "https://kdenlive.org/en/trademark-logo",
+            "guidelines": "https://kdenlive.org/en/trademark-logo"
         },
         {
             "title": "Kedro",
@@ -7619,7 +7619,7 @@
         {
             "title": "KFC",
             "hex": "F40027",
-            "source": "https://global.kfc.com/asset-library/",
+            "source": "https://global.kfc.com/asset-library",
             "aliases": {
                 "aka": [
                     "Kentucky Fried Chicken"
@@ -7635,8 +7635,8 @@
         {
             "title": "Khronos Group",
             "hex": "CC3333",
-            "source": "https://www.khronos.org/legal/trademarks/",
-            "guidelines": "https://www.khronos.org/legal/trademarks/"
+            "source": "https://www.khronos.org/legal/trademarks",
+            "guidelines": "https://www.khronos.org/legal/trademarks"
         },
         {
             "title": "Kia",
@@ -7651,7 +7651,7 @@
         {
             "title": "KiCad",
             "hex": "314CB0",
-            "source": "https://www.kicad.org/about/kicad/",
+            "source": "https://www.kicad.org/about/kicad",
             "license": {
                 "type": "GPL-3.0-or-later"
             }
@@ -7669,7 +7669,7 @@
         {
             "title": "Kik",
             "hex": "82BC23",
-            "source": "https://www.kik.com/news/"
+            "source": "https://www.kik.com/news"
         },
         {
             "title": "Kingston Technology",
@@ -7725,7 +7725,7 @@
         {
             "title": "Klook",
             "hex": "FF5722",
-            "source": "https://www.klook.com/en-GB/newsroom/"
+            "source": "https://www.klook.com/en-GB/newsroom"
         },
         {
             "title": "Knative",
@@ -7784,8 +7784,8 @@
         {
             "title": "Komoot",
             "hex": "6AA127",
-            "source": "https://newsroom.komoot.com/media_kits/219423/",
-            "guidelines": "https://newsroom.komoot.com/media_kits/219423/"
+            "source": "https://newsroom.komoot.com/media_kits/219423",
+            "guidelines": "https://newsroom.komoot.com/media_kits/219423"
         },
         {
             "title": "Konami",
@@ -7795,8 +7795,8 @@
         {
             "title": "Kong",
             "hex": "003459",
-            "source": "https://konghq.com/brand-assets/",
-            "guidelines": "https://konghq.com/brand/"
+            "source": "https://konghq.com/brand-assets",
+            "guidelines": "https://konghq.com/brand"
         },
         {
             "title": "Kongregate",
@@ -7816,8 +7816,8 @@
                 }
             },
             "hex": "7F52FF",
-            "source": "https://www.jetbrains.com/company/brand/logos/",
-            "guidelines": "https://www.jetbrains.com/company/brand/"
+            "source": "https://www.jetbrains.com/company/brand/logos",
+            "guidelines": "https://www.jetbrains.com/company/brand"
         },
         {
             "title": "Koyeb",
@@ -7827,7 +7827,7 @@
         {
             "title": "Krita",
             "hex": "3BABFF",
-            "source": "https://krita.org/en/about/press/"
+            "source": "https://krita.org/en/about/press"
         },
         {
             "title": "KTM",
@@ -7853,7 +7853,7 @@
         {
             "title": "Kuma",
             "hex": "290B53",
-            "source": "https://cncf-branding.netlify.app/projects/kuma/"
+            "source": "https://cncf-branding.netlify.app/projects/kuma"
         },
         {
             "title": "Kuula",
@@ -7935,8 +7935,8 @@
         {
             "title": "LastPass",
             "hex": "D32D27",
-            "source": "https://lastpass.com/press-room/",
-            "guidelines": "https://lastpass.com/press-room/"
+            "source": "https://lastpass.com/press-room",
+            "guidelines": "https://lastpass.com/press-room"
         },
         {
             "title": "LaTeX",
@@ -7955,7 +7955,7 @@
         {
             "title": "Lazarus",
             "hex": "000000",
-            "source": "https://sourceforge.net/projects/lazarus/"
+            "source": "https://sourceforge.net/projects/lazarus"
         },
         {
             "title": "LBRY",
@@ -8012,7 +8012,7 @@
         {
             "title": "Lenovo",
             "hex": "E2231A",
-            "source": "https://news.lenovo.com/press-kits/"
+            "source": "https://news.lenovo.com/press-kits"
         },
         {
             "title": "Lens",
@@ -8047,8 +8047,8 @@
         {
             "title": "Let's Encrypt",
             "hex": "003A70",
-            "source": "https://letsencrypt.org/trademarks/",
-            "guidelines": "https://letsencrypt.org/trademarks/",
+            "source": "https://letsencrypt.org/trademarks",
+            "guidelines": "https://letsencrypt.org/trademarks",
             "license": {
                 "type": "CC-BY-NC-4.0"
             }
@@ -8056,13 +8056,13 @@
         {
             "title": "Letterboxd",
             "hex": "202830",
-            "source": "https://letterboxd.com/about/brand/",
-            "guidelines": "https://letterboxd.com/about/brand/"
+            "source": "https://letterboxd.com/about/brand",
+            "guidelines": "https://letterboxd.com/about/brand"
         },
         {
             "title": "levels.fyi",
             "hex": "788B95",
-            "source": "https://www.levels.fyi/press/"
+            "source": "https://www.levels.fyi/press"
         },
         {
             "title": "LG",
@@ -8222,7 +8222,7 @@
         {
             "title": "Linkerd",
             "hex": "2BEDA7",
-            "source": "https://cncf-branding.netlify.app/projects/linkerd/"
+            "source": "https://cncf-branding.netlify.app/projects/linkerd"
         },
         {
             "title": "Linkfire",
@@ -8242,7 +8242,7 @@
         {
             "title": "Linux",
             "hex": "FCC624",
-            "source": "https://www.linuxfoundation.org/the-linux-mark/"
+            "source": "https://www.linuxfoundation.org/the-linux-mark"
         },
         {
             "title": "Linux Containers",
@@ -8252,8 +8252,8 @@
         {
             "title": "Linux Foundation",
             "hex": "003366",
-            "source": "https://www.linuxfoundation.org/en/about/brand/",
-            "guidelines": "https://www.linuxfoundation.org/en/about/brand/"
+            "source": "https://www.linuxfoundation.org/en/about/brand",
+            "guidelines": "https://www.linuxfoundation.org/en/about/brand"
         },
         {
             "title": "Linux Mint",
@@ -8274,7 +8274,7 @@
         {
             "title": "Lion Air",
             "hex": "ED3237",
-            "source": "https://lionairthai.com/en/"
+            "source": "https://lionairthai.com/en"
         },
         {
             "title": "Liquibase",
@@ -8290,8 +8290,8 @@
         {
             "title": "Litecoin",
             "hex": "A6A9AA",
-            "source": "https://litecoin-foundation.org/litecoin-branding-guidelines/",
-            "guidelines": "https://litecoin-foundation.org/litecoin-branding-guidelines/"
+            "source": "https://litecoin-foundation.org/litecoin-branding-guidelines",
+            "guidelines": "https://litecoin-foundation.org/litecoin-branding-guidelines"
         },
         {
             "title": "LITIENGINE",
@@ -8406,8 +8406,8 @@
         {
             "title": "Lua",
             "hex": "2C2D72",
-            "source": "https://www.lua.org/images/",
-            "guidelines": "https://www.lua.org/images/"
+            "source": "https://www.lua.org/images",
+            "guidelines": "https://www.lua.org/images"
         },
         {
             "title": "Lubuntu",
@@ -8453,7 +8453,7 @@
         {
             "title": "MAAS",
             "hex": "E95420",
-            "source": "https://design.ubuntu.com/downloads/",
+            "source": "https://design.ubuntu.com/downloads",
             "license": {
                 "type": "CC-BY-SA-3.0"
             }
@@ -8498,7 +8498,7 @@
             "title": "mail.com",
             "hex": "004788",
             "source": "https://www.mail.com",
-            "guidelines": "https://www.mail.com/company/terms/"
+            "guidelines": "https://www.mail.com/company/terms"
         },
         {
             "title": "Mail.Ru",
@@ -8546,7 +8546,7 @@
         {
             "title": "MAMP",
             "hex": "02749C",
-            "source": "https://www.mamp.info/en/mamp/mac/"
+            "source": "https://www.mamp.info/en/mamp/mac"
         },
         {
             "title": "MAN",
@@ -8556,7 +8556,7 @@
         {
             "title": "ManageIQ",
             "hex": "EF2929",
-            "source": "https://www.manageiq.org/logo/"
+            "source": "https://www.manageiq.org/logo"
         },
         {
             "title": "Manjaro",
@@ -8585,8 +8585,8 @@
         {
             "title": "MariaDB",
             "hex": "003545",
-            "source": "https://mariadb.com/about-us/logos/",
-            "guidelines": "https://mariadb.com/about-us/logos/"
+            "source": "https://mariadb.com/about-us/logos",
+            "guidelines": "https://mariadb.com/about-us/logos"
         },
         {
             "title": "MariaDB Foundation",
@@ -8646,7 +8646,7 @@
         {
             "title": "Material Design",
             "hex": "757575",
-            "source": "https://material.io/design/"
+            "source": "https://material.io/design"
         },
         {
             "title": "Material Design Icons",
@@ -8669,7 +8669,7 @@
         {
             "title": "Matomo",
             "hex": "3152A0",
-            "source": "https://matomo.org/media/"
+            "source": "https://matomo.org/media"
         },
         {
             "title": "Matrix",
@@ -8684,8 +8684,8 @@
         {
             "title": "Mattermost",
             "hex": "0058CC",
-            "source": "https://www.mattermost.org/brand-guidelines/",
-            "guidelines": "https://www.mattermost.org/brand-guidelines/"
+            "source": "https://www.mattermost.org/brand-guidelines",
+            "guidelines": "https://www.mattermost.org/brand-guidelines"
         },
         {
             "title": "Matternet",
@@ -8715,7 +8715,7 @@
         {
             "title": "Mazda",
             "hex": "101010",
-            "source": "https://www.mazda.com/en/about/profile/library/"
+            "source": "https://www.mazda.com/en/about/profile/library"
         },
         {
             "title": "McAfee",
@@ -8750,8 +8750,8 @@
         {
             "title": "MediaFire",
             "hex": "1299F3",
-            "source": "https://www.mediafire.com/developers/brand_assets/mediafire_brand_assets/",
-            "guidelines": "https://www.mediafire.com/developers/brand_assets/mediafire_brand_assets/"
+            "source": "https://www.mediafire.com/developers/brand_assets/mediafire_brand_assets",
+            "guidelines": "https://www.mediafire.com/developers/brand_assets/mediafire_brand_assets"
         },
         {
             "title": "MediaMarkt",
@@ -8782,7 +8782,7 @@
         {
             "title": "Meetup",
             "hex": "ED1C40",
-            "source": "https://www.meetup.com/media/"
+            "source": "https://www.meetup.com/media"
         },
         {
             "title": "MEGA",
@@ -8832,8 +8832,8 @@
         {
             "title": "Mercurial",
             "hex": "999999",
-            "source": "https://www.mercurial-scm.org/hg-logo/",
-            "guidelines": "https://www.mercurial-scm.org/hg-logo/",
+            "source": "https://www.mercurial-scm.org/hg-logo",
+            "guidelines": "https://www.mercurial-scm.org/hg-logo",
             "license": {
                 "type": "GPL-2.0-or-later"
             }
@@ -8846,8 +8846,8 @@
         {
             "title": "Messenger",
             "hex": "00B2FF",
-            "source": "https://en.facebookbrand.com/facebookapp/assets/messenger/",
-            "guidelines": "https://en.facebookbrand.com/facebookapp/assets/messenger/"
+            "source": "https://en.facebookbrand.com/facebookapp/assets/messenger",
+            "guidelines": "https://en.facebookbrand.com/facebookapp/assets/messenger"
         },
         {
             "title": "Meta",
@@ -8884,7 +8884,7 @@
         {
             "title": "Metro",
             "hex": "EF4242",
-            "source": "https://facebook.github.io/metro/"
+            "source": "https://facebook.github.io/metro"
         },
         {
             "title": "Metro de la Ciudad de México",
@@ -8973,7 +8973,7 @@
         {
             "title": "Microsoft Bing",
             "hex": "258FFA",
-            "source": "https://www.bing.com/covid/",
+            "source": "https://www.bing.com/covid",
             "guidelines": "https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks"
         },
         {
@@ -9324,12 +9324,12 @@
         {
             "title": "Monster",
             "hex": "6D4C9F",
-            "source": "https://www.monster.com/press/"
+            "source": "https://www.monster.com/press"
         },
         {
             "title": "Monzo",
             "hex": "14233C",
-            "source": "https://monzo.com/press/"
+            "source": "https://monzo.com/press"
         },
         {
             "title": "Moo",
@@ -9370,8 +9370,8 @@
         {
             "title": "Mozilla",
             "hex": "000000",
-            "source": "https://mozilla.design/mozilla/",
-            "guidelines": "https://mozilla.design/mozilla/"
+            "source": "https://mozilla.design/mozilla",
+            "guidelines": "https://mozilla.design/mozilla"
         },
         {
             "title": "mpv",
@@ -9475,7 +9475,7 @@
         {
             "title": "MX Linux",
             "hex": "000000",
-            "source": "https://mxlinux.org/art/",
+            "source": "https://mxlinux.org/art",
             "license": {
                 "type": "GPL-3.0-only"
             }
@@ -9613,7 +9613,7 @@
             "title": "NetApp",
             "hex": "0067C5",
             "source": "https://www.netapp.com",
-            "guidelines": "https://www.netapp.com/company/legal/trademark-guidelines/"
+            "guidelines": "https://www.netapp.com/company/legal/trademark-guidelines"
         },
         {
             "title": "NetBSD",
@@ -9652,8 +9652,8 @@
         {
             "title": "Netlify",
             "hex": "00C7B7",
-            "source": "https://www.netlify.com/press/",
-            "guidelines": "https://www.netlify.com/press/",
+            "source": "https://www.netlify.com/press",
+            "guidelines": "https://www.netlify.com/press",
             "aliases": {
                 "dup": [
                     {
@@ -9734,8 +9734,8 @@
         {
             "title": "Nextcloud",
             "hex": "0082C9",
-            "source": "https://nextcloud.com/press/",
-            "guidelines": "https://nextcloud.com/trademarks/"
+            "source": "https://nextcloud.com/press",
+            "guidelines": "https://nextcloud.com/trademarks"
         },
         {
             "title": "NextDNS",
@@ -9745,7 +9745,7 @@
         {
             "title": "Nextdoor",
             "hex": "8ED500",
-            "source": "https://about.nextdoor.com/us-media/"
+            "source": "https://about.nextdoor.com/us-media"
         },
         {
             "title": "Nextra",
@@ -9762,14 +9762,14 @@
         {
             "title": "NFC",
             "hex": "002E5F",
-            "source": "https://nfc-forum.org/our-work/nfc-branding/n-mark/guidelines-and-brand-assets/",
-            "guidelines": "https://nfc-forum.org/our-work/nfc-branding/n-mark/guidelines-and-brand-assets/"
+            "source": "https://nfc-forum.org/our-work/nfc-branding/n-mark/guidelines-and-brand-assets",
+            "guidelines": "https://nfc-forum.org/our-work/nfc-branding/n-mark/guidelines-and-brand-assets"
         },
         {
             "title": "NGINX",
             "hex": "009639",
-            "source": "https://www.nginx.com/press/",
-            "guidelines": "https://www.nginx.com/press/"
+            "source": "https://www.nginx.com/press",
+            "guidelines": "https://www.nginx.com/press"
         },
         {
             "title": "Nginx Proxy Manager",
@@ -9848,7 +9848,7 @@
         {
             "title": "Nintendo Switch",
             "hex": "E60012",
-            "source": "https://www.nintendo.com/switch/"
+            "source": "https://www.nintendo.com/switch"
         },
         {
             "title": "Nissan",
@@ -9863,13 +9863,13 @@
         {
             "title": "Node-RED",
             "hex": "8F0000",
-            "source": "https://nodered.org/about/resources/"
+            "source": "https://nodered.org/about/resources"
         },
         {
             "title": "Node.js",
             "hex": "339933",
-            "source": "https://nodejs.org/en/about/resources/",
-            "guidelines": "https://nodejs.org/en/about/resources/"
+            "source": "https://nodejs.org/en/about/resources",
+            "guidelines": "https://nodejs.org/en/about/resources"
         },
         {
             "title": "Nodemon",
@@ -9900,8 +9900,8 @@
         {
             "title": "NordVPN",
             "hex": "4687FF",
-            "source": "https://nordvpn.com/press-area/",
-            "guidelines": "https://nordvpn.com/press-area/"
+            "source": "https://nordvpn.com/press-area",
+            "guidelines": "https://nordvpn.com/press-area"
         },
         {
             "title": "Normalize.css",
@@ -9916,7 +9916,7 @@
         {
             "title": "Norwegian",
             "hex": "D81939",
-            "source": "https://www.norwegian.com/ie/travel-info/on-board/in-flight-entertainment/magazine/"
+            "source": "https://www.norwegian.com/ie/travel-info/on-board/in-flight-entertainment/magazine"
         },
         {
             "title": "Notepad++",
@@ -9972,7 +9972,7 @@
         {
             "title": "Nubank",
             "hex": "820AD1",
-            "source": "https://nubank.com.br/en/press/"
+            "source": "https://nubank.com.br/en/press"
         },
         {
             "title": "Nucleo",
@@ -9997,7 +9997,7 @@
         {
             "title": "NumPy",
             "hex": "013243",
-            "source": "https://numpy.org/press-kit/",
+            "source": "https://numpy.org/press-kit",
             "guidelines": "https://github.com/numpy/numpy/blob/main/branding/logo/logoguidelines.md"
         },
         {
@@ -10041,8 +10041,8 @@
         {
             "title": "O'Reilly",
             "hex": "D3002D",
-            "source": "https://www.oreilly.com/about/logos/",
-            "guidelines": "https://www.oreilly.com/about/logos/"
+            "source": "https://www.oreilly.com/about/logos",
+            "guidelines": "https://www.oreilly.com/about/logos"
         },
         {
             "title": "OBS Studio",
@@ -10086,7 +10086,7 @@
         {
             "title": "Octave",
             "hex": "0790C0",
-            "source": "https://www.gnu.org/software/octave/"
+            "source": "https://www.gnu.org/software/octave"
         },
         {
             "title": "October CMS",
@@ -10108,7 +10108,7 @@
             "title": "Oculus",
             "hex": "1C1E20",
             "source": "https://en.facebookbrand.com/oculus/assets/oculus?audience=oculus-landing",
-            "guidelines": "https://en.facebookbrand.com/oculus/"
+            "guidelines": "https://en.facebookbrand.com/oculus"
         },
         {
             "title": "Odnoklassniki",
@@ -10139,8 +10139,8 @@
         {
             "title": "Okta",
             "hex": "007DC1",
-            "source": "https://www.okta.com/press-room/media-assets/",
-            "guidelines": "https://www.okta.com/terms-of-use-for-okta-content/"
+            "source": "https://www.okta.com/press-room/media-assets",
+            "guidelines": "https://www.okta.com/terms-of-use-for-okta-content"
         },
         {
             "title": "OnePlus",
@@ -10242,8 +10242,8 @@
         {
             "title": "OpenCV",
             "hex": "5C3EE8",
-            "source": "https://opencv.org/resources/media-kit/",
-            "guidelines": "https://opencv.org/resources/media-kit/"
+            "source": "https://opencv.org/resources/media-kit",
+            "guidelines": "https://opencv.org/resources/media-kit"
         },
         {
             "title": "OpenFaaS",
@@ -10253,7 +10253,7 @@
         {
             "title": "OpenGL",
             "hex": "5586A4",
-            "source": "https://www.khronos.org/legal/trademarks/"
+            "source": "https://www.khronos.org/legal/trademarks"
         },
         {
             "title": "openHAB",
@@ -10264,7 +10264,7 @@
         {
             "title": "OpenID",
             "hex": "F78C40",
-            "source": "https://openid.net/add-openid/logos/"
+            "source": "https://openid.net/add-openid/logos"
         },
         {
             "title": "OpenJDK",
@@ -10285,12 +10285,12 @@
         {
             "title": "OpenNebula",
             "hex": "0097C2",
-            "source": "https://opennebula.io/docs/"
+            "source": "https://opennebula.io/docs"
         },
         {
             "title": "OpenProject",
             "hex": "0770B8",
-            "source": "https://www.openproject.org/press/"
+            "source": "https://www.openproject.org/press"
         },
         {
             "title": "OpenSCAD",
@@ -10316,8 +10316,8 @@
         {
             "title": "OpenStack",
             "hex": "ED1944",
-            "source": "https://www.openstack.org/brand/openstack-logo/",
-            "guidelines": "https://www.openstack.org/brand/openstack-logo/"
+            "source": "https://www.openstack.org/brand/openstack-logo",
+            "guidelines": "https://www.openstack.org/brand/openstack-logo"
         },
         {
             "title": "OpenStreetMap",
@@ -10334,8 +10334,8 @@
         {
             "title": "OpenTelemetry",
             "hex": "000000",
-            "source": "https://cncf-branding.netlify.app/projects/opentelemetry/",
-            "guidelines": "https://cncf-branding.netlify.app/projects/opentelemetry/",
+            "source": "https://cncf-branding.netlify.app/projects/opentelemetry",
+            "guidelines": "https://cncf-branding.netlify.app/projects/opentelemetry",
             "license": {
                 "type": "CC-BY-4.0"
             },
@@ -10397,26 +10397,26 @@
         {
             "title": "Opera",
             "hex": "FF1B2D",
-            "source": "https://brand.opera.com/1472-2/opera-logos/",
+            "source": "https://brand.opera.com/1472-2/opera-logos",
             "guidelines": "https://brand.opera.com"
         },
         {
             "title": "Opera GX",
             "hex": "EE2950",
-            "source": "https://brand.opera.com/1472-2/opera-logos/",
+            "source": "https://brand.opera.com/1472-2/opera-logos",
             "guidelines": "https://brand.opera.com"
         },
         {
             "title": "OPNSense",
             "hex": "D94F00",
-            "source": "https://opnsense.org/about/legal-notices/",
-            "guidelines": "https://opnsense.org/about/legal-notices/"
+            "source": "https://opnsense.org/about/legal-notices",
+            "guidelines": "https://opnsense.org/about/legal-notices"
         },
         {
             "title": "OPPO",
             "hex": "2D683D",
             "source": "https://www.figma.com/community/file/832815970641696814/OPPO-Media-Kit",
-            "guidelines": "https://www.oppo.com/en/terms/"
+            "guidelines": "https://www.oppo.com/en/terms"
         },
         {
             "title": "Opsgenie",
@@ -10444,7 +10444,7 @@
             "title": "ORCID",
             "hex": "A6CE39",
             "source": "https://orcid.figshare.com/articles/figure/ORCID_iD_icon_graphics/5008697",
-            "guidelines": "https://info.orcid.org/brand-guidelines/"
+            "guidelines": "https://info.orcid.org/brand-guidelines"
         },
         {
             "title": "Org",
@@ -10485,7 +10485,7 @@
         {
             "title": "Oshkosh",
             "hex": "E6830F",
-            "source": "https://oshkoshdefense.com/media/photos/",
+            "source": "https://oshkoshdefense.com/media/photos",
             "license": {
                 "type": "CC-BY-SA-4.0"
             }
@@ -10519,7 +10519,7 @@
         {
             "title": "OVH",
             "hex": "123F6D",
-            "source": "https://www.ovh.com/ca/en/newsroom/"
+            "source": "https://www.ovh.com/ca/en/newsroom"
         },
         {
             "title": "OWASP",
@@ -10544,7 +10544,7 @@
             "title": "Oxygen",
             "hex": "3A209E",
             "source": "https://oxygenbuilder.com",
-            "guidelines": "https://oxygenbuilder.com/trademark-policy/"
+            "guidelines": "https://oxygenbuilder.com/trademark-policy"
         },
         {
             "title": "OYO",
@@ -10599,13 +10599,13 @@
         {
             "title": "PagerDuty",
             "hex": "06AC38",
-            "source": "https://www.pagerduty.com/brand/",
-            "guidelines": "https://www.pagerduty.com/brand/"
+            "source": "https://www.pagerduty.com/brand",
+            "guidelines": "https://www.pagerduty.com/brand"
         },
         {
             "title": "PageSpeed Insights",
             "hex": "4285F4",
-            "source": "https://developers.google.com/web/fundamentals/performance/speed-tools/"
+            "source": "https://developers.google.com/web/fundamentals/performance/speed-tools"
         },
         {
             "title": "PagSeguro",
@@ -10844,7 +10844,7 @@
             "title": "Phabricator",
             "hex": "4A5F88",
             "source": "https://github.com/phacility/phabricator/blob/0a3093ef9c1898913196564435346e4daa9d2538/webroot/rsrc/image/logo/light-eye.png",
-            "guidelines": "https://phacility.com/trademarks/"
+            "guidelines": "https://phacility.com/trademarks"
         },
         {
             "title": "Philips Hue",
@@ -10859,7 +10859,7 @@
         {
             "title": "PhonePe",
             "hex": "5F259F",
-            "source": "https://www.phonepe.com/press/"
+            "source": "https://www.phonepe.com/press"
         },
         {
             "title": "Phosphor Icons",
@@ -10900,8 +10900,8 @@
         {
             "title": "PhpStorm",
             "hex": "000000",
-            "source": "https://www.jetbrains.com/company/brand/logos/",
-            "guidelines": "https://www.jetbrains.com/company/brand/"
+            "source": "https://www.jetbrains.com/company/brand/logos",
+            "guidelines": "https://www.jetbrains.com/company/brand"
         },
         {
             "title": "Pi Network",
@@ -10912,7 +10912,7 @@
             "title": "Pi-hole",
             "hex": "96060C",
             "source": "https://docs.pi-hole.net",
-            "guidelines": "https://pi-hole.net/trademark-rules-and-brand-guidelines/"
+            "guidelines": "https://pi-hole.net/trademark-rules-and-brand-guidelines"
         },
         {
             "title": "Piaggio Group",
@@ -10938,7 +10938,7 @@
         {
             "title": "Picnic",
             "hex": "E1171E",
-            "source": "https://picnic.app/nl/feestdagen/"
+            "source": "https://picnic.app/nl/feestdagen"
         },
         {
             "title": "PicPay",
@@ -10969,8 +10969,8 @@
         {
             "title": "Pingdom",
             "hex": "FFF000",
-            "source": "https://www.pingdom.com/resources/brand-assets/",
-            "guidelines": "https://www.pingdom.com/resources/brand-assets/"
+            "source": "https://www.pingdom.com/resources/brand-assets",
+            "guidelines": "https://www.pingdom.com/resources/brand-assets"
         },
         {
             "title": "Pinterest",
@@ -11013,7 +11013,7 @@
         {
             "title": "Pixabay",
             "hex": "2EC66D",
-            "source": "https://pixabay.com/service/about/"
+            "source": "https://pixabay.com/service/about"
         },
         {
             "title": "pixiv",
@@ -11029,7 +11029,7 @@
         {
             "title": "Planet",
             "hex": "009DB1",
-            "source": "https://www.planet.com/explorer/"
+            "source": "https://www.planet.com/explorer"
         },
         {
             "title": "PlanetScale",
@@ -11044,7 +11044,7 @@
         {
             "title": "Platform.sh",
             "hex": "1A182A",
-            "source": "https://platform.sh/logos/"
+            "source": "https://platform.sh/logos"
         },
         {
             "title": "PlatformIO",
@@ -11080,7 +11080,7 @@
         {
             "title": "PlayStation",
             "hex": "003791",
-            "source": "https://www.playstation.com/en-us/"
+            "source": "https://www.playstation.com/en-us"
         },
         {
             "title": "PlayStation 2",
@@ -11100,7 +11100,7 @@
         {
             "title": "PlayStation 5",
             "hex": "003791",
-            "source": "https://www.playstation.com/en-us/ps5/"
+            "source": "https://www.playstation.com/en-us/ps5"
         },
         {
             "title": "PlayStation Vita",
@@ -11124,8 +11124,8 @@
         {
             "title": "Plesk",
             "hex": "52BBE6",
-            "source": "https://www.plesk.com/brand/",
-            "guidelines": "https://www.plesk.com/brand/"
+            "source": "https://www.plesk.com/brand",
+            "guidelines": "https://www.plesk.com/brand"
         },
         {
             "title": "Plex",
@@ -11152,7 +11152,7 @@
         {
             "title": "Plus Codes",
             "hex": "4285F4",
-            "source": "https://maps.google.com/pluscodes/"
+            "source": "https://maps.google.com/pluscodes"
         },
         {
             "title": "PM2",
@@ -11167,12 +11167,12 @@
         {
             "title": "Pocket",
             "hex": "EF3F56",
-            "source": "https://blog.getpocket.com/press/"
+            "source": "https://blog.getpocket.com/press"
         },
         {
             "title": "Pocket Casts",
             "hex": "F43E37",
-            "source": "https://blog.pocketcasts.com/press/"
+            "source": "https://blog.pocketcasts.com/press"
         },
         {
             "title": "PocketBase",
@@ -11227,8 +11227,8 @@
         {
             "title": "Polkadot",
             "hex": "E6007A",
-            "source": "https://polkadot.network/brand-assets/",
-            "guidelines": "https://polkadot.network/brand-assets/"
+            "source": "https://polkadot.network/brand-assets",
+            "guidelines": "https://polkadot.network/brand-assets"
         },
         {
             "title": "Poly",
@@ -11290,7 +11290,7 @@
             "title": "PostgreSQL",
             "hex": "4169E1",
             "source": "https://wiki.postgresql.org/wiki/Logo",
-            "guidelines": "https://www.postgresql.org/about/policies/trademarks/"
+            "guidelines": "https://www.postgresql.org/about/policies/trademarks"
         },
         {
             "title": "PostHog",
@@ -11301,7 +11301,7 @@
         {
             "title": "Postman",
             "hex": "FF6C37",
-            "source": "https://www.getpostman.com/resources/media-assets/"
+            "source": "https://www.getpostman.com/resources/media-assets"
         },
         {
             "title": "Postmates",
@@ -11446,7 +11446,7 @@
         {
             "title": "Prezi",
             "hex": "3181FF",
-            "source": "https://prezi.com/press/kit/"
+            "source": "https://prezi.com/press/kit"
         },
         {
             "title": "Prime",
@@ -11592,7 +11592,7 @@
         {
             "title": "PUBG",
             "hex": "FEAB02",
-            "source": "https://www.pubgmobile.com/en/event/brandassets/"
+            "source": "https://www.pubgmobile.com/en/event/brandassets"
         },
         {
             "title": "Publons",
@@ -11614,7 +11614,7 @@
             "title": "Pulumi",
             "hex": "8A3391",
             "source": "https://www.pulumi.com",
-            "guidelines": "https://www.pulumi.com/brand/"
+            "guidelines": "https://www.pulumi.com/brand"
         },
         {
             "title": "Puma",
@@ -11624,7 +11624,7 @@
         {
             "title": "Puppet",
             "hex": "FFAE1A",
-            "source": "https://puppet.com/company/press-room/"
+            "source": "https://puppet.com/company/press-room"
         },
         {
             "title": "Puppeteer",
@@ -11647,7 +11647,7 @@
         {
             "title": "Purism",
             "hex": "2D2D2D",
-            "source": "https://puri.sm/pr/images/"
+            "source": "https://puri.sm/pr/images"
         },
         {
             "title": "Pushbullet",
@@ -11673,8 +11673,8 @@
         {
             "title": "PyCharm",
             "hex": "000000",
-            "source": "https://www.jetbrains.com/company/brand/logos/",
-            "guidelines": "https://www.jetbrains.com/company/brand/"
+            "source": "https://www.jetbrains.com/company/brand/logos",
+            "guidelines": "https://www.jetbrains.com/company/brand"
         },
         {
             "title": "Pydantic",
@@ -11719,8 +11719,8 @@
         {
             "title": "Python",
             "hex": "3776AB",
-            "source": "https://www.python.org/community/logos/",
-            "guidelines": "https://www.python.org/community/logos/"
+            "source": "https://www.python.org/community/logos",
+            "guidelines": "https://www.python.org/community/logos"
         },
         {
             "title": "PythonAnywhere",
@@ -11912,7 +11912,7 @@
         {
             "title": "R",
             "hex": "276DC3",
-            "source": "https://www.r-project.org/logo/",
+            "source": "https://www.r-project.org/logo",
             "license": {
                 "type": "CC-BY-SA-4.0"
             }
@@ -11921,7 +11921,7 @@
             "title": "R3",
             "hex": "EC1D24",
             "source": "https://www.r3.com",
-            "guidelines": "https://www.r3.com/contact-press-media/"
+            "guidelines": "https://www.r3.com/contact-press-media"
         },
         {
             "title": "RabbitMQ",
@@ -11980,8 +11980,8 @@
         {
             "title": "Rancher",
             "hex": "0075A8",
-            "source": "https://rancher.com/brand-guidelines/",
-            "guidelines": "https://rancher.com/brand-guidelines/"
+            "source": "https://rancher.com/brand-guidelines",
+            "guidelines": "https://rancher.com/brand-guidelines"
         },
         {
             "title": "Rapid",
@@ -12034,8 +12034,8 @@
         {
             "title": "Razorpay",
             "hex": "0C2451",
-            "source": "https://razorpay.com/newsroom/brand-assets/",
-            "guidelines": "https://razorpay.com/newsroom/brand-assets/"
+            "source": "https://razorpay.com/newsroom/brand-assets",
+            "guidelines": "https://razorpay.com/newsroom/brand-assets"
         },
         {
             "title": "React",
@@ -12163,8 +12163,8 @@
         {
             "title": "Redis",
             "hex": "DC382D",
-            "source": "https://www.redislabs.com/brand-guidelines/",
-            "guidelines": "https://www.redislabs.com/brand-guidelines/"
+            "source": "https://www.redislabs.com/brand-guidelines",
+            "guidelines": "https://www.redislabs.com/brand-guidelines"
         },
         {
             "title": "Redmine",
@@ -12192,8 +12192,8 @@
         {
             "title": "RedwoodJS",
             "hex": "BF4722",
-            "source": "https://redwoodjs.com/logos/",
-            "guidelines": "https://redwoodjs.com/logos/"
+            "source": "https://redwoodjs.com/logos",
+            "guidelines": "https://redwoodjs.com/logos"
         },
         {
             "title": "Reebok",
@@ -12292,8 +12292,8 @@
         {
             "title": "ReSharper",
             "hex": "000000",
-            "source": "https://www.jetbrains.com/company/brand/logos/",
-            "guidelines": "https://www.jetbrains.com/company/brand/"
+            "source": "https://www.jetbrains.com/company/brand/logos",
+            "guidelines": "https://www.jetbrains.com/company/brand"
         },
         {
             "title": "Resurrection Remix OS",
@@ -12368,14 +12368,14 @@
         {
             "title": "Rider",
             "hex": "000000",
-            "source": "https://www.jetbrains.com/company/brand/logos/",
-            "guidelines": "https://www.jetbrains.com/company/brand/"
+            "source": "https://www.jetbrains.com/company/brand/logos",
+            "guidelines": "https://www.jetbrains.com/company/brand"
         },
         {
             "title": "Rimac Automobili",
             "hex": "0A222E",
-            "source": "https://www.rimac-automobili.com/media/",
-            "guidelines": "https://www.rimac-automobili.com/media/"
+            "source": "https://www.rimac-automobili.com/media",
+            "guidelines": "https://www.rimac-automobili.com/media"
         },
         {
             "title": "Ring",
@@ -12390,14 +12390,14 @@
         {
             "title": "Ripple",
             "hex": "0085C0",
-            "source": "https://www.ripple.com/media-kit/",
+            "source": "https://www.ripple.com/media-kit",
             "guidelines": "https://brand.ripple.com/article/brand-policy"
         },
         {
             "title": "RISC-V",
             "hex": "283272",
-            "source": "https://riscv.org/risc-v-logo/",
-            "guidelines": "https://riscv.org/about/risc-v-branding-guidelines/"
+            "source": "https://riscv.org/risc-v-logo",
+            "guidelines": "https://riscv.org/about/risc-v-branding-guidelines"
         },
         {
             "title": "Riseup",
@@ -12509,24 +12509,24 @@
         {
             "title": "Roots",
             "hex": "525DDC",
-            "source": "https://roots.io/about/brand/",
-            "guidelines": "https://roots.io/about/brand/"
+            "source": "https://roots.io/about/brand",
+            "guidelines": "https://roots.io/about/brand"
         },
         {
             "title": "Roots Bedrock",
             "hex": "525DDC",
-            "source": "https://roots.io/about/brand/"
+            "source": "https://roots.io/about/brand"
         },
         {
             "title": "Roots Sage",
             "hex": "525DDC",
-            "source": "https://roots.io/about/brand/"
+            "source": "https://roots.io/about/brand"
         },
         {
             "title": "ROS",
             "hex": "22314E",
-            "source": "https://www.ros.org/press-kit/",
-            "guidelines": "https://www.ros.org/press-kit/"
+            "source": "https://www.ros.org/press-kit",
+            "guidelines": "https://www.ros.org/press-kit"
         },
         {
             "title": "Rossmann",
@@ -12562,13 +12562,13 @@
         {
             "title": "RStudio",
             "hex": "75AADB",
-            "source": "https://www.rstudio.com/about/logos/",
-            "guidelines": "https://www.rstudio.com/about/logos/"
+            "source": "https://www.rstudio.com/about/logos",
+            "guidelines": "https://www.rstudio.com/about/logos"
         },
         {
             "title": "RTÉ",
             "hex": "00A7B3",
-            "source": "https://www.rte.ie/archives/"
+            "source": "https://www.rte.ie/archives"
         },
         {
             "title": "RTL",
@@ -12604,7 +12604,7 @@
         {
             "title": "Ruby",
             "hex": "CC342D",
-            "source": "https://www.ruby-lang.org/en/about/logo/",
+            "source": "https://www.ruby-lang.org/en/about/logo",
             "license": {
                 "type": "CC-BY-SA-2.5"
             }
@@ -12613,7 +12613,7 @@
             "title": "Ruby on Rails",
             "hex": "D30001",
             "source": "https://github.com/simple-icons/simple-icons/issues/9619#issuecomment-1735150580",
-            "guidelines": "https://rubyonrails.org/trademarks/"
+            "guidelines": "https://rubyonrails.org/trademarks"
         },
         {
             "title": "Ruby Sinatra",
@@ -12684,8 +12684,8 @@
         {
             "title": "S7 Airlines",
             "hex": "C4D600",
-            "source": "https://www.s7.ru/en/info/s7-airlines/brand/",
-            "guidelines": "https://www.s7.ru/en/info/s7-airlines/brand/"
+            "source": "https://www.s7.ru/en/info/s7-airlines/brand",
+            "guidelines": "https://www.s7.ru/en/info/s7-airlines/brand"
         },
         {
             "title": "Sabanci",
@@ -12741,8 +12741,8 @@
         {
             "title": "Samsung",
             "hex": "1428A0",
-            "source": "https://www.samsung.com/us/about-us/brand-identity/logo/",
-            "guidelines": "https://www.samsung.com/us/about-us/brand-identity/logo/"
+            "source": "https://www.samsung.com/us/about-us/brand-identity/logo",
+            "guidelines": "https://www.samsung.com/us/about-us/brand-identity/logo"
         },
         {
             "title": "Samsung Pay",
@@ -12826,8 +12826,8 @@
         {
             "title": "Scaleway",
             "hex": "4F0599",
-            "source": "https://www.scaleway.com/en/design-resources/",
-            "guidelines": "https://www.scaleway.com/en/design-resources/"
+            "source": "https://www.scaleway.com/en/design-resources",
+            "guidelines": "https://www.scaleway.com/en/design-resources"
         },
         {
             "title": "Scania",
@@ -12957,7 +12957,7 @@
         {
             "title": "Sellfy",
             "hex": "21B352",
-            "source": "https://sellfy.com/about/"
+            "source": "https://sellfy.com/about"
         },
         {
             "title": "Semantic Scholar",
@@ -13018,7 +13018,7 @@
         {
             "title": "Sentry",
             "hex": "362D59",
-            "source": "https://sentry.io/branding/"
+            "source": "https://sentry.io/branding"
         },
         {
             "title": "SEPA",
@@ -13060,7 +13060,7 @@
         {
             "title": "SFML",
             "hex": "8CC445",
-            "source": "https://www.sfml-dev.org/download/goodies/"
+            "source": "https://www.sfml-dev.org/download/goodies"
         },
         {
             "title": "shadcn/ui",
@@ -13131,7 +13131,7 @@
         {
             "title": "Shopware",
             "hex": "189EFF",
-            "source": "https://www.shopware.com/en/press/press-material/"
+            "source": "https://www.shopware.com/en/press/press-material"
         },
         {
             "title": "Shortcut",
@@ -13142,7 +13142,7 @@
         {
             "title": "Shotcut",
             "hex": "115C77",
-            "source": "https://shotcut.com/media/"
+            "source": "https://shotcut.com/media"
         },
         {
             "title": "Showpad",
@@ -13234,7 +13234,7 @@
         {
             "title": "SingleStore",
             "hex": "AA00FF",
-            "source": "https://www.singlestore.com/brand/"
+            "source": "https://www.singlestore.com/brand"
         },
         {
             "title": "Sitecore",
@@ -13355,7 +13355,7 @@
         {
             "title": "SlideShare",
             "hex": "008ED2",
-            "source": "https://www.slideshare.net/ss/creators/"
+            "source": "https://www.slideshare.net/ss/creators"
         },
         {
             "title": "Slint",
@@ -13421,8 +13421,8 @@
         {
             "title": "Snowflake",
             "hex": "29B5E8",
-            "source": "https://www.snowflake.com/brand-guidelines/",
-            "guidelines": "https://www.snowflake.com/brand-guidelines/"
+            "source": "https://www.snowflake.com/brand-guidelines",
+            "guidelines": "https://www.snowflake.com/brand-guidelines"
         },
         {
             "title": "Snowpack",
@@ -13492,7 +13492,7 @@
         {
             "title": "Solus",
             "hex": "5294E2",
-            "source": "https://getsol.us/branding/"
+            "source": "https://getsol.us/branding"
         },
         {
             "title": "Sonar",
@@ -13507,14 +13507,14 @@
         {
             "title": "SonarLint",
             "hex": "CB2029",
-            "source": "https://www.sonarlint.org/logos/",
-            "guidelines": "https://www.sonarlint.org/logos/"
+            "source": "https://www.sonarlint.org/logos",
+            "guidelines": "https://www.sonarlint.org/logos"
         },
         {
             "title": "SonarQube",
             "hex": "4E9BCD",
-            "source": "https://www.sonarqube.org/logos/",
-            "guidelines": "https://www.sonarqube.org/logos/"
+            "source": "https://www.sonarqube.org/logos",
+            "guidelines": "https://www.sonarqube.org/logos"
         },
         {
             "title": "Sonatype",
@@ -13577,8 +13577,8 @@
         {
             "title": "SourceHut",
             "hex": "000000",
-            "source": "https://sourcehut.org/logo/",
-            "guidelines": "https://sourcehut.org/logo/",
+            "source": "https://sourcehut.org/logo",
+            "guidelines": "https://sourcehut.org/logo",
             "license": {
                 "type": "CC0-1.0"
             }
@@ -13587,7 +13587,7 @@
             "title": "Sourcetree",
             "hex": "0052CC",
             "source": "https://atlassian.design/resources/logo-library",
-            "guidelines": "https://atlassian.design/foundations/logos/"
+            "guidelines": "https://atlassian.design/foundations/logos"
         },
         {
             "title": "Southwest Airlines",
@@ -13632,8 +13632,8 @@
         {
             "title": "SparkPost",
             "hex": "FA6423",
-            "source": "https://www.sparkpost.com/press-kit/",
-            "guidelines": "https://www.sparkpost.com/press-kit/"
+            "source": "https://www.sparkpost.com/press-kit",
+            "guidelines": "https://www.sparkpost.com/press-kit"
         },
         {
             "title": "SPDX",
@@ -13829,14 +13829,14 @@
         {
             "title": "Stack Overflow",
             "hex": "F58025",
-            "source": "https://stackoverflow.design/brand/logo/",
+            "source": "https://stackoverflow.design/brand/logo",
             "guidelines": "https://stackoverflow.com/legal/trademark-guidance"
         },
         {
             "title": "Stackbit",
             "hex": "207BEA",
-            "source": "https://www.stackbit.com/branding-guidelines/",
-            "guidelines": "https://www.stackbit.com/branding-guidelines/"
+            "source": "https://www.stackbit.com/branding-guidelines",
+            "guidelines": "https://www.stackbit.com/branding-guidelines"
         },
         {
             "title": "StackBlitz",
@@ -13851,13 +13851,13 @@
         {
             "title": "StackHawk",
             "hex": "00CBC6",
-            "source": "https://www.stackhawk.com/press/"
+            "source": "https://www.stackhawk.com/press"
         },
         {
             "title": "StackPath",
             "hex": "000000",
-            "source": "https://www.stackpath.com/company/logo-and-branding/",
-            "guidelines": "https://www.stackpath.com/company/logo-and-branding/"
+            "source": "https://www.stackpath.com/company/logo-and-branding",
+            "guidelines": "https://www.stackpath.com/company/logo-and-branding"
         },
         {
             "title": "StackShare",
@@ -13872,7 +13872,7 @@
         {
             "title": "Staffbase",
             "hex": "00A4FD",
-            "source": "https://staffbase.com/en/about/press-assets/"
+            "source": "https://staffbase.com/en/about/press-assets"
         },
         {
             "title": "Stagetimer",
@@ -13903,12 +13903,12 @@
         {
             "title": "Stardock",
             "hex": "004B8D",
-            "source": "https://www.stardock.com/press/stardock%20branding/"
+            "source": "https://www.stardock.com/press/stardock%20branding"
         },
         {
             "title": "Starling Bank",
             "hex": "6935D3",
-            "source": "https://www.starlingbank.com/media/",
+            "source": "https://www.starlingbank.com/media",
             "guidelines": "https://www.starlingbank.com/docs/brand/starling-bank-brand-guidelines.pdf"
         },
         {
@@ -13967,7 +13967,7 @@
         {
             "title": "Steem",
             "hex": "171FC9",
-            "source": "https://steem.com/brand/"
+            "source": "https://steem.com/brand"
         },
         {
             "title": "Steemit",
@@ -13977,7 +13977,7 @@
         {
             "title": "Steinberg",
             "hex": "C90827",
-            "source": "https://new.steinberg.net/press/"
+            "source": "https://new.steinberg.net/press"
         },
         {
             "title": "Stellar",
@@ -13987,7 +13987,7 @@
         {
             "title": "Stencyl",
             "hex": "8E1C04",
-            "source": "https://www.stencyl.com/about/press/"
+            "source": "https://www.stencyl.com/about/press"
         },
         {
             "title": "Stimulus",
@@ -14066,7 +14066,7 @@
         {
             "title": "strongSwan",
             "hex": "E00033",
-            "source": "https://www.strongswan.org/images/"
+            "source": "https://www.strongswan.org/images"
         },
         {
             "title": "Stryker",
@@ -14152,7 +14152,7 @@
         {
             "title": "Super User",
             "hex": "38A1CE",
-            "source": "https://stackoverflow.design/brand/logo/",
+            "source": "https://stackoverflow.design/brand/logo",
             "guidelines": "https://stackoverflow.com/legal/trademark-guidance"
         },
         {
@@ -14173,8 +14173,8 @@
         {
             "title": "SurveyMonkey",
             "hex": "00BF6F",
-            "source": "https://www.surveymonkey.com/mp/brandassets/",
-            "guidelines": "https://www.surveymonkey.com/mp/brandassets/"
+            "source": "https://www.surveymonkey.com/mp/brandassets",
+            "guidelines": "https://www.surveymonkey.com/mp/brandassets"
         },
         {
             "title": "SUSE",
@@ -14238,8 +14238,8 @@
         {
             "title": "Swift",
             "hex": "F05138",
-            "source": "https://developer.apple.com/swift/resources/",
-            "guidelines": "https://developer.apple.com/swift/resources/"
+            "source": "https://developer.apple.com/swift/resources",
+            "guidelines": "https://developer.apple.com/swift/resources"
         },
         {
             "title": "Swiggy",
@@ -14343,7 +14343,7 @@
         {
             "title": "Tails",
             "hex": "56347C",
-            "source": "https://tails.boum.org/contribute/how/promote/material/logo/"
+            "source": "https://tails.boum.org/contribute/how/promote/material/logo"
         },
         {
             "title": "Tailwind CSS",
@@ -14567,8 +14567,8 @@
                     "USDt"
                 ]
             },
-            "source": "https://tether.to/branding/",
-            "guidelines": "https://tether.to/branding/"
+            "source": "https://tether.to/branding",
+            "guidelines": "https://tether.to/branding"
         },
         {
             "title": "Textpattern",
@@ -14658,7 +14658,7 @@
         {
             "title": "The Washington Post",
             "hex": "231F20",
-            "source": "https://www.washingtonpost.com/brand-studio/archive/"
+            "source": "https://www.washingtonpost.com/brand-studio/archive"
         },
         {
             "title": "Thingiverse",
@@ -14694,7 +14694,7 @@
         {
             "title": "Thumbtack",
             "hex": "009FD9",
-            "source": "https://www.thumbtack.com/press/media-resources/"
+            "source": "https://www.thumbtack.com/press/media-resources"
         },
         {
             "title": "Thunderbird",
@@ -14720,7 +14720,7 @@
         {
             "title": "Ticketmaster",
             "hex": "026CDF",
-            "source": "https://design.ticketmaster.com/brand/overview/"
+            "source": "https://design.ticketmaster.com/brand/overview"
         },
         {
             "title": "TickTick",
@@ -14750,7 +14750,7 @@
         {
             "title": "TietoEVRY",
             "hex": "063752",
-            "source": "https://www.tietoevry.com/en/about-us/our-company/"
+            "source": "https://www.tietoevry.com/en/about-us/our-company"
         },
         {
             "title": "TikTok",
@@ -14790,7 +14790,7 @@
         {
             "title": "TinyLetter",
             "hex": "ED1C24",
-            "source": "https://tinyletter.com/site/press/"
+            "source": "https://tinyletter.com/site/press"
         },
         {
             "title": "Tistory",
@@ -14889,8 +14889,8 @@
         {
             "title": "Toyota",
             "hex": "EB0A1E",
-            "source": "https://www.toyota.com/brandguidelines/logo/",
-            "guidelines": "https://www.toyota.com/brandguidelines/"
+            "source": "https://www.toyota.com/brandguidelines/logo",
+            "guidelines": "https://www.toyota.com/brandguidelines"
         },
         {
             "title": "TP-Link",
@@ -14938,7 +14938,7 @@
         {
             "title": "Transifex",
             "hex": "0064AB",
-            "source": "https://app.transifex.com/contact/"
+            "source": "https://app.transifex.com/contact"
         },
         {
             "title": "Transmission",
@@ -15079,7 +15079,7 @@
         {
             "title": "Tubi",
             "hex": "000000",
-            "source": "https://corporate.tubitv.com/press-releases/"
+            "source": "https://corporate.tubitv.com/press-releases"
         },
         {
             "title": "TUI",
@@ -15096,7 +15096,7 @@
         {
             "title": "TuneIn",
             "hex": "14D8CC",
-            "source": "https://cms.tunein.com/press/"
+            "source": "https://cms.tunein.com/press"
         },
         {
             "title": "Turbo",
@@ -15214,7 +15214,7 @@
         {
             "title": "Udemy",
             "hex": "A435F0",
-            "source": "https://www.udemy.com/ourbrand/"
+            "source": "https://www.udemy.com/ourbrand"
         },
         {
             "title": "UFC",
@@ -15351,8 +15351,8 @@
         {
             "title": "UpCloud",
             "hex": "7B00FF",
-            "source": "https://upcloud.com/brand-assets/",
-            "guidelines": "https://upcloud.com/brand-assets/"
+            "source": "https://upcloud.com/brand-assets",
+            "guidelines": "https://upcloud.com/brand-assets"
         },
         {
             "title": "Uphold",
@@ -15393,7 +15393,7 @@
         {
             "title": "Upwork",
             "hex": "6FDA44",
-            "source": "https://www.upwork.com/press/"
+            "source": "https://www.upwork.com/press"
         },
         {
             "title": "USPS",
@@ -15549,7 +15549,7 @@
         {
             "title": "Verizon",
             "hex": "CD040B",
-            "source": "https://www.verizondigitalmedia.com/about/logo-usage/"
+            "source": "https://www.verizondigitalmedia.com/about/logo-usage"
         },
         {
             "title": "Vespa",
@@ -15688,7 +15688,7 @@
         {
             "title": "Vitess",
             "hex": "F16728",
-            "source": "https://cncf-branding.netlify.app/projects/vitess/"
+            "source": "https://cncf-branding.netlify.app/projects/vitess"
         },
         {
             "title": "Vitest",
@@ -15946,7 +15946,7 @@
         {
             "title": "Wear OS",
             "hex": "4285F4",
-            "source": "https://partnermarketinghub.withgoogle.com/#/brands/"
+            "source": "https://partnermarketinghub.withgoogle.com/#/brands"
         },
         {
             "title": "Weasyl",
@@ -16334,8 +16334,8 @@
         {
             "title": "Wwise",
             "hex": "00549F",
-            "source": "https://www.audiokinetic.com/resources/credits/",
-            "guidelines": "https://www.audiokinetic.com/resources/credits/"
+            "source": "https://www.audiokinetic.com/resources/credits",
+            "guidelines": "https://www.audiokinetic.com/resources/credits"
         },
         {
             "title": "Wyze",
@@ -16372,7 +16372,7 @@
         {
             "title": "XAMPP",
             "hex": "FB7A24",
-            "source": "https://www.apachefriends.org/en/"
+            "source": "https://www.apachefriends.org/en"
         },
         {
             "title": "Xbox",
@@ -16452,7 +16452,7 @@
         {
             "title": "Yamaha Corporation",
             "hex": "4B1E78",
-            "source": "https://www.yamaha.com/en/"
+            "source": "https://www.yamaha.com/en"
         },
         {
             "title": "Yamaha Motor Corporation",


### PR DESCRIPTION
Removes the remaining trailing slashes from all `source` & `guidelines` URLs.