### PR TITLE
Fixed build failing if some non-required parameters of simple-icons.json are missing

### DIFF
--- a/scripts/build/package.js
+++ b/scripts/build/package.js
@@ -58,7 +58,7 @@ const iconObjectTemplate = await fs.readFile(iconObjectTemplateFile, UTF8);
  * @returns {string} The escaped value.
  */
 const escape = (value) => {
-	return value.replaceAll(/(?<!\\)'/g, "\\'");
+	return typeof value === 'string' ? value.replaceAll(/(?<!\\)'/g, "\\'") : '';
 };
 
 /**


### PR DESCRIPTION
Improved security by replacing non-string values with empty string

<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://simpleicons.org/preview
-->

**Issue:** closes #

**Popularity metric:**

<!--
Regardless of whether or not the linked issue (if there is one) has a metric, please include the metric here for PR reviewers to validate. See our contributing guidelines at https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#assessing-popularity for more details on how we assess a brand's popularity.
-->

### Checklist

- [ ] I updated the JSON data in `_data/simple-icons.json`
- [ ] I optimized the icon with SVGO or SVGOMG
- [ ] The SVG `viewbox` is `0 0 24 24`

### Description

<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
