### PR TITLE
Use TypeScript to lint SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,9 @@
 		"pretest": "npm run prepublishOnly",
 		"test": "mocha tests --reporter tests/min-reporter.cjs --inline-diffs",
 		"posttest": "npm run postpublish",
-		"tslint": "tsc -p jsconfig.json",
+		"tslint": "npm run tslint:main && npm run tslint:sdk",
+		"tslint:main": "tsc -p jsconfig.json",
+		"tslint:sdk": "tsc -p scripts/release/sdk-ts-defs-jsconfig.json --noEmit",
 		"wslint": "editorconfig-checker",
 		"xo:fix": "xo --fix"
 	},

--- a/scripts/release/sdk-ts-defs-jsconfig.json
+++ b/scripts/release/sdk-ts-defs-jsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "es2022",
+		"lib": ["es2022"],
+		"module": "es2022",
+		"allowJs": true,
+		"skipLibCheck": true,
+		"removeComments": true,
+		"esModuleInterop": true,
+		"checkJs": false,
+		"strict": true,
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"include": ["../../sdk.mjs"]
+}

--- a/sdk.d.ts
+++ b/sdk.d.ts
@@ -64,22 +64,26 @@ export type IconData = {
 
 export const SVG_PATH_REGEX: RegExp;
 export function getDirnameFromImportMeta(importMetaUrl: string): string;
-export function urlRegex(jsonschemaPath?: string): Promise<RegExp>;
+export function urlRegex(jsonschemaPath?: string | undefined): Promise<RegExp>;
 export function getIconSlug(icon: IconData): string;
 export function svgToPath(svg: string): string;
 export function titleToSlug(title: string): string;
 export function slugToVariableName(slug: string): string;
 export function titleToHtmlFriendly(brandTitle: string): string;
 export function htmlFriendlyToTitle(htmlFriendlyTitle: string): string;
-export function getIconsDataPath(rootDirectory?: string): string;
-export function getIconsDataString(rootDirectory?: string): Promise<string>;
-export function getIconsData(rootDirectory?: string): Promise<IconData[]>;
+export function getIconsDataPath(rootDirectory?: string | undefined): string;
+export function getIconsDataString(
+	rootDirectory?: string | undefined,
+): Promise<string>;
+export function getIconsData(
+	rootDirectory?: string | undefined,
+): Promise<IconData[]>;
 export function normalizeNewlines(text: string): string;
 export function normalizeColor(text: string): string;
 export function getThirdPartyExtensions(
-	readmePath?: string,
+	readmePath?: string | undefined,
 ): Promise<ThirdPartyExtension[]>;
 export function getThirdPartyLibraries(
-	readmePath?: string,
+	readmePath?: string | undefined,
 ): Promise<ThirdPartyExtension[]>;
 export const collator: Intl.Collator;

--- a/sdk.mjs
+++ b/sdk.mjs
@@ -1,8 +1,8 @@
+// @ts-check
 /**
  * @file
  * Simple Icons SDK.
  */
-
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';


### PR DESCRIPTION
Enables `ts-check` comment removed on #12862. Adds a TypeScript configuration for the SDK file and lint it.

The problem was that the file was being triggering checking TS errors now because the configuration was incomplete. Changed the implementation of the script commands to show STDERR in case of failure.