### PR TITLE
Replace commit user to `simple-icons[bot]`

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -65,6 +65,6 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: version bump
-          commit_user_name: 'github-actions[bot]'
-          commit_user_email: 'github-actions[bot]@users.noreply.github.com'
-          commit_author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
+          commit_user_name: 'simple-icons[bot]'
+          commit_user_email: 'simple-icons[bot]@users.noreply.github.com'
+          commit_author: 'simple-icons[bot] <simple-icons[bot]@users.noreply.github.com>'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,8 +68,8 @@ jobs:
         run: ./scripts/release/reformat-markdown.js "${{ steps.get-version.outputs.version }}"
       - name: Configure GIT credentials
         run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config user.name "simple-icons[bot]"
+          git config user.email "simple-icons[bot]@users.noreply.github.com"
       # Commit that will only be included in the tag
       - name: Commit CDN theme image links removal
         run: |


### PR DESCRIPTION
This pull request only replaces the commit user on `create-release` and `publish`.

For other actions, we need to set up more on the GitHub App. I will implement this in another pull request.