### PR TITLE
Add PlayStation Portable icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -11797,6 +11797,16 @@
             "source": "https://www.playstation.com/en-us/ps5/"
         },
         {
+            "title": "PlayStation Portable",
+            "aliases": {
+                "aka": [
+                    "PSP"
+                ]
+            },
+            "hex": "003791",
+            "source": "https://commons.wikimedia.org/wiki/File:PSP_Logo.svg"
+        },
+        {
             "title": "PlayStation Vita",
             "hex": "003791",
             "source": "https://commons.wikimedia.org/wiki/File:PlayStation_Vita_logo.svg"

--- a/icons/playstationportable.svg
+++ b/icons/playstationportable.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>PlayStation Portable</title><path d="M0 9.93v.296h7.182v1.626H.001v2.217h.295v-1.921h7.182V9.93zm11.29 0v3.844H7.478v.296h4.124v-3.844h3.813V9.93zm5.233 0v.296h7.182v1.626h-7.182v2.217h.296v-1.921H24V9.93z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://wasm.simpleicons.org/preview
-->

![playstationportable-preview](https://github.com/simple-icons/simple-icons/assets/57289288/81f61efb-144d-4efa-8a07-25c8b3f1895a)


**Issue:** closes #11363 

**Popularity metric:**

<!--
Regardless of whether or not the linked issue (if there is one) has a metric, please include the metric here for PR reviewers to validate. See our contributing guidelines at https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#assessing-popularity for more details on how we assess a brand's popularity.
-->

All the other PlayStation logos have already been added so we might as well complete the set.

### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description

<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
  - The Hex value is the same as all the other PlayStation logos
  - The Vector I used is the one present on Wikimedia Commons
  - I added a PSP alias for easier searchability