### PR TITLE
Update PyTorch hex

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -12223,9 +12223,9 @@
         },
         {
             "title": "PyTorch",
-            "hex": "EE4C2C",
+            "hex": "DE3412",
             "source": "https://github.com/pytorch/pytorch.github.io/blob/8f083bd12192ca12d5e1c1f3d236f4831d823d8f/assets/images/logo.svg",
-            "guidelines": "https://github.com/pytorch/pytorch.github.io/blob/381117ec296f002b2de475402ef29cca6c55e209/assets/brand-guidelines/PyTorch-Brand-Guidelines.pdf"
+            "guidelines": "https://github.com/pytorch/pytorch.github.io/blob/5403e593ba6c3ee24e53cbf834f35d8e322cf998/assets/brand-guidelines/PyTorch-Brand-Guidelines.pdf"
         },
         {
             "title": "PyUp",


### PR DESCRIPTION
The color in the brand guidelines was ever so slightly changed in https://github.com/pytorch/pytorch.github.io/pull/1124

### Before

![before](https://github.com/simple-icons/simple-icons/assets/12021217/d70d8770-2bca-4304-ab72-4648fcbcc0e4)

### After

![after](https://github.com/simple-icons/simple-icons/assets/12021217/c58cd1a8-af50-4a30-9342-c35dd840710a)
