### PR TITLE
Amend Fundraising Options

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: simple-icons
-open_collective: simple-icons

--- a/package.json
+++ b/package.json
@@ -14,10 +14,16 @@
 		"type": "git",
 		"url": "git+ssh://git@github.com/simple-icons/simple-icons.git"
 	},
-	"funding": {
-		"type": "opencollective",
-		"url": "https://opencollective.com/simple-icons"
-	},
+	"funding": [
+		{
+			"type": "opencollective",
+			"url": "https://opencollective.com/simple-icons"
+		},
+		{
+			"type": "github",
+			"url": "https://github.com/sponsors/simple-icons"
+		}
+	],
 	"license": "CC0-1.0",
 	"author": "Simple Icons Collaborators",
 	"sideEffects": false,


### PR DESCRIPTION
Removes the `FUNDING.yml` from this repository, opting instead to rely on the org-wide version.
Also adds GitHub sponsor link to the `package.json` file.