### PR TITLE
Update Lerna source

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -8875,7 +8875,7 @@
         {
             "title": "Lerna",
             "hex": "C084FC",
-            "source": "https://user-images.githubusercontent.com/900523/173044458-fd0b57f6-6374-4265-98b5-eb8f55fe1fb3.svg"
+            "source": "https://github.com/lerna/website/blob/98d8454238319ad3203ee6947d983d7a0b3703d9/images/lerna-logo-dark.svg"
         },
         {
             "title": "Leroy Merlin",

--- a/scripts/lint/ourlint.js
+++ b/scripts/lint/ourlint.js
@@ -124,6 +124,14 @@ const TESTS = {
     const isGitHubUrl = ($url) => $url.hostname === 'github.com';
 
     /**
+     * Check if an URL is an 'user-images.githubusercontent.com' URL.
+     * @param {URL} $url URL instance.
+     * @returns {boolean} Whether the URL is an 'user-images.githubusercontent.com' URL.
+     */
+    const isUserImagesGitHubUrl = ($url) =>
+      $url.hostname === 'user-images.githubusercontent.com';
+
+    /**
      * Regex to match a permalink GitHub URL for a file.
      */
     const permalinkGitHubRegex =
@@ -188,10 +196,11 @@ const TESTS = {
       }
 
       if (
-        isSourceUrl &&
-        isGitHubUrl($url) &&
-        !isPermalinkGitHubFileUrl(url) &&
-        !gitHubExcludedUrls.has(url)
+        (isSourceUrl &&
+          isGitHubUrl($url) &&
+          !isPermalinkGitHubFileUrl(url) &&
+          !gitHubExcludedUrls.has(url)) ||
+        isUserImagesGitHubUrl($url)
       ) {
         invalidUrls.push(
           `'${url}' must be a permalink GitHub URL. Expecting something like` +


### PR DESCRIPTION
Contributes to #11901

Prevents more URLs like `https://user-images.githubusercontent.com`