### PR TITLE
Don't use newlines in lychee action args

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -60,8 +60,7 @@ jobs:
         if: steps.changes.outputs.docs == 'true'
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --exclude ^https://www.similarweb.com -- \
-            ${{ steps.changes.outputs.docs_files }}
+          args: --exclude ^https://www.similarweb.com -- ${{ steps.changes.outputs.docs_files }}
           fail: ${{ github.ref != 'refs/heads/develop' }}
           jobSummary: true
           format: markdown


### PR DESCRIPTION
Fixes https://github.com/simple-icons/simple-icons/actions/runs/11316134771/job/31468108639?pr=12003#step:7:90 This problem is blocking #12003

lychee-action internally does:

```bash
eval lychee --format markdown --output /tmp/tmp.7D7CX9kOsg --exclude '^https://www.similarweb.com/' -- '\' README.md
```

which is evaluated to:

```bash
lychee --format markdown --output /tmp/tmp.7D7CX9kOsg --exclude '^https://www.similarweb.com/' -- ' README.md'
```

The problem is in the `' README.md'` argument. Can be locally reproduced with just:

```bash
lychee ' README.md'
```