### PR TITLE
Increase similarity threshold on potential duplicates workflow

### DIFF
--- a/.github/workflows/potential-duplicates.yml
+++ b/.github/workflows/potential-duplicates.yml
@@ -41,7 +41,7 @@ jobs:
             for
             from
           state: all
-          threshold: 0.7
+          threshold: 0.8
           comment: |
             This issue is potentially a duplicate of one of the following issues:
             {{#issues}}


### PR DESCRIPTION
See title. I've been seeing many many false positives at exactly 70%, bumping up to 80% should still catch some actual duplicates while ignoring the obvious false positives.