### PR TITLE
Set `repositories` in Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,5 @@
 {
+  repositories: ["simple-icons/simple-icons"],
   extends: [
     'config:base',
 


### PR DESCRIPTION
Renovate [didn't found the repository](https://github.com/simple-icons/simple-icons/actions/runs/8903303462/job/24450816864#step:4:155) to run against it, seems that this should be manually defined in the configuration.