### PR TITLE
Only check potential duplicates on `opened` event

### DIFF
--- a/.github/workflows/potential-duplicates.yml
+++ b/.github/workflows/potential-duplicates.yml
@@ -1,7 +1,7 @@
 name: Potential Duplicates
 on:
   issues:
-    types: [opened, edited]
+    types: [opened]
 
 jobs:
   run:


### PR DESCRIPTION
Related to #8714

We should bypass the `edited` and `reopened` event in case the issue was closed and marked as duplicated by accident.