### PR TITLE
Normalize automatic commit messages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,6 @@
   // We manually update digest dependencies (eg. hashes in GitHub Actions)
   digest: {enabled: false},
 
-  // We use a custom PR title
+  // PR title and commit message when updating dependencies
   commitMessage: 'Update dependencies',
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,4 +18,7 @@
 
   // We manually update digest dependencies (eg. hashes in GitHub Actions)
   digest: {enabled: false},
+
+  // We use a custom PR title
+  commitMessage: 'Update dependencies',
 }

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Commit version bump
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: version bump
+          commit_message: Bump version
           commit_user_name: 'simple-icons[bot]'
           commit_user_email: 'simple-icons[bot]@users.noreply.github.com'
           commit_author: 'simple-icons[bot] <simple-icons[bot]@users.noreply.github.com>'


### PR DESCRIPTION
The commit message generated when we create a release is lowercased, when all others commits usually are capitalized. So changed "version bump" by "Bump version".

![image](https://github.com/user-attachments/assets/9047fc6b-a757-4c1d-b485-c126fbe96c4c)

PRs of dependency updates are created with an angular-styled title (eg. see #12094). So changed by "Update dependencies". See https://docs.renovatebot.com/configuration-options/#commitmessage
