### PR TITLE
Fix Radio France aliases

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -13368,6 +13368,10 @@
 		"aliases": {
 			"dup": [
 				{
+					"title": "Fip",
+					"hex": "E2007A"
+				},
+				{
 					"title": "France Inter",
 					"hex": "E20134"
 				},
@@ -13378,10 +13382,6 @@
 				{
 					"title": "France Musique",
 					"hex": "A90042"
-				},
-				{
-					"title": "Fip",
-					"hex": "E2007A"
 				},
 				{
 					"title": "Mouv'",


### PR DESCRIPTION
This PR simply puts the Radio France aliases in the correct order, to stop the commit hook from trying to do it on all future PRs.