### PR TITLE
Re-enable pull requests labeling

### DIFF
--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, closed]
 
 jobs:
-  triage:
+  add-labels:
     runs-on: ubuntu-latest
     if: |
       github.event.action == 'opened' &&
@@ -18,138 +18,139 @@ jobs:
       - uses: simple-icons/labeler@v1
         with:
           repo-token: ${{ steps.app-token.outputs.token }}
+# TODO: The next job has been temporarily disabled until the maintainers
+#       team decide to use projects board again.
+#  assign-to-project:
+#    runs-on: ubuntu-latest
+#    name: Assign to Project
+#    if: |
+#      github.event.action == 'opened' &&
+#      github.event.pull_request.base.ref != 'master'
+#    needs: add-labels
+#    steps:
+#      - uses: actions/create-github-app-token@v1
+#        id: app-token
+#        with:
+#          app-id: ${{ vars.BOT_APP_ID }}
+#          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
-  assign-to-project:
-    runs-on: ubuntu-latest
-    name: Assign to Project
-    if: |
-      github.event.action == 'opened' &&
-      github.event.pull_request.base.ref != 'master'
-    needs: triage
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.BOT_APP_ID }}
-          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+#      - name: Checkout
+#        uses: actions/checkout@v4
 
-      - name: Checkout
-        uses: actions/checkout@v4
+#      - id: get-labels
+#        uses: ./.github/actions/get-labels
+#        with:
+#          issue_number: ${{ github.event.pull_request.number }}
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: get-labels
-        uses: ./.github/actions/get-labels
-        with:
-          issue_number: ${{ github.event.pull_request.number }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+#      - id: get-si-members
+#        name: Get simple-icons members
+#        run: |
+#          members="$(curl -H 'Authorization: Bearer ${{ steps.app-token.outputs.token }}' --retry 5 -s https://api.github.com/orgs/simple-icons/members | jq .[].login | tr '\n' ',' | sed -e 's/"//g' -e 's/,$//')"
+#          echo "members=$members" >> $GITHUB_OUTPUT
 
-      - id: get-si-members
-        name: Get simple-icons members
-        run: |
-          members="$(curl -H 'Authorization: Bearer ${{ steps.app-token.outputs.token }}' --retry 5 -s https://api.github.com/orgs/simple-icons/members | jq .[].login | tr '\n' ',' | sed -e 's/"//g' -e 's/,$//')"
-          echo "members=$members" >> $GITHUB_OUTPUT
+#      - id: get-linked-issues
+#        name: Get linked issue numbers
+#        uses: mondeja/pr-linked-issues-action@v2
+#        with:
+#          # Lazy linked issues. If one of the lines of the pull request body
+#          # matches one of the next contents, the matching issue number will
+#          # be added to `issues` output:
+#          add_links_by_content: |
+#            **Issue:** #{issue_number}
+#            **Issue**: #{issue_number}
+#            **Close:** #{issue_number}
+#            **Close**: #{issue_number}
+#            **Closes:** #{issue_number}
+#            **Closes**: #{issue_number}
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: get-linked-issues
-        name: Get linked issue numbers
-        uses: mondeja/pr-linked-issues-action@v2
-        with:
-          # Lazy linked issues. If one of the lines of the pull request body
-          # matches one of the next contents, the matching issue number will
-          # be added to `issues` output:
-          add_links_by_content: |
-            **Issue:** #{issue_number}
-            **Issue**: #{issue_number}
-            **Close:** #{issue_number}
-            **Close**: #{issue_number}
-            **Closes:** #{issue_number}
-            **Closes**: #{issue_number}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      - id: priority-1
+#        name: Assign `update icon/data` pull requests to "Priority 1"
+#        uses: srggrs/assign-one-project-github-action@1.3.1
+#        env:
+#          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+#        if: contains(steps.get-labels.outputs.labels, 'update icon/data')
+#        with:
+#          project: https://github.com/orgs/simple-icons/projects/2
+#          column_name: Priority 1
 
-      - id: priority-1
-        name: Assign `update icon/data` pull requests to "Priority 1"
-        uses: srggrs/assign-one-project-github-action@1.3.1
-        env:
-          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        if: contains(steps.get-labels.outputs.labels, 'update icon/data')
-        with:
-          project: https://github.com/orgs/simple-icons/projects/2
-          column_name: Priority 1
+#      - id: priority-2
+#        name: Assign `new icon` pull requests to "Priority 2"
+#        uses: srggrs/assign-one-project-github-action@1.3.1
+#        env:
+#          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+#        # the PR has the `new icon` label along with a linked issue and
+#        # the opener is not a member of simple-icons organization
+#        if: |
+#          contains(steps.get-labels.outputs.labels, 'new icon') &&
+#          join(steps.get-linked-issues.outputs.issues) != '' &&
+#          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == false
+#        with:
+#          project: https://github.com/orgs/simple-icons/projects/2
+#          column_name: Priority 2
 
-      - id: priority-2
-        name: Assign `new icon` pull requests to "Priority 2"
-        uses: srggrs/assign-one-project-github-action@1.3.1
-        env:
-          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        # the PR has the `new icon` label along with a linked issue and
-        # the opener is not a member of simple-icons organization
-        if: |
-          contains(steps.get-labels.outputs.labels, 'new icon') &&
-          join(steps.get-linked-issues.outputs.issues) != '' &&
-          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == false
-        with:
-          project: https://github.com/orgs/simple-icons/projects/2
-          column_name: Priority 2
+#      - id: priority-3
+#        name: Assign `new icon` pull requests by maintainers to "Priority 3"
+#        uses: srggrs/assign-one-project-github-action@1.3.1
+#        env:
+#          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+#        # the PR has the `new icon` label along with a linked issue and
+#        # the opener is a member of the simple-icons organisation
+#        if: |
+#          contains(steps.get-labels.outputs.labels, 'new icon') &&
+#          join(steps.get-linked-issues.outputs.issues) != '' &&
+#          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == true
+#        with:
+#          project: https://github.com/orgs/simple-icons/projects/2
+#          column_name: Priority 3
 
-      - id: priority-3
-        name: Assign `new icon` pull requests by maintainers to "Priority 3"
-        uses: srggrs/assign-one-project-github-action@1.3.1
-        env:
-          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        # the PR has the `new icon` label along with a linked issue and
-        # the opener is a member of the simple-icons organisation
-        if: |
-          contains(steps.get-labels.outputs.labels, 'new icon') &&
-          join(steps.get-linked-issues.outputs.issues) != '' &&
-          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == true
-        with:
-          project: https://github.com/orgs/simple-icons/projects/2
-          column_name: Priority 3
+#      - id: priority-4
+#        name: Assign `new icon` pull requests by maintainers without an issue to "Priority 4"
+#        uses: srggrs/assign-one-project-github-action@1.3.1
+#        env:
+#          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+#        # the PR has the `new icon` label but with no linked issue and
+#        # the opener is a member of the simple-icons organisation
+#        if: |
+#          contains(steps.get-labels.outputs.labels, 'new icon') &&
+#          join(steps.get-linked-issues.outputs.issues) == '' &&
+#          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == true
+#        with:
+#          project: https://github.com/orgs/simple-icons/projects/2
+#          column_name: Priority 4
 
-      - id: priority-4
-        name: Assign `new icon` pull requests by maintainers without an issue to "Priority 4"
-        uses: srggrs/assign-one-project-github-action@1.3.1
-        env:
-          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        # the PR has the `new icon` label but with no linked issue and
-        # the opener is a member of the simple-icons organisation
-        if: |
-          contains(steps.get-labels.outputs.labels, 'new icon') &&
-          join(steps.get-linked-issues.outputs.issues) == '' &&
-          contains(steps.get-si-members.outputs.members, github.event.pull_request.user.login) == true
-        with:
-          project: https://github.com/orgs/simple-icons/projects/2
-          column_name: Priority 4
+#      - name: Assign pull requests to "Unprioritised"
+#        uses: srggrs/assign-one-project-github-action@1.3.1
+#        env:
+#          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+#        if: |
+#          steps.priority-1.conclusion == 'skipped' &&
+#          steps.priority-2.conclusion == 'skipped' &&
+#          steps.priority-3.conclusion == 'skipped' &&
+#          steps.priority-4.conclusion == 'skipped'
+#        with:
+#          project: https://github.com/orgs/simple-icons/projects/2
+#          column_name: Unprioritised
 
-      - name: Assign pull requests to "Unprioritised"
-        uses: srggrs/assign-one-project-github-action@1.3.1
-        env:
-          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        if: |
-          steps.priority-1.conclusion == 'skipped' &&
-          steps.priority-2.conclusion == 'skipped' &&
-          steps.priority-3.conclusion == 'skipped' &&
-          steps.priority-4.conclusion == 'skipped'
-        with:
-          project: https://github.com/orgs/simple-icons/projects/2
-          column_name: Unprioritised
-
-  unassign-from-project:
-    runs-on: ubuntu-latest
-    name: Unassign from Project
-    if: |
-      github.event.action != 'opened' &&
-      github.event.pull_request.merged == false &&
-      github.event.pull_request.base.ref != 'master'
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.BOT_APP_ID }}
-          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
-      - name: Assign closed pull requests to "Completed or Abandoned"
-        uses: srggrs/assign-one-project-github-action@1.3.1
-        env:
-          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        with:
-          project: https://github.com/orgs/simple-icons/projects/2
-          column_name: Completed or Abandoned
+#  unassign-from-project:
+#    runs-on: ubuntu-latest
+#    name: Unassign from Project
+#    if: |
+#      github.event.action != 'opened' &&
+#      github.event.pull_request.merged == false &&
+#      github.event.pull_request.base.ref != 'master'
+#    steps:
+#      - uses: actions/create-github-app-token@v1
+#        id: app-token
+#        with:
+#          app-id: ${{ vars.BOT_APP_ID }}
+#          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+#      - name: Assign closed pull requests to "Completed or Abandoned"
+#        uses: srggrs/assign-one-project-github-action@1.3.1
+#        env:
+#          MY_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+#        with:
+#          project: https://github.com/orgs/simple-icons/projects/2
+#          column_name: Completed or Abandoned


### PR DESCRIPTION
Just add the labels but don't categorize pull requests in projects. After this we can reenable the `add-labels-priority` workflow.