### PR TITLE
feat: add Replicate icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -13329,6 +13329,11 @@
             "source": "https://seeklogo.com/vector-logo/184137/renren-inc"
         },
         {
+            "title": "Replicate",
+            "hex": "000000",
+            "source": "https://replicate.com"
+        },
+        {
             "title": "Replit",
             "hex": "F26207",
             "source": "https://repl.it"

--- a/icons/replicate.svg
+++ b/icons/replicate.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Replicate</title><path d="M1.063 0v24h3.026V2.702h18.848V0zm5.713 5.124V24h3.028V7.825h13.133V5.124zm5.712 5.106V24h3.029V12.947h7.42V10.23z"/></svg>


### PR DESCRIPTION

![replicate](https://github.com/user-attachments/assets/ecefbbe4-5855-4871-87ae-364963dda4ec)

**Issue:** closes #10186 

**Popularity metric:**#[22,859](https://www.similarweb.com/website/replicate.com/)

### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description

This is identical to #11431 but with the correct hex code and with written permission of Replicate to use the logo. I am deepfates from Replicate and I endorse this message. 

Also okay if we prefer to merge the previous PR from @sebastien46. Just wanted to move this forward since I wasn't sure if we could effectively bump the closed PR. Thanks!