### PR TITLE
Fix version output from `get-version` action

### DIFF
--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -12,5 +12,5 @@ runs:
     - id: get-version
       shell: sh
       run: |
-        version="$(grep version -m 1 -i package.json | sed 's/[ \",:version]//g' | xargs)"
+        version="$(grep version -m 1 -i package.json | cut -d '"' -f4)"
         echo "version=$version" >> $GITHUB_OUTPUT

--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -12,5 +12,5 @@ runs:
     - id: get-version
       shell: sh
       run: |
-        version="$(grep version -m 1 -i package.json | sed 's/[ \",:version]//g')"
+        version="$(grep version -m 1 -i package.json | sed 's/[ \",:version]//g' | xargs)"
         echo "version=$version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixes https://github.com/simple-icons/simple-icons/actions/runs/12458105634/job/34773364133

I used `xargs` to trim spaces and tabs.