### PR TITLE
Authenticate with GitHub token in get-labels action

### DIFF
--- a/.github/actions/get-labels/action.yml
+++ b/.github/actions/get-labels/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Issue or pull request number to get labels from
     required: true
   github-token:
-    description: GitHub token
+    description: GitHub token used to authenticate with the GitHub API
     default: ${{ secrets.GITHUB_TOKEN }}
 outputs:
   labels:

--- a/.github/actions/get-labels/action.yml
+++ b/.github/actions/get-labels/action.yml
@@ -5,6 +5,9 @@ inputs:
   issue_number:
     description: Issue or pull request number to get labels from
     required: true
+  github-token:
+    description: GitHub token
+    default: ${{ secrets.GITHUB_TOKEN }}
 outputs:
   labels:
     description: Labels of the issue or pull request
@@ -15,6 +18,8 @@ runs:
   steps:
     - id: get-labels
       shell: sh
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
       run: |
         labels="$(gh api 'repos/simple-icons/simple-icons/issues/${{ inputs.issue_number }}' --jq '.labels.[].name' | tr '\n' ',')"
         echo "labels=$labels" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Just to prevent a too many request block. I'm not using the app token because is not needed in this context, each user will use their own token to call the API.

See https://cli.github.com/manual/gh_auth_login