### PR TITLE
Fix prepare script for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"lint": "npm run ourlint && npm run prettierlint && npm run jslint && npm run jsonlint && npm run svglint && npm run wslint && npm run tslint && npm run markdownlint",
 		"markdownlint": "markdownlint-cli2 '**/*.md' '#node_modules'",
 		"ourlint": "node scripts/lint/ourlint.js",
-		"prepare": "node -e 'process.exit(process.env.CI ? 0 : 1)' || husky",
+		"prepare": "node -e \"process.exit(process.env.CI ? 0 : 1)\" || husky",
 		"prepublishOnly": "npm run build",
 		"prettier": "prettier --ignore-unknown \"**/*.!(js|jsx|mjs|cjs|ts|tsx|mts|cts|svg)\"",
 		"prettierlint": "npm run prettier -- --check --cache",


### PR DESCRIPTION
Fix the invalid `'` on Windows.

<img width="507" height="321" alt="image" src="https://github.com/user-attachments/assets/ee246d63-0f62-450a-9823-b85e66ca15e8" />