### PR TITLE
Update AssemblyScript color

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -1439,7 +1439,7 @@
 	},
 	{
 		"title": "AssemblyScript",
-		"hex": "007AAC",
+		"hex": "007ACC",
 		"source": "https://www.assemblyscript.org"
 	},
 	{


### PR DESCRIPTION
### Description

From https://www.assemblyscript.org/, the true color should be `#007ACC`