### PR TITLE
Remove Jamboard icon and associated data

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -8047,12 +8047,6 @@
 		"source": "https://media.jaguar.com/en/press-kit"
 	},
 	{
-		"title": "Jamboard",
-		"hex": "F37C20",
-		"source": "https://cdn2.hubspot.net/hubfs/159104/ECS/Jamboard/Approved%20Jamboard%20Brand%20Book.pdf",
-		"guidelines": "https://cdn2.hubspot.net/hubfs/159104/ECS/Jamboard/Approved%20Jamboard%20Brand%20Book.pdf"
-	},
-	{
 		"title": "Jameson",
 		"hex": "004027",
 		"source": "https://www.jamesonwhiskey.com"

--- a/icons/jamboard.svg
+++ b/icons/jamboard.svg
@@ -1,1 +1,0 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Jamboard</title><path d="M12.143 0v7.877h7.783V0zm0 8.155v7.784h7.783V8.155zm-.28.005a7.926 7.923 0 0 0-7.789 7.917A7.926 7.923 0 0 0 12 24a7.926 7.923 0 0 0 7.918-7.78h-8.056Z"/></svg>

--- a/slugs.md
+++ b/slugs.md
@@ -1425,7 +1425,6 @@ update the script at 'scripts/release/update-slugs-table.js'.
 | `Jabber` | `jabber` |
 | `Jaeger` | `jaeger` |
 | `Jaguar` | `jaguar` |
-| `Jamboard` | `jamboard` |
 | `Jameson` | `jameson` |
 | `Jamstack` | `jamstack` |
 | `Japan Airlines` | `japanairlines` |


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://simpleicons.org/preview
-->

**Issue:** closes #11347 

<!--
Regardless of whether or not the linked issue (if there is one) has a metric, please include the metric here for PR reviewers to validate. See our contributing guidelines at https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#assessing-popularity for more details on how we assess a brand's popularity.
-->

### Checklist

- [X] I updated the JSON data in `_data/simple-icons.json`
- [ ] I optimized the icon with SVGO or SVGOMG
- [ ] The SVG `viewbox` is `0 0 24 24`

### Description
Removed jamboard from simple-icons.json, slugs.md, and /icons

<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
