### PR TITLE
Update Kdenlive source URL

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -8519,8 +8519,8 @@
 	{
 		"title": "Kdenlive",
 		"hex": "527EB2",
-		"source": "https://kdenlive.org/en/trademark-logo/",
-		"guidelines": "https://kdenlive.org/en/trademark-logo/"
+		"source": "https://kdenlive.org/trademark-logo/",
+		"guidelines": "https://kdenlive.org/trademark-logo/"
 	},
 	{
 		"title": "Kedro",


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://simpleicons.org/preview
-->

<!--
Regardless of whether or not the linked issue (if there is one) has a metric, please include the metric here for PR reviewers to validate. See our contributing guidelines at https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#assessing-popularity for more details on how we assess a brand's popularity.
-->

### Checklist

- [ ] I have reviewed the [forbidden brands](https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#forbidden-brands) list and confirm the brand I am submitting a PR for is not one of them, nor is it a subsidiary of one of those brands
- [ ] I have reviewed the brand's terms of service, and am confident we can add this icon
- [x] I updated the JSON data in `data/simple-icons.json`
- [ ] I optimized the icon with SVGO or SVGOMG
- [ ] The SVG `viewbox` is `0 0 24 24`

### Description

The current URL (https://kdenlive.org/en/trademark-logo/) does not exist anymore. It has been changed at some point to https://kdenlive.org/trademark-logo/

<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
