### PR TITLE
Remove `ts-check` header to unblock releases

### DIFF
--- a/sdk.mjs
+++ b/sdk.mjs
@@ -1,4 +1,3 @@
-// @ts-check
 /**
  * @file
  * Simple Icons SDK.


### PR DESCRIPTION
The CI failed at https://github.com/simple-icons/simple-icons/actions/runs/13743564664.

This PR removes the `ts-check` header to unblock our releases. We can investigate the issue later.