### PR TITLE
Use Simple Icons app token for Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup node
@@ -18,6 +23,6 @@ jobs:
         uses: renovatebot/github-action@v40.1.4
         with:
           configurationFile: .github/renovate.json5
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
         env:
           LOG_LEVEL: debug


### PR DESCRIPTION
I've updated the next permission in the bot app:

![image](https://github.com/simple-icons/simple-icons/assets/23049315/f8737f39-5f11-476b-9a0a-1b6825d796a2)

Because Renovate needs access to update workflow files. For example, see the [renovatebot/github-action](https://togithub.com/renovatebot/github-action) version update in #10879.