### PR TITLE
Update OpenSearch brand guidelines

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -10915,8 +10915,8 @@
         {
             "title": "OpenSearch",
             "hex": "005EB8",
-            "source": "https://opensearch.org/brand.html",
-            "guidelines": "https://opensearch.org/brand.html"
+            "source": "https://opensearch.org/trademark-brand-policy.html",
+            "guidelines": "https://opensearch.org/trademark-brand-policy.html"
         },
         {
             "title": "OpenSSL",


### PR DESCRIPTION
### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [ ] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description

The current link is a 404