### PR TITLE
Remove Engadget icon

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,7 @@ Some companies and organizations are excessively protective with their brands, s
 - Microchip Technology Inc.
 - [Microsoft](https://github.com/simple-icons/simple-icons/issues/11236)
 - Oracle
+- [Yahoo!](https://github.com/simple-icons/simple-icons/pull/9861#issuecomment-1819664495)
 - Do you know more? Please, [report them](https://github.com/simple-icons/simple-icons/issues/new?labels=docs&template=documentation.yml).
 
 If you are in doubt, feel free to submit it and we'll have a look.

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -4733,12 +4733,6 @@
 		"source": "https://github.com/endeavouros-team/endeavouros-theming/blob/135f642c980ed8d8fc212783eb478f96226f6c72/endeavouros-logo-text.svg"
 	},
 	{
-		"title": "Engadget",
-		"hex": "000000",
-		"source": "https://www.engadget.com",
-		"guidelines": "https://o.aolcdn.com/engadget/brand-kit/eng-logo-guidelines.pdf"
-	},
-	{
 		"title": "Enpass",
 		"hex": "0D47A1",
 		"source": "https://www.enpass.io/press/"

--- a/icons/engadget.svg
+++ b/icons/engadget.svg
@@ -1,1 +1,0 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Engadget</title><path d="M0 20.067a3.9 3.9 0 0 0 4 3.866h16v-4H4v-4h15.733A4.231 4.231 0 0 0 24 12.067V4.333A4.483 4.483 0 0 0 19.733.067H4a4.346 4.346 0 0 0-4 4.266Zm20-8.134H4v-8h16Z"/></svg>

--- a/scripts/autoclose-issues/autoclose.rules.js
+++ b/scripts/autoclose-issues/autoclose.rules.js
@@ -45,6 +45,10 @@ const rules = [
 		patterns: [/amazon/i, /aws/i],
 		reason: autocloseTerm + '#13056.',
 	},
+	{
+		patterns: [/yahoo/i, /engadget/i, /aol/i],
+		reason: autocloseTerm + '#9861.',
+	},
 ];
 
 export default rules;


### PR DESCRIPTION
Removes Engadget icon, and adds Yahoo! and child brands to the forbidden list.

See https://github.com/simple-icons/simple-icons/pull/9861#issuecomment-1819664495