### PR TITLE
Update Node.js icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -10473,7 +10473,7 @@
         {
             "title": "Node.js",
             "hex": "5FA04E",
-            "source": "https://github.com/nodejs/nodejs.org/blob/941b0022c38739d6a9277d558f6b9c78e13a4262/public/static/logos/jsIconGreen.svg",
+            "source": "https://nodejs.org/en/about/branding",
             "guidelines": "https://nodejs.org/en/about/branding"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -10472,9 +10472,9 @@
         },
         {
             "title": "Node.js",
-            "hex": "339933",
-            "source": "https://nodejs.org/en/about/resources/",
-            "guidelines": "https://nodejs.org/en/about/resources/"
+            "hex": "5FA04E",
+            "source": "https://github.com/nodejs/nodejs.org/blob/941b0022c38739d6a9277d558f6b9c78e13a4262/public/static/logos/jsIconGreen.svg",
+            "guidelines": "https://nodejs.org/en/about/branding"
         },
         {
             "title": "Nodemon",


### PR DESCRIPTION

![node.js preview](https://github.com/simple-icons/simple-icons/assets/517295/dde48c37-34ab-4224-9ab1-1ede21116cad)

### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [ ] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description

The existing brand guidelines link is a 404. It also seems the brand color has changed, I pulled this from the fill on the updated source. The icon itself has not changed.

<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
