### PR TITLE
Use lychee config file

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.changes.outputs.docs == 'true'
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --exclude ^https://www.similarweb.com -- ${{ steps.changes.outputs.docs_files }}
+          args: -- ${{ steps.changes.outputs.docs_files }}
           fail: ${{ github.ref != 'refs/heads/develop' }}
           jobSummary: true
           format: markdown

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,1 @@
+exclude = ['^https://www\.similarweb\.com', '^https://www\.figma\.com/community/plugin']

--- a/sdk.d.ts
+++ b/sdk.d.ts
@@ -2,7 +2,7 @@
  * @file
  * Types for Simple Icons SDK.
  */
-
+// eslint-disable-next-line n/file-extension-in-import
 import type {CustomLicense, SPDXLicense} from './types';
 
 /**

--- a/sdk.d.ts
+++ b/sdk.d.ts
@@ -2,7 +2,7 @@
  * @file
  * Types for Simple Icons SDK.
  */
-// eslint-disable-next-line n/file-extension-in-import
+
 import type {CustomLicense, SPDXLicense} from './types';
 
 /**


### PR DESCRIPTION
This moved lychee args to the `lychee.toml`. This also allows users to use the configuration while runnig `lychee` on local.

I also added the `^https://www.figma.com/community/plugin` pattern to fix the error in #12003.

The `curl -I https://www.figma.com/community/plugin/1149614463603005908` will get a 403 response. This may be because Figma rejects requests with unknown user-agents.