### PR TITLE
Remove bot part from Renovate logo title

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -13174,7 +13174,7 @@
             "source": "https://render.com"
         },
         {
-            "title": "RenovateBot",
+            "title": "Renovate",
             "hex": "1A1F6C",
             "source": "https://avatars1.githubusercontent.com/u/38656520",
             "guidelines": "https://docs.renovatebot.com/logo-brand-guidelines"


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://wasm.simpleicons.org/preview
-->

**Issue:** I'm _not_ closing any issue with this PR.

**Popularity metric:**

- The [`renovatebot/renovate` repository](https://github.com/renovatebot/renovate) has 16.3k stars on GitHub
- The [Renovate docs homepage, Who uses Renovate?](https://docs.renovatebot.com/#who-uses-renovate) lists big name companies that use Renovate

<!--
Regardless of whether or not the linked issue (if there is one) has a metric, please include the metric here for PR reviewers to validate. See our contributing guidelines at https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#assessing-popularity for more details on how we assess a brand's popularity.
-->

### Checklist

I don't think the items in this checklist are relevant to the change I'm making. :wink: 

- [ ] I updated the JSON data in `_data/simple-icons.json`
- [ ] I optimized the icon with SVGO or SVGOMG
- [ ] The SVG `viewbox` is `0 0 24 24`

### Description

<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->

The Renovate docs (and repository readme) generally use `Renovate` (without the `bot` part!). The icon should match that branding.