### PR TITLE
Use forked labeler action on CI

### DIFF
--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action == 'opened'
     steps:
-      - uses: ericcornelissen/labeler@label-based-on-status
+      - uses: simple-icons/labeler@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The repository [`ericcornelissen/labeler`](https://github.com/ericcornelissen/labeler) is now a public archive, so I've forked it on [`simple-icons/labeler`](https://github.com/ericcornelissen/labeler) and merged the [`label-based-on-status` branch](https://github.com/ericcornelissen/labeler/tree/label-based-on-status) into master.