### PR TITLE
Add Renovate Bot brand guidelines

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -13058,7 +13058,8 @@
         {
             "title": "RenovateBot",
             "hex": "1A1F6C",
-            "source": "https://avatars1.githubusercontent.com/u/38656520"
+            "source": "https://avatars1.githubusercontent.com/u/38656520",
+            "guidelines": "https://docs.renovatebot.com/logo-brand-guidelines"
         },
         {
             "title": "Renren",


### PR DESCRIPTION
I've added the [recently created Renovate Bot brand guidelines](https://github.com/renovatebot/renovate/pull/29021) to the icon's metadata.