### PR TITLE
Allow license icons

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,7 @@ We welcome icon requests. Before you submit a new issue please make sure the ico
     - Allowed: Space agencies
   - Symbols, including flags and banners
     - Allowed: standards like FCC, CE, CCC, RoHS...
+    - Allowed: licenses like CC, Unlicense, MIT...
   - Sport clubs
     - Allowed: Sports organizations
   - Yearly releases


### PR DESCRIPTION
We are currently in a limbo regarding license icons. Although, CC, Unlicense and BSD have been added to the library, our contributing guidelines states that symbols are not allowed.

This PR is an attempt to formalize allowing of licenses. This would make #7544 possible, which currently is blocked because fall in the category of Universities, which are forbidden brands.