### PR TITLE
Add `dependencies` label with labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,3 +26,6 @@ meta:
         '*',
       ]
     status: modified
+dependencies:
+  - all: ['package-lock.json']
+    status: modified


### PR DESCRIPTION
Since we've a *package-lock.json* file, we can add `dependencies` label with the labeler action when it is modified.