### PR TITLE
Add Braintrust icon

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -2285,6 +2285,11 @@
 		"source": "https://www.braintreepayments.com/press"
 	},
 	{
+		"title": "Braintrust",
+		"hex": "000000",
+		"source": "https://github.com/simple-icons/simple-icons/issues/13497#issuecomment-2992162934"
+	},
+	{
 		"title": "Brandfetch",
 		"hex": "0084FF",
 		"source": "https://brandfetch.com/brandfetch.com",

--- a/icons/braintrust.svg
+++ b/icons/braintrust.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Braintrust</title></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Braintrust</title><g class="layer"><title>Layer 1</title><path d="M.08 12C.08 5.42 5.42.08 12 .08S23.92 5.42 23.92 12 18.58 23.92 12 23.92H2.09a2 2 0 0 1-2-2v-9.91z" style="fill-rule:evenodd"/></g></svg>

--- a/icons/braintrust.svg
+++ b/icons/braintrust.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 446.21 446.19">
+  <!-- Generator: Adobe Illustrator 29.1.0, SVG Export Plug-In . SVG Version: 2.1.0 Build 142)  -->
+  <defs>
+    <style>
+      .st0 {
+        fill-rule: evenodd;
+      }
+    </style>
+  </defs>
+  <path class="st0" d="M0,223.1C0,99.88,99.89,0,223.1,0s223.1,99.88,223.1,223.1-99.89,223.1-223.1,223.1H37.53c-20.72,0-37.53-16.8-37.53-37.52v-185.58Z"/>
+</svg>

--- a/icons/braintrust.svg
+++ b/icons/braintrust.svg
@@ -1,12 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 446.21 446.19">
-  <!-- Generator: Adobe Illustrator 29.1.0, SVG Export Plug-In . SVG Version: 2.1.0 Build 142)  -->
-  <defs>
-    <style>
-      .st0 {
-        fill-rule: evenodd;
-      }
-    </style>
-  </defs>
-  <path class="st0" d="M0,223.1C0,99.88,99.89,0,223.1,0s223.1,99.88,223.1,223.1-99.89,223.1-223.1,223.1H37.53c-20.72,0-37.53-16.8-37.53-37.52v-185.58Z"/>
-</svg>
+<svg role="img" viewBox="0 0 446.21 446.19" xmlns="http://www.w3.org/2000/svg"><path d="M0 223.1C0 99.88 99.89 0 223.1 0s223.1 99.88 223.1 223.1-99.89 223.1-223.1 223.1H37.53C16.81 446.2 0 429.4 0 408.68z" style="fill-rule:evenodd"/></svg>

--- a/icons/braintrust.svg
+++ b/icons/braintrust.svg
@@ -1,1 +1,1 @@
-<svg role="img" viewBox="0 0 446.21 446.19" xmlns="http://www.w3.org/2000/svg"><path d="M0 223.1C0 99.88 99.89 0 223.1 0s223.1 99.88 223.1 223.1-99.89 223.1-223.1 223.1H37.53C16.81 446.2 0 429.4 0 408.68z" style="fill-rule:evenodd"/></svg>
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Braintrust</title></svg>


### PR DESCRIPTION
**Issue:** https://github.com/simple-icons/simple-icons/issues/13497

**Popularity metric:**

- Similarweb global rank: [267622](https://www.similarweb.com/website/braintrust.dev/)
- GitHub stars: [526](https://github.com/braintrustdata/autoevals)

### Checklist

- [x] I have reviewed the [forbidden brands](https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#forbidden-brands) list and confirm the brand I am submitting a PR for is not one of them, nor is it a subsidiary of one of those brands
- [x] I have reviewed the brand's terms of service, and am confident we can add this icon
- [x] I updated the JSON data in `data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`
