### PR TITLE
Minify `_data/simple-icons.json` on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,8 @@ jobs:
         run: node scripts/release/reformat-markdown.js "${{ steps.get-version.outputs.version }}"
       - name: Update SDK Typescript definitions
         run: node scripts/release/update-sdk-ts-defs.js
+      - name: Minify icons data file
+        run: node scripts/release/minify-icons-data.js
       - name: Build NodeJS package
         run: npm run build
       - name: Deploy to NPM

--- a/scripts/release/minify-icons-data.js
+++ b/scripts/release/minify-icons-data.js
@@ -1,0 +1,9 @@
+/**
+ * @file
+ * Minify _data/simple-icons.json file.
+ */
+import {getIconsData} from '../../sdk.mjs';
+import {writeIconsData} from '../utils.js';
+
+const icons = await getIconsData();
+await writeIconsData({icons}, undefined, true);

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -32,14 +32,16 @@ export const getJsonSchemaData = async (
  * Write icons data to _data/simple-icons.json.
  * @param {{icons: IconData[]}} iconsData Icons data object.
  * @param {string} rootDirectory Path to the root directory of the project.
+ * @param {boolean} minify Whether to minify the JSON output.
  */
 export const writeIconsData = async (
   iconsData,
   rootDirectory = path.resolve(__dirname, '..'),
+  minify,
 ) => {
   await fs.writeFile(
     getIconDataPath(rootDirectory),
-    `${JSON.stringify(iconsData, null, 4)}\n`,
+    `${JSON.stringify(iconsData, null, minify ? 0 : 4)}\n`,
     'utf8',
   );
 };


### PR DESCRIPTION
Related to #11741

This added two functions, `minifyIconsData` and `reformatIconsData`, to the distributing process.

I kept the file location the same due to https://github.com/simple-icons/simple-icons/issues/11741#issuecomment-2384129213.

I also added a new environment variable `SI_ENV=distribution` to the `publish.yml` action as an actual distribution. This is useful for our developer running `npm run build` locally. It can avoid generating diffs in our local.

I didn't use `NODE_ENV=distribution` because other packages may use this variable to determine whether it's CI or production. We'd better not to overwrite it.

The `SI_ENV=distribution` is not in `verify.yml` because there is a `npm run lint` after the `npm run build`. If we add it, a linter error will occur.

### Update

I change its logic to the `scripts/release/minify-icons-data.js`.