### PR TITLE
Add LEGO to list of forbidden brands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,7 @@ Some companies and organizations are excessively protective with their brands, s
 - BP
 - Disney
 - International Olympic Committee
+- LEGO
 - Mattel
 - Microchip Technology Inc.
 - Oracle


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://wasm.simpleicons.org/preview
-->

**Issue:** I'm not closing any issue with this PR.

**Popularity metric:**

<!--
Regardless of whether or not the linked issue (if there is one) has a metric, please include the metric here for PR reviewers to validate. See our contributing guidelines at https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#assessing-popularity for more details on how we assess a brand's popularity.
-->

### Checklist

- [ ] I updated the JSON data in `_data/simple-icons.json`
- [ ] I optimized the icon with SVGO or SVGOMG
- [ ] The SVG `viewbox` is `0 0 24 24`

### Description

This project rejected requests for the LEGO logo:

- #5823
- #3674

So it's probably a good idea to add LEGO to the list of forbidden brands, to prevent another duplicate issue down the line.