### PR TITLE
Handle unsettled top-level await warnings

### DIFF
--- a/scripts/add-icon-data.js
+++ b/scripts/add-icon-data.js
@@ -26,6 +26,7 @@ import {
 	writeIconsData,
 } from './utils.js';
 
+process.exitCode = 1;
 process.on('uncaughtException', (error) => {
 	if (error instanceof Error && error.name === 'ExitPromptError') {
 		process.stdout.write('\nAborted\n');
@@ -180,6 +181,7 @@ if (
 	iconsData.sort(sortIconsCompare);
 	await writeIconsData(iconsData);
 	process.stdout.write(chalk.green('\nData written successfully.\n'));
+	process.exit(0);
 } else {
 	process.stdout.write(chalk.red('\nAborted.\n'));
 	process.exit(1);

--- a/scripts/remove-icon.js
+++ b/scripts/remove-icon.js
@@ -13,6 +13,7 @@ import {search as fuzzySearch} from 'fast-fuzzy';
 import {getDirnameFromImportMeta, getIconSlug, getIconsData} from '../sdk.mjs';
 import {writeIconsData} from './utils.js';
 
+process.exitCode = 1;
 process.on('uncaughtException', (error) => {
 	if (error instanceof Error && error.name === 'ExitPromptError') {
 		process.stdout.write('\nAborted\n');
@@ -54,3 +55,4 @@ iconsData.splice(found.index, 1);
 await writeIconsData(iconsData);
 await fs.unlink(path.resolve(svgFilesDirectory, `${found.slug}.svg`));
 process.stdout.write(`Icon "${found.title} (${found.slug}.svg)" removed.\n`);
+process.exit(0);


### PR DESCRIPTION
Fixed a warning from Node.js:

![](https://github.com/user-attachments/assets/f2099e54-b6c2-4ce2-9237-878e02e46024)
