### PR TITLE
Add Wasm alias for WebAssembly

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -17266,7 +17266,7 @@
                 "aka": [
                     "Wasm"
                 ]
-            },
+            }
         },
         {
             "title": "WebAuthn",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -17261,7 +17261,12 @@
         {
             "title": "WebAssembly",
             "hex": "654FF0",
-            "source": "https://webassembly.org"
+            "source": "https://webassembly.org",
+            "aliases": {
+                "aka": [
+                    "Wasm"
+                ]
+            },
         },
         {
             "title": "WebAuthn",


### PR DESCRIPTION
Adds the common abbreviation for the format as an alias. The abbreviation is even officially listed on https://webassembly.org/.