### PR TITLE
Check JSDoc types with TypeScript

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,11 +3,12 @@
 		"target": "es2022",
 		"module": "node16",
 		"moduleResolution": "node16",
-		"checkJs": true,
-		"skipLibCheck": false,
+		"checkJs": false,
+		"skipLibCheck": true,
 		"strict": true,
 		"noImplicitAny": true,
 		"noImplicitThis": true,
-		"forceConsistentCasingInFileNames": true
+		"forceConsistentCasingInFileNames": true,
+		"noEmit": true
 	}
 }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
 		"get-filename": "node scripts/get-filename.js",
 		"jslint": "xo",
 		"jsonlint": "node scripts/lint/jsonlint.js",
-		"lint": "npm run ourlint && npm run prettierlint && npm run jslint && npm run jsonlint && npm run svglint && npm run wslint && npm run markdownlint",
+		"lint": "npm run ourlint && npm run prettierlint && npm run jslint && npm run jsonlint && npm run svglint && npm run wslint && npm run tslint && npm run markdownlint",
 		"markdownlint": "markdownlint-cli2 '**/*.md' '#node_modules'",
 		"ourlint": "node scripts/lint/ourlint.js",
 		"prepare": "husky",
@@ -111,6 +111,7 @@
 		"pretest": "npm run prepublishOnly",
 		"test": "mocha tests --reporter tests/min-reporter.cjs --inline-diffs",
 		"posttest": "npm run postpublish",
+		"tslint": "tsc -p jsconfig.json",
 		"wslint": "editorconfig-checker",
 		"xo:fix": "xo --fix"
 	},

--- a/scripts/add-icon-data.js
+++ b/scripts/add-icon-data.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * Script to add data for a new icon to the simple-icons dataset.

--- a/scripts/build/clean.js
+++ b/scripts/build/clean.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * Clean files built by the build process.

--- a/scripts/build/package.js
+++ b/scripts/build/package.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * Simple Icons package build script.

--- a/scripts/format-icon-data.js
+++ b/scripts/format-icon-data.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * Format _data/simple-icons.json.

--- a/scripts/get-filename.js
+++ b/scripts/get-filename.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * Script that takes a brand name as argument and outputs the corresponding

--- a/scripts/lint/jsonlint.js
+++ b/scripts/lint/jsonlint.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * CLI tool to run jsonschema on the simple-icons.json data file.

