### PR TITLE
Update SDK TS defs and improve extensions getter functions

### DIFF
--- a/sdk.d.ts
+++ b/sdk.d.ts
@@ -80,4 +80,7 @@ export function normalizeColor(text: string): string;
 export function getThirdPartyExtensions(
   readmePath?: string,
 ): Promise<ThirdPartyExtension[]>;
+export function getThirdPartyLibraries(
+  readmePath?: string,
+): Promise<ThirdPartyExtension[]>;
 export const collator: Intl.Collator;

--- a/sdk.mjs
+++ b/sdk.mjs
@@ -197,8 +197,8 @@ export const getThirdPartyExtensions = async (
 ) =>
   normalizeNewlines(await fs.readFile(readmePath, 'utf8'))
     .split('## Third-Party Extensions')[1]
-    .split('\n\n')[2]
-    .split('\n')
+    .split('|\n\n')[0]
+    .split('|\n|')
     .slice(2)
     .map((line) => {
       let [module, author] = line.split(' | ');
@@ -228,8 +228,8 @@ export const getThirdPartyLibraries = async (
 ) =>
   normalizeNewlines(await fs.readFile(readmePath, 'utf8'))
     .split('## Third-Party Libraries')[1]
-    .split('\n\n')[2]
-    .split('\n')
+    .split('|\n\n')[0]
+    .split('|\n|')
     .slice(2)
     .map((line) => {
       let [module, author] = line.split(' | ');


### PR DESCRIPTION
- Don't depend on number of newlines in section descriptions getting third party extensions from SDK.
- Run `node scripts/release/update-sdk-ts-defs.js`.