### PR TITLE
Remove redundant ESLint plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
 				"chalk": "5.4.1",
 				"editorconfig-checker": "6.0.1",
 				"esbuild": "0.25.3",
-				"eslint-plugin-import-x": "4.13.3",
 				"eslint-plugin-jsdoc": "50.6.11",
 				"fake-diff": "1.0.0",
 				"fast-fuzzy": "1.12.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
 		"chalk": "5.4.1",
 		"editorconfig-checker": "6.0.1",
 		"esbuild": "0.25.3",
-		"eslint-plugin-import-x": "4.13.3",
 		"eslint-plugin-jsdoc": "50.6.11",
 		"fake-diff": "1.0.0",
 		"fast-fuzzy": "1.12.0",

--- a/xo.config.mjs
+++ b/xo.config.mjs
@@ -1,7 +1,6 @@
 /**
  * @file XO Flat config file.
  */
-import {importX} from 'eslint-plugin-import-x';
 import jsdoc from 'eslint-plugin-jsdoc';
 
 const xoConfig = [
@@ -10,7 +9,7 @@ const xoConfig = [
 	},
 	jsdoc.configs['flat/recommended'],
 	{
-		plugins: {jsdoc, 'import-x': importX},
+		plugins: {jsdoc},
 		rules: {
 			'sort-imports': [
 				'error',


### PR DESCRIPTION
XO already has `import-x` configured. We don't need to specify it again in the `xo.config.mjs`.