### PR TITLE
Use `simple-icons[bot]` for actions

### DIFF
--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -8,18 +8,27 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action == 'opened'
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: simple-icons/labeler@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ steps.app-token.outputs.token }}
 
   assign-to-project:
     runs-on: ubuntu-latest
     name: Assign to Project
     if: github.event.action == 'opened'
     needs: triage
-    env:
-      MY_GITHUB_TOKEN: ${{ secrets.AUTO_ASSIGN_WORKFLOW_TOKEN }}
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -33,7 +42,7 @@ jobs:
       - id: get-si-members
         name: Get simple-icons members
         run: |
-          members="$(curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' --retry 5 -s https://api.github.com/orgs/simple-icons/members | jq .[].login | tr '\n' ',' | sed -e 's/"//g' -e 's/,$//')"
+          members="$(curl -H 'Authorization: Bearer ${{ steps.app-token.outputs.token }}' --retry 5 -s https://api.github.com/orgs/simple-icons/members | jq .[].login | tr '\n' ',' | sed -e 's/"//g' -e 's/,$//')"
           echo "members=$members" >> $GITHUB_OUTPUT
 
       - id: get-linked-issues
@@ -56,6 +65,8 @@ jobs:
       - id: priority-1
         name: Assign `update icon/data` pull requests to "Priority 1"
         uses: srggrs/assign-one-project-github-action@1.3.1
+        env:
+          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         if: contains(steps.get-labels.outputs.labels, 'update icon/data')
         with:
           project: https://github.com/orgs/simple-icons/projects/2
@@ -64,6 +75,8 @@ jobs:
       - id: priority-2
         name: Assign `new icon` pull requests to "Priority 2"
         uses: srggrs/assign-one-project-github-action@1.3.1
+        env:
+          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         # the PR has the `new icon` label along with a linked issue and
         # the opener is not a member of simple-icons organization
         if: |
@@ -77,6 +90,8 @@ jobs:
       - id: priority-3
         name: Assign `new icon` pull requests by maintainers to "Priority 3"
         uses: srggrs/assign-one-project-github-action@1.3.1
+        env:
+          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         # the PR has the `new icon` label along with a linked issue and
         # the opener is a member of the simple-icons organisation
         if: |
@@ -90,6 +105,8 @@ jobs:
       - id: priority-4
         name: Assign `new icon` pull requests by maintainers without an issue to "Priority 4"
         uses: srggrs/assign-one-project-github-action@1.3.1
+        env:
+          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         # the PR has the `new icon` label but with no linked issue and
         # the opener is a member of the simple-icons organisation
         if: |
@@ -102,6 +119,8 @@ jobs:
 
       - name: Assign pull requests to "Unprioritised"
         uses: srggrs/assign-one-project-github-action@1.3.1
+        env:
+          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         if: |
           steps.priority-1.conclusion == 'skipped' &&
           steps.priority-2.conclusion == 'skipped' &&
@@ -117,11 +136,16 @@ jobs:
     if: |
       github.event.action != 'opened' &&
       github.event.pull_request.merged == false
-    env:
-      MY_GITHUB_TOKEN: ${{ secrets.AUTO_ASSIGN_WORKFLOW_TOKEN }}
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Assign closed pull requests to "Completed or Abandoned"
         uses: srggrs/assign-one-project-github-action@1.3.1
+        env:
+          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           project: https://github.com/orgs/simple-icons/projects/2
           column_name: Completed or Abandoned

--- a/.github/workflows/autoclose-issues.yml
+++ b/.github/workflows/autoclose-issues.yml
@@ -8,6 +8,11 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
       - id: match-java
@@ -39,6 +44,7 @@ jobs:
           contains(steps.get-labels.outputs.labels, 'new icon')
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -34,11 +34,16 @@ jobs:
       github.event_name != 'push' &&
       needs.release-pr.outputs.did-create-pr == 'true'
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
           # Ensure the commit can be pushed regardless of branch protections (must belong to an admin of this repo)
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           # Ensure we are checked out on the develop branch
           ref: develop
       - name: Use Node.js 20.x

--- a/.github/workflows/merge-release.yml
+++ b/.github/workflows/merge-release.yml
@@ -8,6 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'release')
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: simple-icons/release-action@v1
         with:
-          repo-token: ${{ secrets.RELEASE_TOKEN }}
+          repo-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/potential-duplicates.yml
+++ b/.github/workflows/potential-duplicates.yml
@@ -7,9 +7,14 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: wow-actions/potential-duplicates@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           label: duplicate
           exclude: |
             adding

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,11 @@ jobs:
     needs: sanity-check
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
       - name: Get commit message (for release title and body)
@@ -94,10 +99,15 @@ jobs:
     needs: npm
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Trigger simple-icons-font release
         run: |
           curl -X POST \
-            -H "Authorization: Bearer ${{ secrets.REMOTE_DISPATCH_TOKEN }}" \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
             -d '{"ref":"develop"}' \
             https://api.github.com/repos/simple-icons/simple-icons-font/actions/workflows/auto-release.yml/dispatches
   website:
@@ -105,9 +115,14 @@ jobs:
     needs: npm
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Trigger simple-icons-website update
         run: |
           curl -X POST \
-            -H "Authorization: Bearer ${{ secrets.REMOTE_DISPATCH_TOKEN }}" \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
             -d '{"ref":"master"}' \
             https://api.github.com/repos/simple-icons/simple-icons-website/actions/workflows/auto-release.yml/dispatches

--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -13,9 +13,14 @@ jobs:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: mondeja/remove-labels-gh-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           labels: |
             assessing
             awaiting reply
@@ -31,9 +36,14 @@ jobs:
     if: github.event_name == 'pull_request_target' && (! github.event.pull_request.merged)
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: mondeja/remove-labels-gh-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           labels: |
             in discussion
             pending
@@ -43,9 +53,14 @@ jobs:
     if: github.event.issue.state == 'closed'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: mondeja/remove-labels-gh-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           labels: |
             in discussion
             pending


### PR DESCRIPTION
I've set up the `BOT_PRIVATE_KEY` and `BOT_APP_ID` in organization settings for the action https://github.com/actions/create-github-app-token. I've changed all role-related visible actions to the token of our GitHub App.

### References

This is the main idea for the GitHub App in GitHub Actions:
- https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow

And this is how I generate the private key:
- https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps