### PR TITLE
Add slug to data JSON distribution file

### DIFF
--- a/data/simple-icons.d.ts
+++ b/data/simple-icons.d.ts
@@ -10,7 +10,7 @@ export type IconData = {
 	title: string;
 	hex: string;
 	source: string;
-	slug?: string;
+	slug: string;
 	guidelines?: string;
 	license?: Omit<SPDXLicense, 'url'> | CustomLicense;
 	aliases?: Aliases;

--- a/scripts/add-icon-data.js
+++ b/scripts/add-icon-data.js
@@ -115,6 +115,7 @@ const answers = {
 	title: '',
 	hex: '',
 	source: '',
+	slug: '',
 };
 
 answers.title = await input({

--- a/scripts/release/minify-icons-data.js
+++ b/scripts/release/minify-icons-data.js
@@ -4,8 +4,11 @@
  * @file
  * Minify data/simple-icons.json file.
  */
-import {getIconsData} from '../../sdk.mjs';
-import {writeIconsData} from '../utils.js';
+import {getIconSlug, getIconsData} from '../../sdk.mjs';
+import {formatIconData, writeIconsData} from '../utils.js';
 
-const icons = await getIconsData();
-await writeIconsData(icons, true);
+const plainIcons = await getIconsData();
+const iconsWithSlugs = plainIcons.map((icon) =>
+	icon.slug ? icon : {...icon, slug: getIconSlug(icon)},
+);
+await writeIconsData(formatIconData(iconsWithSlugs), true);


### PR DESCRIPTION
This PR adds the `slug` to our data JSON distribution file. This provides a convenient way for getting the `slug` from a non-JavaScript language.