### PR TITLE
Fix errors adding `meta` label with labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,6 +8,16 @@ docs:
   - any: ['*.md']
     status: modified
 meta:
-  - any: ['.github/*', 'scripts/*', 'tests/*', '*']
-  - all: ['!*.md', '!icons/*.svg', '!_data/*', '!package.json']
+  - any:
+      [
+        '.github/*',
+        'scripts/*',
+        'tests/*',
+        '.husky/*',
+        '*.mjs',
+        '*.d.ts',
+        '*.json',
+        '*.toml',
+        '*',
+      ]
     status: modified


### PR DESCRIPTION
Currently the labeler is using only files without extensions in the root directory with `*`. This PR simplifies the configuration making it more explicit.