### PR TITLE
Add titles to issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/icon_removal.yml
+++ b/.github/ISSUE_TEMPLATE/icon_removal.yml
@@ -1,6 +1,7 @@
 name: Icon removal
 description: Report an icon for removal
 labels: [removal request]
+title: 'Removal: <brand-name>'
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/icon_request.yml
+++ b/.github/ISSUE_TEMPLATE/icon_request.yml
@@ -1,6 +1,7 @@
 name: Icon request
 description: Request a new icon for Simple Icons
 labels: [new icon]
+title: 'Request: <brand-name>'
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/icon_update.yml
+++ b/.github/ISSUE_TEMPLATE/icon_update.yml
@@ -1,6 +1,7 @@
 name: Icon update
 description: Help us improve by reporting outdated icons
 labels: [icon outdated]
+title: 'Update: <brand-name>'
 
 body:
   - type: markdown


### PR DESCRIPTION
### Checklist

- [ ] I updated the JSON data in `_data/simple-icons.json`
- [ ] I optimized the icon with SVGO or SVGOMG
- [ ] The SVG `viewbox` is `0 0 24 24`

### Description

I've noticed a lot of issues have been renamed to follow this format, so I think it makes sense to nudge contributors in the right direction by adding placeholder titles (see https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax) to the issue templates.

<details>
<summary>Examples of cases where issues have been renamed to follow this format</summary>

![Screenshot 2024-03-12 at 06 43 09 (Arc)](https://github.com/simple-icons/simple-icons/assets/47499684/24558cf2-e1ae-4981-92c7-eb877a7c5606)
![Screenshot 2024-03-12 at 06 43 22 (Arc)](https://github.com/simple-icons/simple-icons/assets/47499684/6ca8d891-46d7-4261-af01-c24f24f3ae62)
![Screenshot 2024-03-12 at 06 43 28 (Arc)](https://github.com/simple-icons/simple-icons/assets/47499684/4ae97f44-5c15-4604-9d99-69a8df85bea2)
![Screenshot 2024-03-12 at 06 43 33 (Arc)](https://github.com/simple-icons/simple-icons/assets/47499684/0d44a7bc-d425-495b-bfbb-b318caa17493)
![Screenshot 2024-03-12 at 06 43 39 (Arc)](https://github.com/simple-icons/simple-icons/assets/47499684/143b3385-8c08-4a4e-b7f5-117ca1af72e8)
![Screenshot 2024-03-12 at 06 43 52 (Arc)](https://github.com/simple-icons/simple-icons/assets/47499684/76b0b14a-e166-43d0-ab93-ff8bf5812569)
![Screenshot 2024-03-12 at 06 44 00 (Arc)](https://github.com/simple-icons/simple-icons/assets/47499684/db0f5c6a-146d-4c0f-8106-6a5065c194b2)
![Screenshot 2024-03-12 at 06 44 08 (Arc)](https://github.com/simple-icons/simple-icons/assets/47499684/c7a6edbc-094c-4a1f-8f7e-e6bf1b3f6d49)

</details>