### PR TITLE
Add Replicate icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -12998,6 +12998,11 @@
             "source": "https://seeklogo.com/vector-logo/184137/renren-inc"
         },
         {
+            "title": "Replicate",
+            "hex": "141414",
+            "source": "https://replicate.com"
+        },
+        {
             "title": "Replit",
             "hex": "F26207",
             "source": "https://repl.it"

--- a/icons/replicate.svg
+++ b/icons/replicate.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Replicate</title><path d="M1.063 0v24h3.026V2.702h18.848V0zm5.713 5.124V24h3.028V7.825h13.133V5.124zm5.712 5.106V24h3.029V12.947h7.42V10.23z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://wasm.simpleicons.org/preview
-->

![replicate-preview](https://github.com/simple-icons/simple-icons/assets/57289288/8be892a5-5d0f-4a05-a54f-2af37a910f3e)

**Issue:** closes #10186

**Popularity metric:**

- Similarweb: [18,229](https://www.similarweb.com/website/replicate.com)

<!--
Regardless of whether or not the linked issue (if there is one) has a metric, please include the metric here for PR reviewers to validate. See our contributing guidelines at https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#assessing-popularity for more details on how we assess a brand's popularity.
-->

### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description

<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->

- The hex value `#141414` was chosen from one of the inline variants of the logo on the website: [https://replicate.com](https://replicate.com).
  Another potential hex to use is `#EA2804`, which is prominently used on their website.
- The vector is from the website header: https://replicate.com
- https://github.com/simple-icons/simple-icons/labels/permission%20required, from their [ToS](https://replicate.com/terms):
  > Our trademarks and trade dress may not be used in connection with any product or service without the prior written consent of Replicate.

  A usage request has been sent & is pending.
