### PR TITLE
Handling `Ctrl+C` gracefully

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,8 +116,8 @@
 		"xo:fix": "xo --fix"
 	},
 	"devDependencies": {
-		"@inquirer/core": "10.0.1",
-		"@inquirer/prompts": "7.0.1",
+		"@inquirer/core": "10.1.7",
+		"@inquirer/prompts": "7.3.2",
 		"@types/node": "22.8.6",
 		"chalk": "5.3.0",
 		"editorconfig-checker": "6.0.0",
@@ -128,7 +128,6 @@
 		"fast-fuzzy": "1.12.0",
 		"get-relative-luminance": "1.0.0",
 		"husky": "9.1.6",
-		"inquirer-autocomplete-standalone": "0.8.1",
 		"jsonschema": "1.4.1",
 		"markdownlint-cli2": "0.15.0",
 		"mocha": "10.8.2",

--- a/scripts/add-icon-data.js
+++ b/scripts/add-icon-data.js
@@ -10,11 +10,10 @@
  */
 import process from 'node:process';
 import {ExitPromptError} from '@inquirer/core';
-import {checkbox, confirm, input} from '@inquirer/prompts';
+import {checkbox, confirm, input, search} from '@inquirer/prompts';
 import chalk from 'chalk';
-import {search} from 'fast-fuzzy';
+import {search as fuzzySearch} from 'fast-fuzzy';
 import getRelativeLuminance from 'get-relative-luminance';
-import autocomplete from 'inquirer-autocomplete-standalone';
 import {
 	getIconsDataString,
 	normalizeColor,
@@ -28,11 +27,12 @@ import {
 	writeIconsData,
 } from './utils.js';
 
-// Ctrl+C to abort
-process.stdin.on('data', (key) => {
-	if (key.toString() === '\u0003') {
-		process.stdout.write('Aborted\n');
+process.on('uncaughtException', (error) => {
+	if (error instanceof ExitPromptError) {
+		process.stdout.write('\nAborted\n');
 		process.exit(1);
+	} else {
+		throw error;
 	}
 });
 
@@ -95,102 +95,102 @@ const previewHexColor = (input) => {
 	);
 };
 
-try {
-	const answers = {
-		title: await input({
-			message: 'What is the title of this icon?',
-			validate: (input) =>
-				input.trim().length > 0
-					? isNewIcon(input) || 'This icon title or slug already exists.'
-					: 'This field is required.',
+// Try {
+const answers = {
+	title: await input({
+		message: 'What is the title of this icon?',
+		validate: (input) =>
+			input.trim().length > 0
+				? isNewIcon(input) || 'This icon title or slug already exists.'
+				: 'This field is required.',
+	}),
+	hex: normalizeColor(
+		await input({
+			message: 'What is the brand color of this icon?',
+			validate: isValidHexColor,
+			transformer: previewHexColor,
 		}),
-		hex: normalizeColor(
-			await input({
-				message: 'What is the brand color of this icon?',
-				validate: isValidHexColor,
-				transformer: previewHexColor,
-			}),
-		),
-		source: await input({
-			message: 'What is the source URL of the icon?',
-			validate: isValidURL,
-		}),
-		guidelines: (await confirm({
-			message: 'Does this icon have brand guidelines?',
-		}))
-			? await input({
-					message: 'What is the URL for the brand guidelines?',
-					validate: isValidURL,
-				})
-			: undefined,
-		license: (await confirm({
-			message: 'Does this icon have a license?',
-		}))
-			? {
-					type: await autocomplete({
-						message: "What is the icon's license?",
-						async source(input) {
-							input = (input || '').trim();
-							return input
-								? search(input, licenseTypes, {keySelector: (x) => x.value})
-								: licenseTypes;
-						},
-					}),
-					url:
-						(await input({
-							message: `What is the URL for the license? (optional)`,
-							validate: (input) => input.length === 0 || isValidURL(input),
-						})) || undefined,
+	),
+	source: await input({
+		message: 'What is the source URL of the icon?',
+		validate: isValidURL,
+	}),
+	guidelines: (await confirm({
+		message: 'Does this icon have brand guidelines?',
+	}))
+		? await input({
+				message: 'What is the URL for the brand guidelines?',
+				validate: isValidURL,
+			})
+		: undefined,
+	license: (await confirm({
+		message: 'Does this icon have a license?',
+	}))
+		? {
+				type: await search({
+					message: "What is the icon's license?",
+					async source(input) {
+						input = (input || '').trim();
+						return input
+							? fuzzySearch(input, licenseTypes, {
+									keySelector: (x) => x.value,
+								})
+							: licenseTypes;
+					},
+				}),
+				url:
+					(await input({
+						message: `What is the URL for the license? (optional)`,
+						validate: (input) => input.length === 0 || isValidURL(input),
+					})) || undefined,
+			}
+		: undefined,
+	aliases: (await confirm({
+		message: 'Does this icon have brand aliases?',
+		default: false,
+	}))
+		? await checkbox({
+				message: 'What types of aliases do you want to add?',
+				choices: aliasTypes,
+			}).then(async (aliases) => {
+				/** @type {{[_: string]: string[]}} */
+				const result = {};
+				for (const alias of aliases) {
+					// eslint-disable-next-line no-await-in-loop
+					result[alias] = await input({
+						message: `What ${alias} aliases would you like to add? (separate with commas)`,
+					}).then((aliases) => aliases.split(',').map((alias) => alias.trim()));
 				}
-			: undefined,
-		aliases: (await confirm({
-			message: 'Does this icon have brand aliases?',
-			default: false,
-		}))
-			? await checkbox({
-					message: 'What types of aliases do you want to add?',
-					choices: aliasTypes,
-				}).then(async (aliases) => {
-					/** @type {{[_: string]: string[]}} */
-					const result = {};
-					for (const alias of aliases) {
-						// eslint-disable-next-line no-await-in-loop
-						result[alias] = await input({
-							message: `What ${alias} aliases would you like to add? (separate with commas)`,
-						}).then((aliases) =>
-							aliases.split(',').map((alias) => alias.trim()),
-						);
-					}
 
-					return result;
-				})
-			: undefined,
-	};
+				return result;
+			})
+		: undefined,
+};
 
-	process.stdout.write(
-		'About to write the following to simple-icons.json:\n' +
-			JSON.stringify(answers, null, '\t') +
-			'\n',
-	);
+process.stdout.write(
+	'About to write the following to simple-icons.json:\n' +
+		JSON.stringify(answers, null, '\t') +
+		'\n',
+);
 
-	if (
-		await confirm({
-			message: 'Is this OK?',
-		})
-	) {
-		iconsData.push(answers);
-		iconsData.sort(sortIconsCompare);
-		await writeIconsData(iconsData);
-		process.stdout.write(chalk.green('\nData written successfully.\n'));
-	} else {
-		process.stdout.write(chalk.red('\nAborted.\n'));
-		process.exit(1);
-	}
-} catch (error) {
-	if (error instanceof ExitPromptError) {
-		process.stdout.write(chalk.red('\nAborted.\n'));
-		process.exit(1);
-	}
-
-	throw error;
+if (
+	await confirm({
+		message: 'Is this OK?',
+	})
+) {
+	iconsData.push(answers);
+	iconsData.sort(sortIconsCompare);
+	await writeIconsData(iconsData);
+	process.stdout.write(chalk.green('\nData written successfully.\n'));
+} else {
+	process.stdout.write(chalk.red('\nAborted.\n'));
+	process.exit(1);
 }
+// } catch (error) {
+// 	if (error instanceof ExitPromptError) {
+// 		process.stdout.write(chalk.red('\nAborted.\n'));
+// 		process.exit(1);
+// 	}
+
+// 	throw error;
+// }

--- a/scripts/remove-icon.js
+++ b/scripts/remove-icon.js
@@ -8,22 +8,24 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
-import {search} from 'fast-fuzzy';
-import autocomplete from 'inquirer-autocomplete-standalone';
+import {ExitPromptError} from '@inquirer/core';
+import {search} from '@inquirer/prompts';
+import {search as fuzzySearch} from 'fast-fuzzy';
 import {getDirnameFromImportMeta, getIconSlug, getIconsData} from '../sdk.mjs';
 import {writeIconsData} from './utils.js';
+
+process.on('uncaughtException', (error) => {
+	if (error instanceof ExitPromptError) {
+		process.stdout.write('\nAborted\n');
+		process.exit(1);
+	} else {
+		throw error;
+	}
+});
 
 const __dirname = getDirnameFromImportMeta(import.meta.url);
 const rootDirectory = path.resolve(__dirname, '..');
 const svgFilesDirectory = path.resolve(rootDirectory, 'icons');
-
-// Ctrl+C to abort
-process.stdin.on('data', (key) => {
-	if (key.toString() === '\u0003') {
-		process.stdout.write('Aborted\n');
-		process.exit(1);
-	}
-});
 
 const iconsData = await getIconsData();
 const icons = iconsData.map((icon, index) => {
@@ -34,11 +36,11 @@ const icons = iconsData.map((icon, index) => {
 	};
 });
 
-const found = await autocomplete({
-	message: 'Select an icon to remove:',
+const found = await search({
+	message: 'Search for an icon to remove:',
 	async source(input) {
-		if (!input) return icons;
-		return search(input, icons, {
+		if (!input) return [];
+		return fuzzySearch(input, icons, {
 			keySelector: (icon) => [icon.value.title, icon.value.slug],
 		});
 	},


### PR DESCRIPTION
### Changes

Related to #12852

- Remove the redundant dependency `inquirer-autocomplete-standalone`
- Handling `Ctrl+C` gracefully
- Bump `@inquirer` dependencies to the latest