### PR TITLE
Make Terms of Service more explicit in our request process

### DIFF
--- a/.github/ISSUE_TEMPLATE/icon_request.yml
+++ b/.github/ISSUE_TEMPLATE/icon_request.yml
@@ -55,6 +55,13 @@ body:
     validations:
       required: true
 
+  - type: input
+    attributes:
+      label: Terms of Service
+      description: |
+        A lot of websites specify whether or not we can use their brand assets in their Terms of Service.
+        Please ensure you include the link here where relevant.
+
   - type: textarea
     attributes:
       label: Official Resources for Icon and Color

--- a/.github/ISSUE_TEMPLATE/icon_update.yml
+++ b/.github/ISSUE_TEMPLATE/icon_update.yml
@@ -21,6 +21,13 @@ body:
     validations:
       required: true
 
+  - type: input
+    attributes:
+      label: Terms of Service
+      description: |
+        A lot of websites specify whether or not we can use their brand assets in their Terms of Service.
+        Please ensure you include the link here where relevant.
+
   - type: textarea
     attributes:
       label: Official Resources for Icon and Color

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@ Regardless of whether or not the linked issue (if there is one) has a metric, pl
 
 ### Checklist
 
+- [ ] I have reviewed the brand's terms of service, and am confident we can add this icon
 - [ ] I updated the JSON data in `_data/simple-icons.json`
 - [ ] I optimized the icon with SVGO or SVGOMG
 - [ ] The SVG `viewbox` is `0 0 24 24`


### PR DESCRIPTION
Tweaks the PR and Issue templates to ask users to provide a link to the Terms of Service for a brand. Should help us to improve awareness of brands requiring permission requests.