--- a/scripts/lint/ourlint.js
+++ b/scripts/lint/ourlint.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * Linters for the package that can't easily be implemented in the existing ones.
@@ -239,14 +240,14 @@ ${invalids.map((icon) => `${format(icon)} ${findPositon(expectedOrder, icon)}`).
 	async checkLicense(icons) {
 		const spdxLicenseIds = new Set(await getSpdxLicenseIds());
 		const badLicenses = [];
-		for (const {title, slug, license} of icons) {
+		for (const icon of icons) {
 			if (
-				license &&
-				license.type !== 'custom' &&
-				!spdxLicenseIds.has(license.type)
+				icon.license &&
+				icon.license.type !== 'custom' &&
+				!spdxLicenseIds.has(icon.license.type)
 			) {
 				badLicenses.push(
-					`${title} (${getIconSlug({title, slug})}) has not a valid SPDX license.`,
+					`${icon.title} (${getIconSlug(icon)}) has not a valid SPDX license.`,
 				);
 			}
 		}
@@ -258,7 +259,7 @@ ${invalids.map((icon) => `${format(icon)} ${findPositon(expectedOrder, icon)}`).
 
 	/* Ensure that fields are sorted in the same way for all icons */
 	fieldsSorted(icons) {
-		const formatted = formatIconData(icons, true);
+		const formatted = formatIconData(icons);
 		const previous = JSON.stringify(icons, null, '\t');
 		const sorted = JSON.stringify(formatted, null, '\t');
 		if (previous !== sorted) {

--- a/scripts/release/discord-release-message.js
+++ b/scripts/release/discord-release-message.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * Send release message to Discord #releases channel.
@@ -10,6 +11,18 @@ const releaseVersion = process.argv[2];
 const discordReleasesRoleId = process.env.DISCORD_RELEASES_ROLE_ID;
 const discordReleasesWebhookUrl = process.env.DISCORD_RELEASES_WEBHOOK_URL;
 const githubReleaseUrl = `https://github.com/simple-icons/simple-icons/releases/tag/${releaseVersion}`;
+
+if (discordReleasesRoleId === undefined) {
+	console.error('DISCORD_RELEASES_ROLE_ID environment variable is not set.');
+	process.exit(1);
+}
+
+if (discordReleasesWebhookUrl === undefined) {
+	console.error(
+		'DISCORD_RELEASES_WEBHOOK_URL environment variable is not set.',
+	);
+	process.exit(1);
+}
 
 try {
 	await globalThis.fetch(discordReleasesWebhookUrl, {

--- a/scripts/release/minify-icons-data.js
+++ b/scripts/release/minify-icons-data.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * Minify _data/simple-icons.json file.
@@ -6,4 +8,4 @@ import {getIconsData} from '../../sdk.mjs';
 import {writeIconsData} from '../utils.js';
 
 const icons = await getIconsData();
-await writeIconsData(icons, undefined, true);
+await writeIconsData(icons, true);

--- a/scripts/release/reformat-markdown.js
+++ b/scripts/release/reformat-markdown.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * Rewrite some Markdown files.

--- a/scripts/release/update-cdn-urls.js
+++ b/scripts/release/update-cdn-urls.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * Updates the CDN URLs in the README.md to match the major version in the

--- a/scripts/release/update-sdk-ts-defs.js
+++ b/scripts/release/update-sdk-ts-defs.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * Updates the SDK Typescript definitions located in the file sdk.d.ts

--- a/scripts/release/update-slugs-table.js
+++ b/scripts/release/update-slugs-table.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * Generates a MarkDown file that lists every brand name and their slug.

--- a/scripts/release/update-svgs-count.js
+++ b/scripts/release/update-svgs-count.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * Replaces the SVG count milestone "Over <NUMBER> SVG icons..." located

--- a/scripts/remove-icon.js
+++ b/scripts/remove-icon.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 /**
  * @file
  * Script to remove an icon and its data.
@@ -27,7 +28,6 @@ const icons = iconsData.map((icon, index) => {
 
 const found = await autocomplete({
 	message: 'Select an icon to remove:',
-	name: 'icon',
 	async source(input) {
 		if (!input) return icons;
 		return search(input, icons, {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * @file Internal utilities.
  *
@@ -35,13 +36,13 @@ export const getJsonSchemaData = async (
 /**
  * Write icons data to _data/simple-icons.json.
  * @param {IconData[]} iconsData Icons data array.
- * @param {string} rootDirectory Path to the root directory of the project.
- * @param {boolean} minify Whether to minify the JSON output.
+ * @param {boolean} [minify] Whether to minify the JSON output.
+ * @param {string} [rootDirectory] Path to the root directory of the project.
  */
 export const writeIconsData = async (
 	iconsData,
+	minify = false,
 	rootDirectory = path.resolve(__dirname, '..'),
-	minify,
 ) => {
 	await fs.writeFile(
 		getIconsDataPath(rootDirectory),
@@ -99,11 +100,13 @@ const sortIcon = (icon) => {
 		// This is not appears in icon data but it's in the alias object.
 		'loc',
 	];
+
 	const sortedIcon = Object.fromEntries(
 		Object.entries(icon).sort(
 			([key1], [key2]) => keyOrder.indexOf(key1) - keyOrder.indexOf(key2),
 		),
 	);
+	// @ts-ignore
 	return sortedIcon;
 };
 
@@ -120,6 +123,7 @@ const sortLicense = (license) => {
 			([key1], [key2]) => keyOrder.indexOf(key1) - keyOrder.indexOf(key2),
 		),
 	);
+	// @ts-ignore
 	return sortedLicense;
 };
 
@@ -150,13 +154,20 @@ export const formatIconData = (iconsData) => {
 				? sortAlphabetically({
 						aka: icon.aliases.aka?.sort(collator.compare),
 						dup: icon.aliases.dup
-							? icon.aliases.dup.sort(sortIconsCompare).map((d) =>
-									sortIcon({
-										...d,
-										loc: sortAlphabetically(d.loc),
-									}),
-								)
+							? icon.aliases.dup
+									.sort(
+										// @ts-ignore
+										sortIconsCompare,
+									)
+									.map((d) =>
+										sortIcon({
+											...d,
+											// @ts-ignore
+											loc: sortAlphabetically(d.loc),
+										}),
+									)
 							: undefined,
+						// @ts-ignore
 						loc: sortAlphabetically(icon.aliases.loc),
 						old: icon.aliases.old?.sort(collator.compare),
 					})

--- a/sdk.d.ts
+++ b/sdk.d.ts
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * @file
  * Types for Simple Icons SDK.

--- a/sdk.mjs
+++ b/sdk.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * @file
  * Simple Icons SDK.

--- a/svglint.config.mjs
+++ b/svglint.config.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * @file
  * Linting rules for SVGLint to check SVG icons.

--- a/svgo.config.mjs
+++ b/svgo.config.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * @file SVGO configuration for Simple Icons.
  */

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * @file Types for Simple Icons package.
  */


### PR DESCRIPTION
Execute `tsc` to check that types defined in JSDoc are compiled as if TypeScript would be used.

The problem of the implementation, and the reason why I haven't opened this PR before, is that is not possible to skip libraries in *node_modules/* using `checkJs` and `skipLibCheck` as everyone expected, so `// @ts-check` must be added at the beginning of all JS files. See https://github.com/microsoft/TypeScript/issues/40426#issuecomment-1022437203 and the rest of the discussion for details.

It seems to me that is worth it as is catching a lot of incoherences and potential strange bugs in the code and brings us some more material to fine tune it.