### PR TITLE
Make single `aka`s and `old`s render in one line on data-file

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -5,9 +5,7 @@
             "hex": "ECD53F",
             "source": "https://github.com/motdotla/dotenv/blob/40e75440337d1de2345dc8326d6108331f583fd8/dotenv.svg",
             "aliases": {
-                "aka": [
-                    "Dotenv"
-                ]
+                "aka": ["Dotenv"]
             }
         },
         {
@@ -371,9 +369,7 @@
         {
             "title": "AEW",
             "aliases": {
-                "aka": [
-                    "All Elite Wrestling"
-                ]
+                "aka": ["All Elite Wrestling"]
             },
             "hex": "000000",
             "source": "https://commons.wikimedia.org/wiki/File:AEW_Logo_(simplified).svg"
@@ -424,9 +420,7 @@
             "hex": "7F2B7B",
             "source": "https://aib.ie",
             "aliases": {
-                "aka": [
-                    "Allied Irish Banks"
-                ]
+                "aka": ["Allied Irish Banks"]
             }
         },
         {
@@ -711,9 +705,7 @@
             "source": "https://aws.amazon.com/architecture/icons",
             "guidelines": "https://aws.amazon.com/architecture/icons",
             "aliases": {
-                "aka": [
-                    "AWS API Gateway"
-                ]
+                "aka": ["AWS API Gateway"]
             }
         },
         {
@@ -722,9 +714,7 @@
             "source": "https://aws.amazon.com/architecture/icons",
             "guidelines": "https://aws.amazon.com/architecture/icons",
             "aliases": {
-                "aka": [
-                    "AWS CloudWatch"
-                ]
+                "aka": ["AWS CloudWatch"]
             }
         },
         {
@@ -733,9 +723,7 @@
             "source": "https://aws.amazon.com/architecture/icons",
             "guidelines": "https://aws.amazon.com/architecture/icons",
             "aliases": {
-                "aka": [
-                    "AWS Cognito"
-                ]
+                "aka": ["AWS Cognito"]
             }
         },
         {
@@ -744,9 +732,7 @@
             "source": "https://aws.amazon.com/architecture/icons",
             "guidelines": "https://aws.amazon.com/architecture/icons",
             "aliases": {
-                "aka": [
-                    "AWS DocumentDB"
-                ]
+                "aka": ["AWS DocumentDB"]
             }
         },
         {
@@ -755,9 +741,7 @@
             "source": "https://aws.amazon.com/architecture/icons",
             "guidelines": "https://aws.amazon.com/architecture/icons",
             "aliases": {
-                "aka": [
-                    "AWS DynamoDB"
-                ]
+                "aka": ["AWS DynamoDB"]
             }
         },
         {
@@ -805,9 +789,7 @@
             "source": "https://aws.amazon.com/architecture/icons",
             "guidelines": "https://aws.amazon.com/architecture/icons",
             "aliases": {
-                "aka": [
-                    "AWS ElastiCache"
-                ]
+                "aka": ["AWS ElastiCache"]
             }
         },
         {
@@ -860,9 +842,7 @@
             "source": "https://aws.amazon.com/architecture/icons",
             "guidelines": "https://aws.amazon.com/architecture/icons",
             "aliases": {
-                "aka": [
-                    "AWS RDS"
-                ]
+                "aka": ["AWS RDS"]
             }
         },
         {
@@ -877,9 +857,7 @@
             "source": "https://aws.amazon.com/architecture/icons/",
             "guidelines": "https://aws.amazon.com/architecture/icons/",
             "aliases": {
-                "aka": [
-                    "AWS Route53"
-                ]
+                "aka": ["AWS Route53"]
             }
         },
         {
@@ -888,9 +866,7 @@
             "source": "https://aws.amazon.com/architecture/icons",
             "guidelines": "https://aws.amazon.com/architecture/icons",
             "aliases": {
-                "aka": [
-                    "AWS S3"
-                ]
+                "aka": ["AWS S3"]
             }
         },
         {
@@ -899,9 +875,7 @@
             "source": "https://aws.amazon.com/architecture/icons",
             "guidelines": "https://aws.amazon.com/architecture/icons",
             "aliases": {
-                "aka": [
-                    "AWS SES"
-                ]
+                "aka": ["AWS SES"]
             }
         },
         {
@@ -922,9 +896,7 @@
             "hex": "232F3E",
             "source": "https://commons.wikimedia.org/wiki/File:Amazon_Web_Services_Logo.svg",
             "aliases": {
-                "aka": [
-                    "AWS"
-                ]
+                "aka": ["AWS"]
             }
         },
         {
@@ -1882,9 +1854,7 @@
             "source": "https://aws.amazon.com/architecture/icons",
             "guidelines": "https://aws.amazon.com/architecture/icons",
             "aliases": {
-                "aka": [
-                    "Amazon Secrets Manager"
-                ]
+                "aka": ["Amazon Secrets Manager"]
             }
         },
         {
@@ -2017,9 +1987,7 @@
             "hex": "80247B",
             "source": "https://brave.com/media-assets",
             "aliases": {
-                "aka": [
-                    "BAT"
-                ]
+                "aka": ["BAT"]
             }
         },
         {
@@ -2027,9 +1995,7 @@
             "hex": "00A4FF",
             "source": "https://github.com/pocketnetteam/pocketnet.gui/blob/978201dca0d63bc87c4c66513a67f085f2f51d83/img/logo.svg",
             "aliases": {
-                "aka": [
-                    "pocketnet"
-                ]
+                "aka": ["pocketnet"]
             }
         },
         {
@@ -2188,9 +2154,7 @@
             "hex": "60A5FA",
             "source": "https://github.com/biomejs/resources/blob/551f36498dfe34b24bc7755fcdd0fa501b757cf4/svg/icon-light-mono.svg",
             "aliases": {
-                "old": [
-                    "Rome"
-                ]
+                "old": ["Rome"]
             }
         },
         {
@@ -2318,9 +2282,7 @@
             "hex": "0285FF",
             "source": "https://github.com/FortAwesome/Font-Awesome/issues/19810#issuecomment-1854999604",
             "aliases": {
-                "aka": [
-                    "bsky"
-                ]
+                "aka": ["bsky"]
             }
         },
         {
@@ -2658,9 +2620,7 @@
             "hex": "F0D722",
             "source": "https://www.bvg.de",
             "aliases": {
-                "aka": [
-                    "Berliner Verkehrsbetriebe"
-                ]
+                "aka": ["Berliner Verkehrsbetriebe"]
             }
         },
         {
@@ -2849,9 +2809,7 @@
             "hex": "E60505",
             "source": "https://www.cbc.ca",
             "aliases": {
-                "aka": [
-                    "Canadian Broadcasting Company"
-                ],
+                "aka": ["Canadian Broadcasting Company"],
                 "dup": [
                     {
                         "title": "Radio Canada",
@@ -3056,9 +3014,7 @@
             "hex": "999999",
             "source": "https://www.google.com/intl/en_us/chromecast/built-in/",
             "aliases": {
-                "aka": [
-                    "Google Cast"
-                ]
+                "aka": ["Google Cast"]
             }
         },
         {
@@ -3403,9 +3359,7 @@
             "hex": "09B6A2",
             "source": "https://github.com/Exafunction/codeium.vim/blob/e03c410a7673dbbe7f64afbc9a08f423363ded81/codeium-simple-logo.svg",
             "aliases": {
-                "aka": [
-                    "Exafunction"
-                ]
+                "aka": ["Exafunction"]
             }
         },
         {
@@ -3874,9 +3828,7 @@
             "hex": "E53236",
             "source": "https://commons.wikimedia.org/wiki/File:Logo_Compagnie_des_transports_strasbourgeois.svg",
             "aliases": {
-                "aka": [
-                    "Compagnie des Transports Strasbourgeois"
-                ]
+                "aka": ["Compagnie des Transports Strasbourgeois"]
             }
         },
         {
@@ -4188,9 +4140,7 @@
             "hex": "0000FF",
             "source": "https://del.icio.us",
             "aliases": {
-                "aka": [
-                    "Delicious"
-                ]
+                "aka": ["Delicious"]
             }
         },
         {
@@ -4314,9 +4264,7 @@
             "hex": "F08705",
             "source": "https://github.com/jgraph/drawio/blob/4743eba8d5eaa497dc003df7bf7295b695c59bea/src/main/webapp/images/drawlogo.svg",
             "aliases": {
-                "aka": [
-                    "draw.io"
-                ]
+                "aka": ["draw.io"]
             }
         },
         {
@@ -4603,9 +4551,7 @@
             "source": "https://dnd.wizards.com/articles/features/basicrules",
             "guidelines": "https://dnd.wizards.com/articles/features/fan-site-kit",
             "aliases": {
-                "aka": [
-                    "D&D"
-                ]
+                "aka": ["D&D"]
             }
         },
         {
@@ -4632,9 +4578,7 @@
         {
             "title": "DVC",
             "aliases": {
-                "aka": [
-                    "Data Version Control"
-                ]
+                "aka": ["Data Version Control"]
             },
             "hex": "13ADC7",
             "source": "https://iterative.ai/brand/",
@@ -4660,9 +4604,7 @@
             "hex": "E73D2F",
             "source": "https://commons.wikimedia.org/wiki/File:E3_Logo.svg",
             "aliases": {
-                "aka": [
-                    "Electronic Entertainment Expo"
-                ]
+                "aka": ["Electronic Entertainment Expo"]
             }
         },
         {
@@ -4865,9 +4807,7 @@
             "hex": "222222",
             "source": "https://www.11ty.dev",
             "aliases": {
-                "aka": [
-                    "11ty"
-                ]
+                "aka": ["11ty"]
             }
         },
         {
@@ -5174,9 +5114,7 @@
             "source": "https://foundation.fsharp.org/logo",
             "guidelines": "https://foundation.fsharp.org/logo",
             "aliases": {
-                "aka": [
-                    "F sharp"
-                ]
+                "aka": ["F sharp"]
             }
         },
         {
@@ -5317,9 +5255,7 @@
                 "url": "https://www.fcc.gov/licensing"
             },
             "aliases": {
-                "aka": [
-                    "Federal Communications Commission"
-                ]
+                "aka": ["Federal Communications Commission"]
             }
         },
         {
@@ -5932,9 +5868,7 @@
             "hex": "E60012",
             "source": "https://www.gamedeveloper.com",
             "aliases": {
-                "aka": [
-                    "Gamasutra"
-                ]
+                "aka": ["Gamasutra"]
             }
         },
         {
@@ -6534,9 +6468,7 @@
             "hex": "8E75B2",
             "source": "https://gemini.google.com",
             "aliases": {
-                "old": [
-                    "Google Bard"
-                ]
+                "old": ["Google Bard"]
             }
         },
         {
@@ -6797,9 +6729,7 @@
             "hex": "F36633",
             "source": "https://www.gskbrandhub.com",
             "aliases": {
-                "aka": [
-                    "GlaxoSmithKline"
-                ]
+                "aka": ["GlaxoSmithKline"]
             }
         },
         {
@@ -6979,9 +6909,7 @@
             "hex": "000000",
             "source": "https://www.harmonyos.com",
             "aliases": {
-                "aka": [
-                    "HMOS"
-                ]
+                "aka": ["HMOS"]
             }
         },
         {
@@ -7037,9 +6965,7 @@
             "hex": "004B8D",
             "source": "https://www.hdfcsales.com",
             "aliases": {
-                "aka": [
-                    "HDB"
-                ]
+                "aka": ["HDB"]
             }
         },
         {
@@ -7165,9 +7091,7 @@
             "hex": "E42C51",
             "source": "https://www.hibob.com",
             "aliases": {
-                "aka": [
-                    "Bob"
-                ]
+                "aka": ["Bob"]
             }
         },
         {
@@ -7793,9 +7717,7 @@
             "source": "https://dfinity.frontify.com/d/pD7yZhsmpqos/internet-computer#/internet-computer/logo",
             "guidelines": "https://dfinity.frontify.com/d/pD7yZhsmpqos",
             "aliases": {
-                "aka": [
-                    "Internet Computer Protocol"
-                ]
+                "aka": ["Internet Computer Protocol"]
             }
         },
         {
@@ -7872,9 +7794,7 @@
             "hex": "468145",
             "source": "https://www.isc2.org",
             "aliases": {
-                "aka": [
-                    "(ISC)²"
-                ]
+                "aka": ["(ISC)²"]
             }
         },
         {
@@ -8219,9 +8139,7 @@
             "hex": "7D64FF",
             "source": "https://commons.wikimedia.org/wiki/File:K6-logo.svg",
             "aliases": {
-                "aka": [
-                    "Grafana k6"
-                ]
+                "aka": ["Grafana k6"]
             }
         },
         {
@@ -8404,9 +8322,7 @@
             "hex": "F40027",
             "source": "https://global.kfc.com/asset-library/",
             "aliases": {
-                "aka": [
-                    "Kentucky Fried Chicken"
-                ]
+                "aka": ["Kentucky Fried Chicken"]
             }
         },
         {
@@ -8457,9 +8373,7 @@
         {
             "title": "Kingston Technology",
             "aliases": {
-                "aka": [
-                    "Kingston"
-                ]
+                "aka": ["Kingston"]
             },
             "hex": "000000",
             "source": "https://www.kingston.com"
@@ -9866,9 +9780,7 @@
         {
             "title": "MG",
             "aliases": {
-                "aka": [
-                    "Morris Garages"
-                ]
+                "aka": ["Morris Garages"]
             },
             "hex": "FF0000",
             "source": "https://www.mg.co.uk/themes/custom/mg/assets/images/svg/mg-logo-desktop.svg",
@@ -10024,9 +9936,7 @@
             "hex": "041E42",
             "source": "https://www.mlb.com",
             "aliases": {
-                "aka": [
-                    "Major League Baseball"
-                ]
+                "aka": ["Major League Baseball"]
             }
         },
         {
@@ -10211,9 +10121,7 @@
         {
             "title": "MSI",
             "aliases": {
-                "aka": [
-                    "Micro-Star International"
-                ]
+                "aka": ["Micro-Star International"]
             },
             "hex": "FF0000",
             "source": "https://www.msi.com/page/brochure"
@@ -10241,9 +10149,7 @@
         {
             "title": "MUI",
             "aliases": {
-                "aka": [
-                    "Material-UI"
-                ]
+                "aka": ["Material-UI"]
             },
             "hex": "007FFF",
             "source": "https://github.com/mui-org/material-ui/blob/353cecb5391571163eb6bd8cbf36d2dd299aaf56/docs/src/icons/SvgMuiLogo.tsx"
@@ -10276,9 +10182,7 @@
             "hex": "C60D0D",
             "source": "https://www.makeuseof.com",
             "aliases": {
-                "aka": [
-                    "MakeUseOf"
-                ]
+                "aka": ["MakeUseOf"]
             }
         },
         {
@@ -10569,9 +10473,7 @@
             "hex": "FF160B",
             "source": "https://en.wikipedia.org/wiki/File:NJPW_World_Logo.svg",
             "aliases": {
-                "aka": [
-                    "NJPW"
-                ],
+                "aka": ["NJPW"],
                 "dup": [
                     {
                         "title": "NJPW World",
@@ -10684,9 +10586,7 @@
             "hex": "000000",
             "source": "https://www.nhl.com",
             "aliases": {
-                "aka": [
-                    "National Hockey League"
-                ]
+                "aka": ["National Hockey League"]
             }
         },
         {
@@ -10850,9 +10750,7 @@
             "hex": "01B0F0",
             "source": "https://github.com/idleberg/nsis-logo/blob/885ba2fd08a6ff450c6f7cbd675563b5df728d38/src/Logo/below%2024x24/mono-flat.svg",
             "aliases": {
-                "aka": [
-                    "Nullsoft Scriptable Install System"
-                ]
+                "aka": ["Nullsoft Scriptable Install System"]
             }
         },
         {
@@ -10985,9 +10883,7 @@
             "hex": "000000",
             "source": "https://render.otoy.com/forum/viewtopic.php?f=9&t=359",
             "aliases": {
-                "aka": [
-                    "otoy"
-                ]
+                "aka": ["otoy"]
             }
         },
         {
@@ -11124,9 +11020,7 @@
                 "type": "CC-BY-SA-4.0"
             },
             "aliases": {
-                "aka": [
-                    "OSHWA"
-                ]
+                "aka": ["OSHWA"]
             }
         },
         {
@@ -11268,9 +11162,7 @@
                 "type": "CC-BY-4.0"
             },
             "aliases": {
-                "aka": [
-                    "OTel"
-                ]
+                "aka": ["OTel"]
             }
         },
         {
@@ -11278,9 +11170,7 @@
             "hex": "000000",
             "source": "https://www.opentext.com",
             "aliases": {
-                "aka": [
-                    "Micro Focus"
-                ]
+                "aka": ["Micro Focus"]
             }
         },
         {
@@ -11404,9 +11294,7 @@
             "hex": "2CB9F1",
             "source": "https://github.com/CenterForOpenScience/osf.io/blob/de170682924278eba1db9d6e1c50166bf43700e0/website/static/img/circle_logo.png",
             "aliases": {
-                "aka": [
-                    "Open Science Framework"
-                ],
+                "aka": ["Open Science Framework"],
                 "dup": [
                     {
                         "title": "Center for Open Science",
@@ -12094,9 +11982,7 @@
         {
             "title": "PlayStation Portable",
             "aliases": {
-                "aka": [
-                    "PSP"
-                ]
+                "aka": ["PSP"]
             },
             "hex": "003791",
             "source": "https://commons.wikimedia.org/wiki/File:PSP_Logo.svg"
@@ -12241,9 +12127,7 @@
             "source": "https://www.polygon.technology",
             "guidelines": "https://polygon.technology/brandguidelines",
             "aliases": {
-                "aka": [
-                    "Matic"
-                ]
+                "aka": ["Matic"]
             }
         },
         {
@@ -12293,9 +12177,7 @@
             "source": "https://docs.posit.co",
             "guidelines": "https://posit.co/about/trademark-guidelines",
             "aliases": {
-                "old": [
-                    "RStudio"
-                ]
+                "old": ["RStudio"]
             }
         },
         {
@@ -12641,9 +12523,7 @@
             "source": "https://github.com/webmaxru/progressive-web-apps-logo/blob/77744cd5c0a4d484bb3d082c6ac458c44202da03/pwalogo-white.svg",
             "guidelines": "https://github.com/webmaxru/progressive-web-apps-logo#readme",
             "aliases": {
-                "aka": [
-                    "Progressive Web Application"
-                ]
+                "aka": ["Progressive Web Application"]
             }
         },
         {
@@ -12670,9 +12550,7 @@
             "hex": "3C2179",
             "source": "https://github.com/pyg-team/pyg_sphinx_theme/blob/4f696513b4b4adf2ba3874574a10a8e8718672fe/pyg_sphinx_theme/static/img/pyg_logo.svg",
             "aliases": {
-                "aka": [
-                    "PyTorch Geometric"
-                ]
+                "aka": ["PyTorch Geometric"]
             }
         },
         {
@@ -12796,9 +12674,7 @@
             "source": "https://marketing.qnap.com/resource/qnap-logo-k100",
             "guidelines": "https://marketing.qnap.com/resource/qnap-brand-logo-guideline",
             "aliases": {
-                "aka": [
-                    "Quality Network Appliance Provider"
-                ]
+                "aka": ["Quality Network Appliance Provider"]
             }
         },
         {
@@ -13397,9 +13273,7 @@
             "hex": "FF4655",
             "source": "https://app.revolt.chat/assets/badges/revolt_r.svg",
             "aliases": {
-                "aka": [
-                    "revolt"
-                ]
+                "aka": ["revolt"]
             }
         },
         {
@@ -13673,12 +13547,8 @@
             "hex": "36474F",
             "source": "https://www.rtm.fr",
             "aliases": {
-                "aka": [
-                    "Régie des Transports Métropolitains"
-                ],
-                "old": [
-                    "Régie des Transports de Marseille"
-                ]
+                "aka": ["Régie des Transports Métropolitains"],
+                "old": ["Régie des Transports de Marseille"]
             }
         },
         {
@@ -14381,9 +14251,7 @@
             "hex": "D23F31",
             "source": "https://b3log.org/brand-marking.html",
             "aliases": {
-                "aka": [
-                    "sy"
-                ],
+                "aka": ["sy"],
                 "loc": {
                     "zh-CN": "思源笔记",
                     "zh-HK": "思源筆記",
@@ -14531,9 +14399,7 @@
             "hex": "C33139",
             "source": "https://commons.wikimedia.org/wiki/File:Snapdragon_Logo.svg",
             "aliases": {
-                "aka": [
-                    "Qualcomm Snapdragon"
-                ]
+                "aka": ["Qualcomm Snapdragon"]
             }
         },
         {
@@ -14613,9 +14479,7 @@
             "hex": "149EF2",
             "source": "https://www.sololearn.com",
             "aliases": {
-                "aka": [
-                    "SoloLearn"
-                ]
+                "aka": ["SoloLearn"]
             }
         },
         {
@@ -14803,9 +14667,7 @@
             "title": "Sphere Online Judge",
             "slug": "spoj",
             "aliases": {
-                "aka": [
-                    "SPOJ"
-                ]
+                "aka": ["SPOJ"]
             },
             "hex": "337AB7",
             "source": "https://www.spoj.com"
@@ -15405,9 +15267,7 @@
             "hex": "68751C",
             "source": "https://github.com/swaywm/sway/blob/77b9ddabe2a97c5d04c30929b0f8cbde3470fdd7/assets/Sway_Tree.svg",
             "aliases": {
-                "aka": [
-                    "SwayWM"
-                ]
+                "aka": ["SwayWM"]
             }
         },
         {
@@ -15618,9 +15478,7 @@
             "hex": "EE3984",
             "source": "https://www.tcs.com",
             "aliases": {
-                "aka": [
-                    "TCS"
-                ]
+                "aka": ["TCS"]
             }
         },
         {
@@ -15779,9 +15637,7 @@
             "title": "Tether",
             "hex": "50AF95",
             "aliases": {
-                "aka": [
-                    "USDt"
-                ]
+                "aka": ["USDt"]
             },
             "source": "https://tether.to/branding/",
             "guidelines": "https://tether.to/branding/"
@@ -15796,9 +15652,7 @@
             "hex": "0014FF",
             "source": "https://thegameawards.com/about",
             "aliases": {
-                "aka": [
-                    "The Game Awards"
-                ]
+                "aka": ["The Game Awards"]
             }
         },
         {
@@ -15854,9 +15708,7 @@
         {
             "title": "The Movie Database",
             "aliases": {
-                "aka": [
-                    "TMDB"
-                ]
+                "aka": ["TMDB"]
             },
             "hex": "01B4E4",
             "source": "https://www.themoviedb.org/about/logos-attribution"
@@ -15896,9 +15748,7 @@
             "hex": "003399",
             "source": "https://weather.com",
             "aliases": {
-                "aka": [
-                    "weather.com"
-                ]
+                "aka": ["weather.com"]
             }
         },
         {
@@ -16280,9 +16130,7 @@
             "hex": "E61414",
             "source": "https://fite.tv",
             "aliases": {
-                "old": [
-                    "FITE"
-                ]
+                "old": ["FITE"]
             }
         },
         {
@@ -16573,9 +16421,7 @@
             "hex": "FABD14",
             "source": "https://www.uml.org",
             "aliases": {
-                "aka": [
-                    "Unified Modelling Language"
-                ]
+                "aka": ["Unified Modelling Language"]
             }
         },
         {
@@ -16647,9 +16493,7 @@
             "source": "https://unjs.io",
             "guidelines": "https://unjs.io/design-kit",
             "aliases": {
-                "aka": [
-                    "Unified JavaScript"
-                ]
+                "aka": ["Unified JavaScript"]
             }
         },
         {
@@ -16946,9 +16790,7 @@
         {
             "title": "VictoriaMetrics",
             "aliases": {
-                "aka": [
-                    "VM"
-                ],
+                "aka": ["VM"],
                 "loc": {
                     "ko-KR": "빅토리아메트릭스"
                 }
@@ -16982,9 +16824,7 @@
         {
             "title": "Virgin",
             "aliases": {
-                "aka": [
-                    "Virgin Group"
-                ]
+                "aka": ["Virgin Group"]
             },
             "hex": "E10A0A",
             "source": "https://www.virgin.com/img/virgin-logo-square.svg"
@@ -17328,9 +17168,7 @@
             "hex": "654FF0",
             "source": "https://webassembly.org",
             "aliases": {
-                "aka": [
-                    "Wasm"
-                ]
+                "aka": ["Wasm"]
             }
         },
         {
@@ -17448,9 +17286,7 @@
         {
             "title": "Welcome to the Jungle",
             "aliases": {
-                "aka": [
-                    "WTTJ"
-                ]
+                "aka": ["WTTJ"]
             },
             "hex": "FFCD00",
             "source": "https://www.welcometothejungle.com"
@@ -17473,9 +17309,7 @@
         {
             "title": "Western Digital",
             "aliases": {
-                "aka": [
-                    "WD"
-                ]
+                "aka": ["WD"]
             },
             "hex": "995DFF",
             "source": "https://www.westerndigital.com"
@@ -17720,9 +17554,7 @@
             "source": "https://x.com",
             "guidelines": "https://about.x.com/en/who-we-are/brand-toolkit",
             "aliases": {
-                "aka": [
-                    "Twitter"
-                ]
+                "aka": ["Twitter"]
             }
         },
         {
@@ -17785,9 +17617,7 @@
             "hex": "005FAD",
             "source": "https://www.w3.org/Icons/XML",
             "aliases": {
-                "aka": [
-                    "Extensible Markup Language"
-                ]
+                "aka": ["Extensible Markup Language"]
             }
         },
         {
@@ -17963,9 +17793,7 @@
             "hex": "00549E",
             "source": "https://www.zaproxy.org",
             "aliases": {
-                "aka": [
-                    "Zed Attack Proxy"
-                ]
+                "aka": ["Zed Attack Proxy"]
             }
         },
         {
@@ -17988,9 +17816,7 @@
         {
             "title": "Zcash",
             "aliases": {
-                "aka": [
-                    "ZEC"
-                ]
+                "aka": ["ZEC"]
             },
             "hex": "F3B724",
             "source": "https://z.cash",

--- a/scripts/lint/ourlint.js
+++ b/scripts/lint/ourlint.js
@@ -81,8 +81,55 @@ const TESTS = {
 
   /* Check the formatting of the data file */
   prettified(data, dataString) {
+    /**
+     * Prettify the data file.
+     * @param {{icons: IconsData}} data Data to prettify.
+     * @returns {string} Prettified data.
+     */
+    const prettify = (data) => {
+      const indentSpaces = 4;
+      const json = `${JSON.stringify(data, null, indentSpaces)}\n`;
+
+      // Make `old` and `aka` icons fields to render in single line
+      // if they have only one item.
+      const prettified = [];
+      const lines = json.split('\n');
+      const fieldsDeep = 4;
+      const fieldsIndent = ' '.repeat(indentSpaces * fieldsDeep);
+
+      let skips = 0;
+      for (const [i, line] of lines.entries()) {
+        if (skips > 0) {
+          skips--;
+          continue;
+        }
+
+        if (
+          line.startsWith(fieldsIndent) &&
+          (line.endsWith('"aka": [') || line.endsWith('"old": ['))
+        ) {
+          const next2Line = lines[i + 2];
+          if (
+            next2Line.startsWith(fieldsIndent) &&
+            (next2Line.endsWith(']') || next2Line.endsWith('],'))
+          ) {
+            const nextLine = lines[i + 1];
+            const newLine = `${line}${nextLine.trim()}${next2Line.trim()}`;
+            prettified.push(newLine);
+            skips += 2;
+          } else {
+            prettified.push(line);
+          }
+        } else {
+          prettified.push(line);
+        }
+      }
+
+      return prettified.join('\n');
+    };
+
     const normalizedDataString = normalizeNewlines(dataString);
-    const dataPretty = `${JSON.stringify(data, null, 4)}\n`;
+    const dataPretty = prettify(data);
 
     if (normalizedDataString !== dataPretty) {
       const dataDiff = fakeDiff(normalizedDataString, dataPretty);


### PR DESCRIPTION
The idea has been taken from [this commit](https://github.com/simple-icons/simple-icons/pull/12146/commits/72da9a6281f56daf2b0f1116fb6134574588818f) at #12146. 

Prettify the data file making `aka` and `old` aliases render in a single line if they contain one item. This format is accepted by Prettier, the input election is respected.

Now is more comfortable and readable in my opinion.