### PR TITLE
Allow GitHub user attachment for ourlint

### DIFF
--- a/scripts/lint/ourlint.js
+++ b/scripts/lint/ourlint.js
@@ -133,7 +133,9 @@ ${invalids.map((icon) => `${format(icon)} ${findPositon(expectedOrder, icon)}`).
 		 * @returns {boolean} Whether the URL is raw GitHub asset URL.
 		 */
 		const isRawGithubAssetUrl = ($url) =>
-			$url.hostname === 'raw.githubusercontent.com';
+			$url.hostname === 'raw.githubusercontent.com' ||
+			($url.hostname === 'gihtub.com' &&
+				$url.pathname.startsWith('/user-attachments/assets'));
 
 		/**
 		 * Check if an URL is a GitHub URL.


### PR DESCRIPTION
This resolves a linting issue from https://github.com/simple-icons/simple-icons/pull/12584.

The `https://github.com/user-attachments/assets` is permanent. So it's OK to use them as the source.