### PR TITLE
Sort fields when formatting package.json with Prettier

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
+	"plugins": ["prettier-plugin-packagejson"],
 	"useTabs": true,
 	"singleQuote": true,
 	"bracketSpacing": false,

--- a/package.json
+++ b/package.json
@@ -2,14 +2,26 @@
 	"name": "simple-icons",
 	"version": "14.4.0",
 	"description": "SVG icons for popular brands https://simpleicons.org",
-	"homepage": "https://simpleicons.org",
 	"keywords": [
 		"svg",
 		"icons"
 	],
+	"homepage": "https://simpleicons.org",
+	"bugs": {
+		"url": "https://github.com/simple-icons/simple-icons/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+ssh://git@github.com/simple-icons/simple-icons.git"
+	},
+	"funding": {
+		"type": "opencollective",
+		"url": "https://opencollective.com/simple-icons"
+	},
+	"license": "CC0-1.0",
+	"author": "Simple Icons Collaborators",
+	"sideEffects": false,
 	"type": "commonjs",
-	"main": "index.js",
-	"types": "index.d.ts",
 	"exports": {
 		".": {
 			"import": {
@@ -75,19 +87,32 @@
 			"default": "./_data/simple-icons.json"
 		}
 	},
-	"sideEffects": false,
-	"repository": {
-		"type": "git",
-		"url": "git+ssh://git@github.com/simple-icons/simple-icons.git"
-	},
-	"bugs": {
-		"url": "https://github.com/simple-icons/simple-icons/issues"
-	},
-	"author": "Simple Icons Collaborators",
-	"license": "CC0-1.0",
-	"funding": {
-		"type": "opencollective",
-		"url": "https://opencollective.com/simple-icons"
+	"main": "index.js",
+	"types": "index.d.ts",
+	"scripts": {
+		"add-icon-data": "node scripts/add-icon-data.js",
+		"build": "node scripts/build/package.js",
+		"clean": "node scripts/build/clean.js",
+		"format": "npm run format:icondata && npm run prettier -- --write && npm run xo:fix",
+		"format:icondata": "node scripts/format-icon-data.js",
+		"get-filename": "node scripts/get-filename.js",
+		"jslint": "xo",
+		"jsonlint": "node scripts/lint/jsonlint.js",
+		"lint": "npm run ourlint && npm run prettierlint && npm run jslint && npm run jsonlint && npm run svglint && npm run wslint && npm run markdownlint",
+		"markdownlint": "markdownlint-cli2 '**/*.md' '#node_modules'",
+		"ourlint": "node scripts/lint/ourlint.js",
+		"prepare": "husky",
+		"prepublishOnly": "npm run build",
+		"prettier": "prettier --ignore-unknown \"**/*.!(js|jsx|mjs|cjs|ts|tsx|mts|cts|svg)\"",
+		"prettierlint": "npm run prettier -- --check --cache",
+		"postpublish": "npm run clean",
+		"remove-icon": "node scripts/remove-icon.js",
+		"svglint": "svglint --ci --config svglint.config.mjs icons/*.svg",
+		"pretest": "npm run prepublishOnly",
+		"test": "mocha tests --reporter tests/min-reporter.cjs --inline-diffs",
+		"posttest": "npm run postpublish",
+		"wslint": "editorconfig-checker",
+		"xo:fix": "xo --fix"
 	},
 	"devDependencies": {
 		"@inquirer/core": "10.0.1",
@@ -107,6 +132,7 @@
 		"markdownlint-cli2": "0.15.0",
 		"mocha": "10.8.2",
 		"named-html-entities-json": "1.0.0",
+		"prettier-plugin-packagejson": "2.5.8",
 		"spdx-license-ids": "3.0.20",
 		"svg-path-bbox": "2.1.0",
 		"svg-path-segments": "2.0.1",
@@ -115,31 +141,6 @@
 		"svgpath": "2.6.0",
 		"typescript": "5.6.3",
 		"xo": "0.60.0"
-	},
-	"scripts": {
-		"build": "node scripts/build/package.js",
-		"clean": "node scripts/build/clean.js",
-		"format:icondata": "node scripts/format-icon-data.js",
-		"format": "npm run format:icondata && npm run prettier -- --write && npm run xo:fix",
-		"xo:fix": "xo --fix",
-		"prettier": "prettier --ignore-unknown \"**/*.!(js|jsx|mjs|cjs|ts|tsx|mts|cts|svg)\"",
-		"lint": "npm run ourlint && npm run prettierlint && npm run jslint && npm run jsonlint && npm run svglint && npm run wslint && npm run markdownlint",
-		"ourlint": "node scripts/lint/ourlint.js",
-		"prettierlint": "npm run prettier -- --check --cache",
-		"jslint": "xo",
-		"jsonlint": "node scripts/lint/jsonlint.js",
-		"svglint": "svglint --ci --config svglint.config.mjs icons/*.svg",
-		"wslint": "editorconfig-checker",
-		"markdownlint": "markdownlint-cli2 '**/*.md' '#node_modules'",
-		"prepare": "husky",
-		"prepublishOnly": "npm run build",
-		"postpublish": "npm run clean",
-		"test": "mocha tests --reporter tests/min-reporter.cjs --inline-diffs",
-		"pretest": "npm run prepublishOnly",
-		"posttest": "npm run postpublish",
-		"get-filename": "node scripts/get-filename.js",
-		"add-icon-data": "node scripts/add-icon-data.js",
-		"remove-icon": "node scripts/remove-icon.js"
 	},
 	"engines": {
 		"node": ">=0.12.18"


### PR DESCRIPTION
Add [`prettier-plugin-packagejson`](https://github.com/matzkoh/prettier-plugin-packagejson) to sort fields of package.json. That would disallow any attempt to specify a custom order for fields. IMO, the [alphabetical order for `scripts` (except for pre/post ones)](https://github.com/keithamus/sort-package-json/blob/main/defaultRules.md#scripts) make them easier to read.