### PR TITLE
Expose `_data/simple-icons.json` as `simple-icons/icons.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,12 @@
 				"types": "./sdk.d.ts",
 				"default": "./sdk.js"
 			}
+		},
+		"./icons.json": {
+			"import": "./_data/simple-icons.json",
+			"module": "./_data/simple-icons.json",
+			"require": "./_data/simple-icons.json",
+			"default": "./_data/simple-icons.json"
 		}
 	},
 	"sideEffects": false,


### PR DESCRIPTION
Expsoes the `_data/simple-icons.json` file through `package.json`'s `exports`. 

Users can also import the JSON file directly instead of using the `getIconsData()`. The `import` way is suitable for more scenes since it has no `fs` calls.

The file location issue we discussed in #12416 should not be a problem anymore.

### How to use

```js
// CommonJS
const icons = require('simple-icons/icons.json');
```

```js
// ESM
import icons from 'simple-icons/icons.json' with {type: 'json'};
```