### PR TITLE
Update source URLs for Kuma, Linkerd and Parity Substrate

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -8754,7 +8754,7 @@
 	{
 		"title": "Kuma",
 		"hex": "290B53",
-		"source": "https://kuma.io/"
+		"source": "https://kuma.io"
 	},
 	{
 		"title": "Kununu",
@@ -9172,7 +9172,7 @@
 	{
 		"title": "Linkerd",
 		"hex": "2BEDA7",
-		"source": "https://linkerd.io/"
+		"source": "https://linkerd.io"
 	},
 	{
 		"title": "Linkfire",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -8754,7 +8754,7 @@
 	{
 		"title": "Kuma",
 		"hex": "290B53",
-		"source": "https://cncf-branding.netlify.app/projects/kuma/"
+		"source": "https://kuma.io/"
 	},
 	{
 		"title": "Kununu",
@@ -9172,7 +9172,7 @@
 	{
 		"title": "Linkerd",
 		"hex": "2BEDA7",
-		"source": "https://cncf-branding.netlify.app/projects/linkerd/"
+		"source": "https://linkerd.io/"
 	},
 	{
 		"title": "Linkfire",
@@ -11777,7 +11777,7 @@
 	{
 		"title": "Parity Substrate",
 		"hex": "282828",
-		"source": "https://substrate.dev"
+		"source": "https://docs.substrate.io"
 	},
 	{
 		"title": "Parrot Security",


### PR DESCRIPTION


**Issue:** Fixes some issues in  https://github.com/simple-icons/simple-icons/issues/11901

**Popularity metric:**



### Checklist

- [x] I updated the JSON data in `_data/simple-icons.json`
- [ ] I optimized the icon with SVGO or SVGOMG
- [ ] The SVG `viewbox` is `0 0 24 24`

### Description

Updates broken source URLs:

- Kuma: Change from CNCF branding page to kuma.io
- Linkerd: Change from CNCF branding page to linkerd.io  
- Parity Substrate: Update from substrate.dev to docs.substrate.io

These changes point to the primary project websites which are more stable and authoritative sources for the icons.
