### PR TITLE
Don't run Renovate and Create Release workflows on forks

### DIFF
--- a/.github/actions/check-is-fork/action.yml
+++ b/.github/actions/check-is-fork/action.yml
@@ -1,0 +1,28 @@
+# If some workflows are executed in a fork, we don't want to run them
+# because would fail due to missing permissions and will generate
+# noise for activity watchers.
+
+name: Check if running in a fork
+description: Check if a workflow is running in a forked repository and set an output accordingly.
+
+inputs:
+  in-fork-message:
+    description: Message to display when the workflow is running in a fork.
+    required: true
+outputs:
+  is-fork:
+    description: Indicates if the current repository is a fork.
+    value: ${{ steps.check-is-fork.outputs.is-fork }}
+
+runs:
+  using: composite
+  steps:
+    - id: check-is-fork
+      shell: bash
+      run: |
+        if [ "${{ github.repository_owner }}" != "simple-icons" ]; then
+          echo "is-fork=true" >> $GITHUB_OUTPUT
+          echo "${{ inputs.in-fork-message }}"
+        else
+          echo "is-fork=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,9 +16,23 @@ on:
 # Replacing <token> by a personal access token with scope `public_repo`
 
 jobs:
+  check-is-fork:
+    name: Check if running in a fork
+    runs-on: ubuntu-latest
+    outputs:
+      is-fork: ${{ steps.check.outputs.is-fork }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/check-is-fork
+        id: check
+        with:
+          in-fork-message: 'Create Release Pull Request workflow only can run in the main repository, skipping.'
   release-pr:
     runs-on: ubuntu-latest
-    if: github.event_name != 'push'
+    needs: check-is-fork
+    if: |
+      github.event_name != 'push' &&
+      needs.check-is-fork.outputs.is-fork != 'true'
     outputs:
       did-create-pr: ${{ steps.release.outputs.did-create-pr }}
       new-version: ${{ steps.release.outputs.new-version }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -6,8 +6,21 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-is-fork:
+    name: Check if running in a fork
+    runs-on: ubuntu-latest
+    outputs:
+      is-fork: ${{ steps.check.outputs.is-fork }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/check-is-fork
+        id: check
+        with:
+          in-fork-message: 'Renovate workflow only can run in the main repository, skipping.'
   renovate:
     runs-on: ubuntu-latest
+    needs: check-is-fork
+    if: needs.check-is-fork.outputs.is-fork != 'true'
     timeout-minutes: 15
     steps:
       - uses: actions/create-github-app-token@v2


### PR DESCRIPTION
Following from https://github.com/simple-icons/simple-icons-font/pull/236 and https://github.com/simple-icons/simple-icons-website-rs/pull/382

When sheduled workflows are executed in forks, they fail with strange error messages and generate noise activity for repository watchers.

You can see the same implementation tested in simple-icons-font [here](https://github.com/simple-icons/simple-icons-font/actions/runs/15900152929) and in my fork [here](https://github.com/mondeja/simple-icons-font/actions/runs/15900140889/job/44840954665).