### PR TITLE
Fix fields-sort lint

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -13368,20 +13368,20 @@
 		"aliases": {
 			"dup": [
 				{
-					"title": "France Inter",
-					"hex": "E20134"
+					"title": "Fip",
+					"hex": "E2007A"
 				},
 				{
 					"title": "France Culture",
 					"hex": "762B84"
 				},
 				{
-					"title": "France Musique",
-					"hex": "A90042"
+					"title": "France Inter",
+					"hex": "E20134"
 				},
 				{
-					"title": "Fip",
-					"hex": "E2007A"
+					"title": "France Musique",
+					"hex": "A90042"
 				},
 				{
 					"title": "Mouv'",

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -170,7 +170,8 @@ const sortAlphabetically = (object) => {
  * @returns {IconData[]} The sorted icons data.
  */
 export const formatIconData = (iconsData) => {
-	const icons = iconsData.map((icon) => {
+	const iconsDataCopy = structuredClone(iconsData);
+	const icons = iconsDataCopy.map((icon) => {
 		return sortIconOrDuplicate({
 			...icon,
 			license: sortLicense(icon.license),


### PR DESCRIPTION
The `formatIconData()` is changing the same array. I've used [`structuredClone ()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone) to create a deep clone for resolving this issue.