### PR TITLE
Remove invalid `secrets` usage

### DIFF
--- a/.github/actions/get-labels/action.yml
+++ b/.github/actions/get-labels/action.yml
@@ -7,6 +7,7 @@ inputs:
     required: true
   github-token:
     description: GitHub token used to authenticate with the GitHub API
+    required: true
 outputs:
   labels:
     description: Labels of the issue or pull request

--- a/.github/actions/get-labels/action.yml
+++ b/.github/actions/get-labels/action.yml
@@ -7,7 +7,6 @@ inputs:
     required: true
   github-token:
     description: GitHub token used to authenticate with the GitHub API
-    default: ${{ secrets.GITHUB_TOKEN }}
 outputs:
   labels:
     description: Labels of the issue or pull request


### PR DESCRIPTION
Fixes the failing action: https://github.com/simple-icons/simple-icons/actions/runs/8500128507.

We cannot access `secret` from a composite directly.