### PR TITLE
Add EAC icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -4671,6 +4671,16 @@
             "source": "https://www.ea.com"
         },
         {
+            "title": "EAC",
+            "hex": "000000",
+            "source": "https://commons.wikimedia.org/wiki/File:EAC-black-on-white.svg",
+            "aliases": {
+                "aka": [
+                    "Eurasian Conformity"
+                ]
+            }
+        },
+        {
             "title": "Eagle",
             "hex": "0072EF",
             "source": "https://en.eagle.cool"

--- a/icons/eac.svg
+++ b/icons/eac.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>EAC</title><path d="M2.667 24h2.667v-2.667H2.667v-8h2.667v-2.666H2.667v-8h2.667V0H0v24zm21.334-2.667h-2.668V2.667h2.668V0h-5.333v24h5.333zM13.334 0H8v24h2.667V13.335h2.667V24H16V0Zm0 10.667h-2.667v-8h2.667z"/></svg>


### PR DESCRIPTION
![](https://github.com/user-attachments/assets/94187ed7-c4c8-4b39-a3b6-992b8162f046)

### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description

This is a standard icon related to #12107. Their official website is https://www.eaeunion.org, but I didn't find the EAC page.
