### PR TITLE
Don't show config nor controls in Renovate PR body

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,4 +21,7 @@
 
   // PR title and commit message when updating dependencies
   commitMessage: 'Update dependencies',
+
+  // Simplify PR body when updating dependencies
+  prBodyTemplate: '{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}',
 }


### PR DESCRIPTION
Removes the next part from pull requests bodies that update dependencies (see #12094):

![image](https://github.com/user-attachments/assets/8648d111-bb75-4835-8ade-02162c0d6667)

The box does nothing because our bot does not runs after clicking it. See https://docs.renovatebot.com/configuration-options/#prbodytemplate