### PR TITLE
Fix linting after build

### DIFF
--- a/sdk.d.ts
+++ b/sdk.d.ts
@@ -45,9 +45,6 @@ type DuplicateAlias = {
 
 /**
  * The data for a Simple Icon.
- *
- * Corresponds to the data stored for each icon in the *data/simple-icons.json* file.
- * @see {@link https://github.com/mondeja/simple-icons/blob/utils-entrypoint/CONTRIBUTING.md#7-update-the-json-data-for-simpleiconsorg Update the JSON Data for SimpleIcons.org}
  */
 export type IconData = {
 	title: string;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -4,16 +4,18 @@
  */
 
 // The index.mjs file is generated on build before running tests
-// @ts-expect-error
-import * as simpleIcons from '../index.mjs';
+// @ts-ignore
+import * as rawSimpleIcons from '../index.mjs';
 import {getIconSlug, getIconsData, slugToVariableName} from '../sdk.mjs';
 import {testIcon} from './test-icon.js';
 
-for (const icon of await getIconsData()) {
-	const slug = getIconSlug(icon);
+/** @type {{ [key: string]: import('../types.d.ts').SimpleIcon }} */
+const simpleIcons = rawSimpleIcons;
+
+for (const iconData of await getIconsData()) {
+	const slug = getIconSlug(iconData);
 	const variableName = slugToVariableName(slug);
-	/** @type {import('../types.d.ts').SimpleIcon} */
 	const subject = simpleIcons[variableName];
 
-	testIcon(icon, subject, slug);
+	testIcon(iconData, subject, slug);
 }


### PR DESCRIPTION
Currently, running `npm run build && npm run lint`, the linting process will fail at `tslint` script:

```
> simple-icons@15.2.0 tslint
> npm run tslint:main && npm run tslint:sdk


> simple-icons@15.2.0 tslint:main
> tsc -p jsconfig.json

tests/index.test.js:7:1 - error TS2578: Unused '@ts-expect-error' directive.

7 // @ts-expect-error
  ~~~~~~~~~~~~~~~~~~~

tests/index.test.js:16:18 - error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'typeof import("/.../simple-icons/index", { with: { "resolution-mode": "import" } })'.
  No index signature with a parameter of type 'string' was found on type 'typeof import("/.../simple-icons/index", { with: { "resolution-mode": "import" } })'.

16  const subject = simpleIcons[variableName];
                    ~~~~~~~~~~~~~~~~~~~~~~~~~


Found 2 errors in the same file, starting at: tests/index.test.js:7

```

This PR fixes that and removes a 404 link from the source code.