### PR TITLE
Mention GitHub Sponsor funding method

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: simple-icons
 open_collective: simple-icons


### PR DESCRIPTION
Our GitHub Sponsor account is ready: https://github.com/sponsors/simple-icons

Here is our internal discussion on Discord: https://discord.com/channels/1142044630909726760/1142045966078316574/1376918035943784532