### PR TITLE
Migrate from `ts-ignore` to `ts-expect-error`

### DIFF
--- a/scripts/add-icon-data.js
+++ b/scripts/add-icon-data.js
@@ -158,7 +158,7 @@ if (
 	};
 
 	if (answers.license.type === 'custom') {
-		// @ts-ignore
+		// @ts-expect-error
 		answers.license.url = await input({
 			message: `What is the URL for the license? (optional)`,
 			validate: (input) => input.length === 0 || isValidURL(input),

--- a/scripts/autoclose-issues/autoclose.app.js
+++ b/scripts/autoclose-issues/autoclose.app.js
@@ -55,7 +55,7 @@ const githubFetch = async (url, options) => {
 	});
 	if (!response.ok) {
 		throw new Error(
-			`Failed to fetch: ${response.status} (${response.statusText}).`,
+			`Failed to fetch ${url}: ${response.status} (${response.statusText}).`,
 		);
 	}
 
@@ -70,11 +70,6 @@ const githubFetch = async (url, options) => {
 const checkIfCanBeClosed = async () => {
 	const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}`;
 	const response = await githubFetch(url, {method: 'GET'});
-	if (!response.ok) {
-		throw new Error(
-			`Failed to fetch: ${response.status} (${response.statusText}).`,
-		);
-	}
 
 	/** @type {Issue} */
 	const json = await response.json();

--- a/scripts/lint/ourlint.js
+++ b/scripts/lint/ourlint.js
@@ -191,7 +191,7 @@ ${invalids.map((icon) => `${format(icon)} ${findPositon(expectedOrder, icon)}`).
 					// TODO: `hasOwn` is not currently supported by TS.
 					// See https://github.com/microsoft/TypeScript/issues/44253
 					/** @type {string} */
-					// @ts-ignore
+					// @ts-expect-error
 					icon.license.url,
 				]);
 			}

--- a/svglint.config.mjs
+++ b/svglint.config.mjs
@@ -422,7 +422,7 @@ const config = {
 
 				/** @type {Segment['segments']} */
 				const absSegments =
-					// @ts-ignore
+					// @ts-expect-error
 					svgpath(iconPath).abs().unshort().segments;
 
 				const lowerMovementCommands = ['m', 'l'];


### PR DESCRIPTION
See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#-ts-expect-error-comments

and remove the dead code introduced at #13022 