### PR TITLE
Use lychee instead of markdown-link-check on CI

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -1,7 +1,0 @@
-{
-  "ignorePatterns": [
-    {
-      "pattern": "^https://www.similarweb.com"
-    }
-  ]
-}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -58,11 +58,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check documentation links
         if: steps.changes.outputs.docs == true
-        run: |
-          npx markdown-link-check --retry \
-            --config .github/markdown-link-check.json \
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --exclude ^https://www.similarweb.com -- \
             ${{ steps.changes.outputs.docs_files }}
-        continue-on-error: ${{ github.ref == 'refs/heads/develop' }}
+          fail: ${{ github.ref != 'refs/heads/develop' }}
+          jobSummary: true
+          format: markdown
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify file permissions
         run: |
           CHECK_DIRS="icons/ _data/"

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "husky": "9.0.11",
     "inquirer-autocomplete-standalone": "0.8.1",
     "jsonschema": "1.4.1",
-    "markdown-link-check": "3.12.1",
     "mocha": "10.4.0",
     "named-html-entities-json": "1.0.0",
     "spdx-license-ids": "3.0.20",


### PR DESCRIPTION
Just use lychee instead of markdown-link-check on CI. See a comparsion between both tools: https://github.com/lycheeverse/lychee?tab=readme-ov-file#features