### PR TITLE
Update Scratch color

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -14628,7 +14628,7 @@
 	},
 	{
 		"title": "Scratch",
-		"hex": "4D97FF",
+		"hex": "855CD6",
 		"source": "https://github.com/LLK/scratch-link/blob/027e3754ba6db976495e905023d5ac5e730dccfc/Assets/Windows/SVG/Windows%20Tray%20400x400.svg"
 	},
 	{


### PR DESCRIPTION
As described by [this Scratch Wiki article](https://en.scratch-wiki.info/wiki/Accessibility_Color_Changes), on January 31st, 2023, Scratch changed its brand color from blue to purple, due to accessibility concerns with the former hue. Therefore, the simple icons color for the platform needs to be updated to reflect this. The new color's hex is #855cd6. 

Here are the before and after simple icons previews respectively:

**Before:**
<img width="740" height="490" alt="scratch(1)" src="https://github.com/user-attachments/assets/c2b66067-7e65-4fab-bc75-8cccd6396781" />

**After:**
<img width="740" height="490" alt="scratch" src="https://github.com/user-attachments/assets/8732223c-c741-443b-a5f1-4b95df8ef8b8" />
