### PR TITLE
change the brand guidelines link for unity

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -17296,7 +17296,7 @@
 		"title": "Unity",
 		"hex": "FFFFFF",
 		"source": "https://brand.unity.com",
-		"guidelines": "https://brand.unity.com"
+		"guidelines": "https://unity.com/legal/branding-trademarks"
 	},
 	{
 		"title": "UnJS",


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://simpleicons.org/preview
-->

**Issue:** closes a part of #11901

<!--
Regardless of whether or not the linked issue (if there is one) has a metric, please include the metric here for PR reviewers to validate. See our contributing guidelines at https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#assessing-popularity for more details on how we assess a brand's popularity.
-->

### Description

The guidelines were just the link to the site and not the actual brand guidelines (it may have been updated).

The link already there was: https://brand.unity.com/

The updated brand guidelines link is: https://unity.com/legal/branding-trademarks

<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
