### PR TITLE
Add duplicate of iLovePDF (iLoveIMG and iLoveAPI)

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -7554,14 +7554,14 @@
 		"aliases": {
 			"dup": [
 				{
-					"title": "iLoveIMG",
-					"hex": "4D90FE",
-					"source": "https://www.iloveimg.com/press"
-				},
-				{
 					"title": "iLoveAPI",
 					"hex": "26AEBA",
 					"source": "https://www.iloveapi.com"
+				},
+				{
+					"title": "iLoveIMG",
+					"hex": "4D90FE",
+					"source": "https://www.iloveimg.com/press"
 				}
 			]
 		}

--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -7550,7 +7550,21 @@
 	{
 		"title": "iLovePDF",
 		"hex": "E5322D",
-		"source": "https://www.ilovepdf.com/press"
+		"source": "https://www.ilovepdf.com/press",
+		"aliases": {
+			"dup": [
+				{
+					"title": "iLoveIMG",
+					"hex": "4D90FE",
+					"source": "https://www.iloveimg.com/press"
+				},
+				{
+					"title": "iLoveAPI",
+					"hex": "26AEBA",
+					"source": "https://www.iloveapi.com"
+				}
+			]
+		}
 	},
 	{
 		"title": "Image.sc",


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://simpleicons.org/preview
-->

**Issue:** closes #
Related PR: #13278

**Popularity metric:**

<!--
Regardless of whether or not the linked issue (if there is one) has a metric, please include the metric here for PR reviewers to validate. See our contributing guidelines at https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#assessing-popularity for more details on how we assess a brand's popularity.
-->

### Checklist

- [ ] I have reviewed the [forbidden brands](https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#forbidden-brands) list and confirm the brand I am submitting a PR for is not one of them, nor is it a subsidiary of one of those brands
- [ ] I have reviewed the brand's terms of service, and am confident we can add this icon
- [x] I updated the JSON data in `data/simple-icons.json`
- [ ] I optimized the icon with SVGO or SVGOMG
- [ ] The SVG `viewbox` is `0 0 24 24`

### Description

<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
