### PR TITLE
Remove Chrome Webstore link from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ Most of the icons and brand colors on SimpleIcons have been derived from officia
 Official high quality brand logos and brand colors can usually be found in the following locations:
 
 1. About pages, Press pages, Media Kits, and Brand Guidelines.
-1. Website headers (you can use [svg-grabber](https://chrome.google.com/webstore/detail/svg-grabber-get-all-the-s/ndakggdliegnegeclmfgodmgemdokdmg) for Chrome)
+1. Website headers
 1. Favicons
 1. Wikimedia (which should provide a source)
 1. GitHub repositories


### PR DESCRIPTION
The Chrome Webstore link is breaking our linter, most likely through a CORS policy.
PR just removes the mention of the link.