### PR TITLE
Add fuzzy matching for licenses search to add-icon-data script

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "editorconfig-checker": "5.1.1",
     "esbuild": "0.19.4",
     "fake-diff": "1.0.0",
+    "fast-fuzzy": "1.12.0",
     "get-relative-luminance": "1.0.0",
     "husky": "9.0.10",
     "inquirer-autocomplete-standalone": "0.8.1",

--- a/scripts/add-icon-data.js
+++ b/scripts/add-icon-data.js
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import { input, confirm, checkbox } from '@inquirer/prompts';
 import autocomplete from 'inquirer-autocomplete-standalone';
 import getRelativeLuminance from 'get-relative-luminance';
+import { search } from 'fast-fuzzy';
 import {
   URL_REGEX,
   collator,
@@ -24,7 +25,7 @@ const titleValidator = (text) => {
       (x) => x.title === text || titleToSlug(x.title) === titleToSlug(text),
     )
   )
-    return 'This icon title or slug already exist';
+    return 'This icon title or slug already exists';
   return true;
 };
 
@@ -132,16 +133,14 @@ if (answers.hasLicense) {
     source: async (input) => {
       input = (input || '').trim();
       return input
-        ? licenseTypes.filter((license) =>
-            license.value.toLowerCase().includes(input.toLowerCase()),
-          )
+        ? search(input, licenseTypes, { keySelector: (x) => x.value })
         : licenseTypes;
     },
   });
 
   answers.licenseUrl = await input({
     message: `License URL ${chalk.reset('(optional)')}:`,
-    validate: (text) => !Boolean(text) || sourceValidator(text),
+    validate: (text) => text.length === 0 || sourceValidator(text),
   });
 }
 
@@ -160,7 +159,7 @@ if (answers.hasAliases) {
     if (!answers?.aliasesTypes?.includes(x.value)) continue;
     answers[`${x.value}AliasesList`] = await input({
       message: x.value + chalk.reset(' (separate with commas)'),
-      validate: (text) => Boolean(text),
+      validate: (text) => text.length > 0,
       transformer: aliasesTransformer,
     });
   }

--- a/scripts/add-icon-data.js
+++ b/scripts/add-icon-data.js
@@ -159,7 +159,7 @@ if (answers.hasAliases) {
     if (!answers?.aliasesTypes?.includes(x.value)) continue;
     answers[`${x.value}AliasesList`] = await input({
       message: x.value + chalk.reset(' (separate with commas)'),
-      validate: (text) => text.length > 0,
+      validate: (text) => text.trim().length > 0,
       transformer: aliasesTransformer,
     });
   }


### PR DESCRIPTION
Also:

- Changed usages of `Boolean(string)` by `string.length` comparisons because is more readable and the performance is the same.
- Use `trim()` method validating aliases.

Contributes to #10572