### PR TITLE
Update MoneyGram color

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -10154,7 +10154,7 @@
         },
         {
             "title": "MoneyGram",
-            "hex": "FF6600",
+            "hex": "E2231A",
             "source": "https://moneygram.com"
         },
         {

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -10154,7 +10154,7 @@
         },
         {
             "title": "MoneyGram",
-            "hex": "E2231A",
+            "hex": "DA291C",
             "source": "https://moneygram.com"
         },
         {


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://wasm.simpleicons.org/preview
-->

![MoneyGram preview with red color](https://github.com/user-attachments/assets/fbf8ef68-8a1d-420c-a36b-c8e648c791f0)

<details>
<summary>Previous orange color as included in Simple Icons</summary>
<img src="https://github.com/user-attachments/assets/f6cfe744-9b2b-4144-bd99-70ded80582a1" alt="MoneyGram preview with orange color" />
</details>

**Issue:** closes #12240 

<!--
Regardless of whether or not the linked issue (if there is one) has a metric, please include the metric here for PR reviewers to validate. See our contributing guidelines at https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#assessing-popularity for more details on how we assess a brand's popularity.
-->

### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description

<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->

Updates the color for MoneyGram’s logo based on MoneyGram.com's own “themeColorMain" CSS variable (see my comment: https://github.com/simple-icons/simple-icons/issues/12240#issuecomment-2508855256)
