### PR TITLE
Remove trailing slash from websites

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -27,4 +27,4 @@ For these and/or other purposes and motivations, and without any expectation of 
     3. Affirmer disclaims responsibility for clearing rights of other persons that may apply to the Work or any use thereof, including without limitation any person’s Copyright and Related Rights in the Work. Further, Affirmer disclaims responsibility for obtaining any necessary consents, permissions or other rights required for any use of the Work.
     4. Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work.
 
-For more information, please see <https://creativecommons.org/publicdomain/zero/1.0/>.
+For more information, please see <https://creativecommons.org/publicdomain/zero/1.0>.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Icons can be downloaded as SVGs directly from [simpleicons.org](https://simpleic
 
 ### CDN Usage
 
-Icons can be served from a CDN such as [jsDelivr](https://www.jsdelivr.com/package/npm/simple-icons) or [unpkg](https://unpkg.com/simple-icons). Simply use the `simple-icons` npm package and specify a version in the URL like the following:
+Icons can be served from a CDN such as [jsDelivr](https://www.jsdelivr.com/package/npm/simple-icons) or [unpkg](https://unpkg.com/browse/simple-icons). Simply use the `simple-icons` npm package and specify a version in the URL like the following:
 
 ```html
 <img height="32" width="32" src="https://cdn.jsdelivr.net/npm/simple-icons@v14/icons/[ICON SLUG].svg" />

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Over 3200 Free SVG icons for popular brands. See them all on one page at <a href
 
 ### General Usage
 
-Icons can be downloaded as SVGs directly from <https://simpleicons.org> - simply click the download button of the icon you want, and the download will start automatically.
+Icons can be downloaded as SVGs directly from [simpleicons.org](https://simpleicons.org) - simply click the download button of the icon you want, and the download will start automatically.
 
 ### CDN Usage
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Icons can be downloaded as SVGs directly from [simpleicons.org](https://simpleic
 
 ### CDN Usage
 
-Icons can be served from a CDN such as [jsDelivr](https://www.jsdelivr.com/package/npm/simple-icons) or [unpkg](https://unpkg.com/browse/simple-icons). Simply use the `simple-icons` npm package and specify a version in the URL like the following:
+Icons can be served from a CDN such as [jsDelivr](https://www.jsdelivr.com/package/npm/simple-icons) or [unpkg](https://unpkg.com/browse/simple-icons/). Simply use the `simple-icons` npm package and specify a version in the URL like the following:
 
 ```html
 <img height="32" width="32" src="https://cdn.jsdelivr.net/npm/simple-icons@v14/icons/[ICON SLUG].svg" />

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Over 3200 Free SVG icons for popular brands. See them all on one page at <a href
 
 ### General Usage
 
-Icons can be downloaded as SVGs directly from <https://simpleicons.org/> - simply click the download button of the icon you want, and the download will start automatically.
+Icons can be downloaded as SVGs directly from <https://simpleicons.org> - simply click the download button of the icon you want, and the download will start automatically.
 
 ### CDN Usage
 
-Icons can be served from a CDN such as [jsDelivr](https://www.jsdelivr.com/package/npm/simple-icons) or [unpkg](https://unpkg.com/browse/simple-icons/). Simply use the `simple-icons` npm package and specify a version in the URL like the following:
+Icons can be served from a CDN such as [jsDelivr](https://www.jsdelivr.com/package/npm/simple-icons) or [unpkg](https://unpkg.com/simple-icons). Simply use the `simple-icons` npm package and specify a version in the URL like the following:
 
 ```html
 <img height="32" width="32" src="https://cdn.jsdelivr.net/npm/simple-icons@v14/icons/[ICON SLUG].svg" />


### PR DESCRIPTION
Removing trailing slash from website links to make the visual better.

The https://unpkg.com/browse/simple-icons is broken. It always returns a `not found` message. I've replaced it with https://unpkg.com/simple-icons.

I also removed the `https://` prefix from the markdown visual to make it clean.