### PR TITLE
Add Cloudfanatic icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -3214,6 +3214,11 @@
             "source": "https://www.cloudera.com"
         },
         {
+            "title": "Cloudfanatic",
+            "hex": "0A185F",
+            "source": "https://cloudfanatic.net"
+        },
+        {
             "title": "Cloudflare",
             "hex": "F38020",
             "source": "https://www.cloudflare.com/logo/",

--- a/icons/cloudfanatic.svg
+++ b/icons/cloudfanatic.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Cloudfanatic</title><path d="m.1 16.1 12.7.027.035 2.92-12.7.053zm.047-5.54h18.2v2.93l-18.2.06zM0 4.92l24-.018v3.22L.1 8.105z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Cloudfanatic</title><path d="M0 4v4h24V4zm0 6v4h18v-4zm0 6v4h14v-4z"/></svg>

--- a/icons/cloudfanatic.svg
+++ b/icons/cloudfanatic.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Cloudfanatic</title><path d="m.1 16.1 12.7.027.035 2.92-12.7.053zm.047-5.54h18.2v2.93l-18.2.06zM0 4.92l24-.018v3.22L.1 8.105z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://wasm.simpleicons.org/preview
-->

**Issue:** N/A

**Popularity metric:** **Low** (954,652 globally, 362,283 USA)

<!--
Regardless of whether or not the linked issue (if there is one) has a metric, please include the metric here for PR reviewers to validate. See our contributing guidelines at https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#assessing-popularity for more details on how we assess a brand's popularity.
-->

### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description

This icon was taken from the now archived aegis-icons repository. Color hex value matches color scheme used on their website. Image was cleaned up using Inkscape to meet requirements.

Wanting to add this icon since it was in the [aegis-icons](https://github.com/aegis-icons/aegis-icons) repo, but needed to use this repo for more icon sets for use with the [Aegis Authenticator](https://github.com/beemdevelopment/Aegis) and this repo is an upstream for the [aegis-simple-icons](https://github.com/alexbakker/aegis-simple-icons) repo.

It may be worth considering adding any missing icons between this and aegis-icons so things are in parity, but I cannot vouch for the popularity metric which is a weird way to justify something as websites can swing several 100k month over month.
