### PR TITLE
No additional labeling nor project assigning for release pull requests

### DIFF
--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -66,7 +66,9 @@ jobs:
         uses: srggrs/assign-one-project-github-action@1.3.1
         env:
           MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        if: contains(steps.get-labels.outputs.labels, 'update icon/data')
+        if: |
+          contains(steps.get-labels.outputs.labels, 'update icon/data') &&
+          contains(steps.get-labels.outputs.labels, 'release') == false
         with:
           project: https://github.com/orgs/simple-icons/projects/2
           column_name: Priority 1
@@ -81,7 +83,8 @@ jobs:
         if: |
           contains(steps.get-labels.outputs.labels, 'new icon') &&
           join(steps.get-linked-issues.outputs.issues) != '' &&
-          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == false
+          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == false &&
+          contains(steps.get-labels.outputs.labels, 'release') == false
         with:
           project: https://github.com/orgs/simple-icons/projects/2
           column_name: Priority 2
@@ -96,7 +99,8 @@ jobs:
         if: |
           contains(steps.get-labels.outputs.labels, 'new icon') &&
           join(steps.get-linked-issues.outputs.issues) != '' &&
-          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == true
+          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == true &&
+          contains(steps.get-labels.outputs.labels, 'release') == false
         with:
           project: https://github.com/orgs/simple-icons/projects/2
           column_name: Priority 3
@@ -111,7 +115,8 @@ jobs:
         if: |
           contains(steps.get-labels.outputs.labels, 'new icon') &&
           join(steps.get-linked-issues.outputs.issues) == '' &&
-          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == true
+          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == true &&
+          contains(steps.get-labels.outputs.labels, 'release') == false
         with:
           project: https://github.com/orgs/simple-icons/projects/2
           column_name: Priority 4

--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -6,7 +6,9 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
-    if: github.event.action == 'opened'
+    if: |
+      github.event.action == 'opened' &&
+      github.event.pull_request.base.ref != 'master'
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token
@@ -20,7 +22,9 @@ jobs:
   assign-to-project:
     runs-on: ubuntu-latest
     name: Assign to Project
-    if: github.event.action == 'opened'
+    if: |
+      github.event.action == 'opened' &&
+      github.event.pull_request.base.ref != 'master'
     needs: triage
     steps:
       - uses: actions/create-github-app-token@v1
@@ -66,9 +70,7 @@ jobs:
         uses: srggrs/assign-one-project-github-action@1.3.1
         env:
           MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        if: |
-          contains(steps.get-labels.outputs.labels, 'update icon/data') &&
-          contains(steps.get-labels.outputs.labels, 'release') == false
+        if: contains(steps.get-labels.outputs.labels, 'update icon/data')
         with:
           project: https://github.com/orgs/simple-icons/projects/2
           column_name: Priority 1
@@ -83,8 +85,7 @@ jobs:
         if: |
           contains(steps.get-labels.outputs.labels, 'new icon') &&
           join(steps.get-linked-issues.outputs.issues) != '' &&
-          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == false &&
-          contains(steps.get-labels.outputs.labels, 'release') == false
+          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == false
         with:
           project: https://github.com/orgs/simple-icons/projects/2
           column_name: Priority 2
@@ -99,8 +100,7 @@ jobs:
         if: |
           contains(steps.get-labels.outputs.labels, 'new icon') &&
           join(steps.get-linked-issues.outputs.issues) != '' &&
-          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == true &&
-          contains(steps.get-labels.outputs.labels, 'release') == false
+          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == true
         with:
           project: https://github.com/orgs/simple-icons/projects/2
           column_name: Priority 3
@@ -115,8 +115,7 @@ jobs:
         if: |
           contains(steps.get-labels.outputs.labels, 'new icon') &&
           join(steps.get-linked-issues.outputs.issues) == '' &&
-          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == true &&
-          contains(steps.get-labels.outputs.labels, 'release') == false
+          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == true
         with:
           project: https://github.com/orgs/simple-icons/projects/2
           column_name: Priority 4
@@ -139,7 +138,8 @@ jobs:
     name: Unassign from Project
     if: |
       github.event.action != 'opened' &&
-      github.event.pull_request.merged == false
+      github.event.pull_request.merged == false &&
+      github.event.pull_request.base.ref != 'master'
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token


### PR DESCRIPTION
We started adding https://github.com/simple-icons/simple-icons/labels/new%20icon and https://github.com/simple-icons/simple-icons/labels/update%20icon%2Fdata labels to release pull requests in #10785 (see [here](https://github.com/simple-icons/simple-icons/issues?q=label%3Arelease+is%3Aclosed)). After some digging, I think that the change was introduced by #10726, but I'm not sure.

Anyways, if we're targetting `master` base ref we don't need to assign to a project nor add labels to that pull request because we can assume that is a special pull request.

When this PR is merged I'll remove those labels of the release pull requests for previous releases.