### PR TITLE
Don't edit `slugs.md` in pull requests

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -42,11 +42,20 @@ jobs:
           list-files: shell
           filters: |
             docs:
-              - '*.md'
+              - '*!(slugs).md'
               - '.github/**.md'
             icons:
               - 'icons/*.svg'
+            slugs:
+              - 'slugs.md'
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Don't edit slugs.md in pull requests
+        if: github.event_name == 'pull_request' && steps.changes.outputs.slugs == 'true'
+        run: |
+          echo -ne "Detected slugs.md file edition in PR.\n" 1>&2
+          echo -ne "Please revert it, we build the slugs.md" 1>&2
+          echo -ne " file automatically at releases.\n" 1>&2
+          exit 1
       - name: Install dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Run linter

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,7 +50,10 @@ jobs:
               - 'slugs.md'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Don't edit slugs.md in pull requests
-        if: github.event_name == 'pull_request' && steps.changes.outputs.slugs == 'true'
+        if: |
+          github.base_ref != 'refs/heads/master' &&
+          github.event_name == 'pull_request' &&
+          steps.changes.outputs.slugs == 'true'
         run: |
           echo -ne "Detected slugs.md file edition in PR.\n" 1>&2
           echo -ne "Please revert it, we build the slugs.md" 1>&2

--- a/slugs.md
+++ b/slugs.md
@@ -7,7 +7,7 @@ update the script at 'scripts/release/update-slugs-table.js'.
 
 | Brand name | Brand slug |
 | :--- | :--- |
-| `.ENV` | `dotenv` |
+| `.ENV` | `foo` |
 | `.NET` | `dotnet` |
 | `/e/` | `e` |
 | `1.1.1.1` | `1dot1dot1dot1` |

--- a/slugs.md
+++ b/slugs.md
@@ -7,7 +7,7 @@ update the script at 'scripts/release/update-slugs-table.js'.
 
 | Brand name | Brand slug |
 | :--- | :--- |
-| `.ENV` | `foo` |
+| `.ENV` | `dotenv` |
 | `.NET` | `dotnet` |
 | `/e/` | `e` |
 | `1.1.1.1` | `1dot1dot1dot1` |


### PR DESCRIPTION
Explicitcly forbidden editing *slugs.md* on pull requests. Potentially prevents unneeded reviews like https://github.com/simple-icons/simple-icons/pull/12115#pullrequestreview-2418724477