### PR TITLE
Refactor release action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,10 @@ jobs:
           tag="${{ steps.get-version.outputs.version }}"
           git tag -a "${tag}" -m "${{ steps.commit.outputs.git-message }}"
           git push origin "${tag}"
+      - name: Generate release note
+        id: generate-release-note
+        run: |
+          echo "release_note=$(node scripts/release/generate-release-note.js)" >> $GITHUB_OUTPUT
       - name: Create release
         uses: softprops/action-gh-release@v2
         env:
@@ -98,7 +102,7 @@ jobs:
         with:
           tag_name: ${{ steps.get-version.outputs.version }}
           name: ${{ steps.commit.outputs.title }}
-          body: ${{ steps.commit.outputs.body }}
+          body: ${{ steps.generate-release-note.outputs.release_note }}
       - name: Send release to Discord
         run: node scripts/release/discord-release-message.js "${{ steps.get-version.outputs.version }}"
         env:

--- a/scripts/release/generate-release-note.js
+++ b/scripts/release/generate-release-note.js
@@ -1,0 +1,81 @@
+/**
+ * @file
+ * Script for generating release note.
+ */
+import {execSync} from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import {getDirnameFromImportMeta, titleToSlug} from '../../sdk.mjs';
+
+const loadRevision = (revision) => {
+	const projectRoot = path.join(
+		getDirnameFromImportMeta(import.meta.url),
+		'..',
+		'..',
+	);
+	const json = JSON.parse(
+		execSync(`git show ${revision}:_data/simple-icons.json`).toString(),
+	);
+
+	const hashes = new Map(
+		execSync(
+			`git ls-tree --format="%(objectname) %(path)" ${revision} icons/*`,
+			{cwd: projectRoot, shell: true},
+		)
+			.toString()
+			.trim()
+			.replaceAll(/(icons\/|\.svg)/g, '')
+			.split('\n')
+			.map((line) => {
+				const [hash, slug] = line.split(' ');
+				return [slug, hash];
+			}),
+	);
+	const icons = new Map(
+		json.icons
+			? json.icons.map((icon) => [icon.slug ?? titleToSlug(icon.title), icon])
+			: json.map((icon) => [icon.slug ?? titleToSlug(icon.title), icon]),
+	);
+	return {hashes, icons};
+};
+
+const iconDiff = (beforeRevision, afterRevision) => {
+	const before = loadRevision(beforeRevision);
+	const after = loadRevision(afterRevision);
+	const beforeSlugs = new Set(before.icons.keys());
+	const afterSlugs = new Set(after.icons.keys());
+
+	const newSlugs = afterSlugs.difference(beforeSlugs);
+	const removedSlugs = beforeSlugs.difference(afterSlugs);
+	const restSlugs = beforeSlugs.intersection(afterSlugs);
+
+	const updatedSlugs = new Set();
+	for (const slug of restSlugs) {
+		const beforeIconString = JSON.stringify(before.icons.get(slug));
+		const afterIconString = JSON.stringify(after.icons.get(slug));
+		if (beforeIconString !== afterIconString) updatedSlugs.add(slug);
+
+		const beforeIconHash = before.hashes.get(slug);
+		const afterIconHash = after.hashes.get(slug);
+		if (beforeIconHash !== afterIconHash) updatedSlugs.add(slug);
+	}
+
+	return {
+		newIcons: [...newSlugs].map((x) => after.icons.get(x)),
+		removeIcons: [...removedSlugs].map((x) => before.icons.get(x)),
+		updatedIcons: [...updatedSlugs].map((x) => after.icons.get(x)),
+	};
+};
+
+const diff = iconDiff('master', 'develop');
+const releaseNote = Object.entries(diff)
+	.map(([key, icons]) => {
+		const title = key.replace(/Icons$/, ' icons');
+		return icons.length > 0
+			? `## ${icons.length} ${title}\n\n${icons.map((icon) => `- ${icon.title}`).join('\n')}`
+			: '';
+	})
+	.filter(Boolean)
+	.join('\n\n');
+
+process.stdout.write(releaseNote);


### PR DESCRIPTION
### Related

- Fixes #9781
- Fixes https://github.com/simple-icons/release-action/issues/83

This is still working in the process.

Most of the code may move to https://github.com/simple-icons/release-action when I finish it. But for now I am developing it here so that everyone can preview and test it.

The icon corresponding to PR and contributors is not in the release note yet. But I already have an idea to implement this feature.

It can also unblock our proposal of #12383.

This is super fast since it doesn't use any GitHub REST API.

### Checklist

- [x] A simple script to get all new, updated, and removed icons
- [ ] Release PR body
- [x] GitHub release note
- [ ] Discord release notification

### How to preview

Simply run `node scripts/release/generate-release-note.js` to preview the release note.