### PR TITLE
Only run Verify workflow on push against develop and master branches

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,5 +1,10 @@
 name: Verify Source
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - develop
 
 jobs:
   build:


### PR DESCRIPTION
Renovate opens a PR in a `renovate/all` branch that triggers two times the same Verify workflow, see https://github.com/simple-icons/simple-icons/pull/10882 for an example. We sometimes also open a PR using a branch on the main repo directly, mainly when adding a manual patch through the GH interface because is easy to forget to change to our own fork.

Note that currently this workflow is not being triggered for tags, when should be by default behaviour. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags at `'**'`:

> Matches all branch and tag names. This is the default behavior when you don't use a `branches` or `tags` filter.

 I think that is because the latest commit before the tag is pushed does not belong to a branch as seen at, for example, https://github.com/simple-icons/simple-icons/commit/91a37d360718b8577a467c104112ddc19e8d94b5, which doesn't triggers the push event. So this change doesn't affect that.