### PR TITLE
Use `kceb/git-message-action@v3.0.1`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Get commit message (for release title and body)
         id: commit
-        uses: kceb/git-message-action@v2
+        uses: kceb/git-message-action@v3.0.1
       - id: get-version
         uses: ./.github/actions/get-version
       - name: Reformat to regular markdown


### PR DESCRIPTION
We cannot use `@v3` for now due to https://github.com/kceb/git-message-action/issues/19