### PR TITLE
Add `update icon/data` label when only data file is changed

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,8 @@ new icon:
 update icon/data:
   - any: [icons/*.svg]
     status: modified
+  - all: [_data/simple-icons.json]
+    status: modified
 breaking change:
   - any: [icons/*.svg]
     status: removed


### PR DESCRIPTION
With this change, the labeler would have been added the `update icon/data` label to #13020.

I'm not totally sure if we're adding this label to data-only changed PRs; looks to me like that's the case. Probably, we need to add the label `skip release note` too. Thoughs about it @LitoMore?