### PR TITLE
Move GitHub URLs linting from JSONSchema to our lint

### DIFF
--- a/.jsonschema.json
+++ b/.jsonschema.json
@@ -678,16 +678,7 @@
     "sourceUrl": {
       "$id": "#sourceUrl",
       "description": "URL for icon source. If is a GitHub URL, is validated to contain a commit hash, to be an issue comment or to be a GitHub organization URL",
-      "type": "string",
-      "if": {
-        "pattern": "^https://github\\.com/(?!(features/actions)|(sponsors)|(logos)$)"
-      },
-      "then": {
-        "pattern": "^https://github\\.com/[^/]+/[^/]+/(blob/[a-f\\d]{40}/[^\\s]+)|(tree/[a-f\\d]{40}(/[^\\s]+)?)|(((issues)|(pull)|(discussions))/\\d+#((issuecomment)|(discussioncomment))-\\d+)$"
-      },
-      "else": {
-        "$ref": "#/definitions/url"
-      }
+      "$ref": "#/definitions/url"
     },
     "url": {
       "$id": "#url",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -571,7 +571,7 @@
             "title": "Alby",
             "hex": "FFDF6F",
             "source": "https://github.com/getAlby/media/blob/c24fee4a3f76d6cd000343a972f10590d3913b25/Alby-logo-icons/Alby-logo-head/alby.svg",
-            "guidelines": "https://github.com/getAlby/lightning-browser-extension/wiki/Open-Design"
+            "guidelines": "https://github.com/getAlby/lightning-browser-extension/wiki/Open-Design/9e8ebe4d3e7707742d227554c4ee27b29983a1b6"
         },
         {
             "title": "Alchemy",


### PR DESCRIPTION
From the comment https://github.com/simple-icons/simple-icons/pull/11785#pullrequestreview-2310947947

> Probably it would be worth to migrate the Github URLs checking of JSONSchema to our linting script.

That's what this PR does. It has catched a non handled case: wiki files.