### PR TITLE
Add dltHub icon

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -4213,6 +4213,16 @@
 		"source": "https://commons.wikimedia.org/wiki/File:DLNA_logo.svg"
 	},
 	{
+		"title": "dltHub",
+		"hex": "C6D300",
+		"source": "https://dlthub.com/images/favicon.png",
+		"aliases": {
+			"aka": [
+				"dlt"
+			]
+		}
+	},
+	{
 		"title": "dm",
 		"hex": "002878",
 		"source": "https://www.dm.de",

--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -4215,7 +4215,7 @@
 	{
 		"title": "dltHub",
 		"hex": "C6D300",
-		"source": "https://dlthub.com/images/favicon.png",
+		"source": "https://dlthub.com",
 		"aliases": {
 			"aka": [
 				"dlt"

--- a/icons/dlthub.svg
+++ b/icons/dlthub.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>dltHub</title><path d="M0 0v8h8V0zm8 8v16h16V8z"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>dltHub</title><path d="M9.375 9.375H0V0h9.375zH24V24H9.375Z"/></svg>

--- a/icons/dlthub.svg
+++ b/icons/dlthub.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>dltHub</title><path d="M0 0v8h8V0zm8 8v16h16V8z"/></svg>


### PR DESCRIPTION
![dltHub](https://github.com/user-attachments/assets/f65dfbc9-9341-46b5-8623-65b1925d7ce0)

**Issue:** closes #13342 

**Popularity metric:**

Downloads last day: 33,833
Downloads last week: 406,727
Downloads last month: 1,864,116

https://pypistats.org/packages/dlt
<!--
Regardless of whether or not the linked issue (if there is one) has a metric, please include the metric here for PR reviewers to validate. See our contributing guidelines at https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#assessing-popularity for more details on how we assess a brand's popularity.
-->

### Checklist

- [x] I have reviewed the [forbidden brands](https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#forbidden-brands) list and confirm the brand I am submitting a PR for is not one of them, nor is it a subsidiary of one of those brands
- [x] I have reviewed the brand's terms of service, and am confident we can add this icon
- [x] I updated the JSON data in `_data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description
PIcked the dominant color in the favicon. Source is https://dlthub.com/images/favicon.png. Manually vectorized the logo (but its just 2 squares).
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
