### PR TITLE
Catch Ctrl+C keys to abort execution in scripts

### DIFF
--- a/scripts/add-icon-data.js
+++ b/scripts/add-icon-data.js
@@ -28,6 +28,14 @@ import {
 	writeIconsData,
 } from './utils.js';
 
+// Ctrl+C to abort
+process.stdin.on('data', (key) => {
+	if (key.toString() === '\u0003') {
+		process.stdout.write('Aborted\n');
+		process.exit();
+	}
+});
+
 /** @type {import('../sdk.js').IconData[]} */
 const iconsData = JSON.parse(await getIconsDataString());
 const jsonSchema = await getJsonSchemaData();

--- a/scripts/add-icon-data.js
+++ b/scripts/add-icon-data.js
@@ -32,7 +32,7 @@ import {
 process.stdin.on('data', (key) => {
 	if (key.toString() === '\u0003') {
 		process.stdout.write('Aborted\n');
-		process.exit();
+		process.exit(1);
 	}
 });
 

--- a/scripts/remove-icon.js
+++ b/scripts/remove-icon.js
@@ -17,6 +17,14 @@ const __dirname = getDirnameFromImportMeta(import.meta.url);
 const rootDirectory = path.resolve(__dirname, '..');
 const svgFilesDirectory = path.resolve(rootDirectory, 'icons');
 
+// Ctrl+C to abort
+process.stdin.on('data', (key) => {
+	if (key.toString() === '\u0003') {
+		process.stdout.write('Aborted\n');
+		process.exit();
+	}
+});
+
 const iconsData = await getIconsData();
 const icons = iconsData.map((icon, index) => {
 	const slug = getIconSlug(icon);

--- a/scripts/remove-icon.js
+++ b/scripts/remove-icon.js
@@ -21,7 +21,7 @@ const svgFilesDirectory = path.resolve(rootDirectory, 'icons');
 process.stdin.on('data', (key) => {
 	if (key.toString() === '\u0003') {
 		process.stdout.write('Aborted\n');
-		process.exit();
+		process.exit(1);
 	}
 });
 


### PR DESCRIPTION
Currently, strange errors appear in the screen when you try to stop these scripts using <kbd>Ctrl</kbd>+<kbd>C</kbd>.
