### PR TITLE
Add Indie Hackers Icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -6933,6 +6933,11 @@
             "source": "https://indeed.design/resources"
         },
         {
+            "title": "Indie Hackers",
+            "hex": "9CB3C9",
+            "source": "https://www.indiehackers.com"
+        },
+        {
             "title": "IndiGo",
             "hex": "09009B",
             "source": "https://www.goindigo.in"

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -6934,7 +6934,7 @@
         },
         {
             "title": "Indie Hackers",
-            "hex": "9CB3C9",
+            "hex": "0E2439",
             "source": "https://www.indiehackers.com"
         },
         {

--- a/icons/indiehackers.svg
+++ b/icons/indiehackers.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Indie Hackers</title><path d="M0 0h24v24H0V0Zm5.4 17.2h2.4V6.8H5.4v10.4Zm4.8 0h2.4v-4h3.6v4h2.4V6.8h-2.4v4h-3.6v-4h-2.4v10.4Z"/></svg>


### PR DESCRIPTION
![indiehackers](https://github.com/simple-icons/simple-icons/assets/54018894/9a301c8c-ac8e-449f-a201-70b80fc1089d)

**Issue:** closes #9343

**Similarweb rank:** [58,402](https://www.similarweb.com/website/indiehackers.com/#overview)

### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description

[svg](https://storage.googleapis.com/indie-hackers.appspot.com/branding/logos/indie-hackers-logo__glyph--light.svg) taken from [website](https://www.indiehackers.com/) header, Hex taken from stylesheet ` color: ` ` #9cb3c9 `

I just want to point out that the ` background-color: ` ` #0e2439 ` in their stylesheet is also being used in logo ` hsl(210, 60%, 14%) `