### PR TITLE
Fix `normalizeColor` function

### DIFF
--- a/sdk.mjs
+++ b/sdk.mjs
@@ -175,10 +175,8 @@ export const normalizeNewlines = (text) => {
 export const normalizeColor = (text) => {
   let color = text.replace('#', '').toUpperCase();
   if (color.length < 6) {
-    color = color
-      .slice(0, 3)
-      .map((x) => x.repeat(2))
-      .join('');
+    // eslint-disable-next-line unicorn/no-useless-spread
+    color = [...color.slice(0, 3)].map((x) => x.repeat(2)).join('');
   } else if (color.length > 6) {
     color = color.slice(0, 6);
   }


### PR DESCRIPTION
### Description

When running the script to add new icon data, an error popped up:

```shell
npm run add-icon-data
```

```
~/Code/git/ooss/simple-icons develop ❯ npm run add-icon-data                                                                                                                                                              05:04:54

> simple-icons@11.10.0 add-icon-data
> ./scripts/add-icon-data.js

? What is the title of this icon? Foo

file:///Users/davidlj95/Code/git/ooss/simple-icons/sdk.mjs:180
      .map((x) => x.repeat(2))
       ^

TypeError: color.slice(...).map is not a function
    at normalizeColor (file:///Users/davidlj95/Code/git/ooss/simple-icons/sdk.mjs:180:8)
    at Object.previewHexColor [as transformer] (file:///Users/davidlj95/Code/git/ooss/simple-icons/scripts/add-icon-data.js:45:17)
    at file:///Users/davidlj95/Code/git/ooss/simple-icons/node_modules/@inquirer/input/dist/esm/index.mjs:50:33
    at workLoop (file:///Users/davidlj95/Code/git/ooss/simple-icons/node_modules/@inquirer/core/dist/esm/lib/create-prompt.mjs:66:42)
    at file:///Users/davidlj95/Code/git/ooss/simple-icons/node_modules/@inquirer/core/dist/esm/lib/create-prompt.mjs:76:17
    at file:///Users/davidlj95/Code/git/ooss/simple-icons/node_modules/@inquirer/core/dist/esm/lib/hook-engine.mjs:19:9
    at AsyncLocalStorage.run (node:async_hooks:346:14)
    at withHooks (file:///Users/davidlj95/Code/git/ooss/simple-icons/node_modules/@inquirer/core/dist/esm/lib/hook-engine.mjs:18:24)
    at file:///Users/davidlj95/Code/git/ooss/simple-icons/node_modules/@inquirer/core/dist/esm/lib/create-prompt.mjs:23:13
    at new Promise (<anonymous>)

Node.js v20.12.0
```

Node is right: `.map` function is called on a string resulting from `color.slice`. But strings don't have a `.map` function. 

Looking for recent history, found out the line was recently changed when introducing XO linter in #10643 

https://github.com/simple-icons/simple-icons/pull/10643/files#diff-995497d12cba57a3d4c41acdd8c3503d4fb9a5155f617b9e3b2624a47ab48f1fL176

```diff
-    color = [...color.slice(0, 3)].map((x) => x.repeat(2)).join('');
+    color = color
+      .slice(0, 3)
+      .map((x) => x.repeat(2))
+     .join('');
```

Probably the linter assumed `slice` was for an array, so it thought you don't need to clone it again. Hence the spread was removed. But now the `slice` result is a string and the string has no `map`.

To solve it, separating the `slice` from the string to char array conversion. 

Tried with `.split('')` but then [`prefer-spread` linter rule is triggered](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-spread.md)

Tried adding data and now everything works 🎉 