### PR TITLE
Add 17TRACK Icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -31,6 +31,11 @@
             "source": "https://www.1001tracklists.com"
         },
         {
+            "title": "17TRACK",
+            "hex": "003A9B",
+            "source": "https://www.17track.net"
+        },
+        {
             "title": "1Panel",
             "hex": "0854C1",
             "source": "https://1panel.cn"

--- a/icons/17track.svg
+++ b/icons/17track.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>17TRACK</title><path d="M1.973 3.563 0 7.78h4.234v12.657h4.237V3.563H1.973zm7.91 0V7.78h7.906l-5.924 12.657H16.1L24 3.563H9.883zm12.705 8.45-3.943 8.425h3.943v-8.424z"/></svg>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f8c4e2d9-2a75-4e90-8d59-045f4a6ab4e2)

**Issue:** closes #

**Popularity metric:**

Global Rank: 2233

### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description

SVG and hex value `#003a9b` extracted from the website