### PR TITLE
Fix changed documentation files not detected on CI

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -57,7 +57,7 @@ jobs:
           # Authorise GitHub API requests for editorconfig-checker
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check documentation links
-        if: steps.changes.outputs.docs == true
+        if: steps.changes.outputs.docs == 'true'
         uses: lycheeverse/lychee-action@v2
         with:
           args: --exclude ^https://www.similarweb.com -- \


### PR DESCRIPTION
Changed documentation files are not detected on CI. See https://github.com/simple-icons/simple-icons/actions/runs/11313905041/job/31466507743?pr=12003 as example.

Used syntax of the example that the action recommends, see https://github.com/dorny/paths-filter?tab=readme-ov-file#example