### PR TITLE
Update Linux Foundation icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -8755,9 +8755,9 @@
         },
         {
             "title": "Linux Foundation",
-            "hex": "003366",
-            "source": "https://www.linuxfoundation.org/en/about/brand/",
-            "guidelines": "https://www.linuxfoundation.org/en/about/brand/"
+            "hex": "003778",
+            "source": "https://www.linuxfoundation.org/brand-guidelines",
+            "guidelines": "https://www.linuxfoundation.org/brand-guidelines"
         },
         {
             "title": "Linux Mint",


### PR DESCRIPTION
![linuxfoundation prview](https://github.com/simple-icons/simple-icons/assets/517295/800c969f-b1c1-4e03-80dd-863dd3382e13)

### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [ ] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description

I noticed that the Linux Foundation brand guidelines link was a 404. As I was updating the link, I saw that the listed color was not one of those within the guidelines and updated that as well.

There is no change to the icon itself.