### PR TITLE
Update color for Lua

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -9627,7 +9627,7 @@
 	},
 	{
 		"title": "Lua",
-		"hex": "2C2D72",
+		"hex": "00007C",
 		"source": "https://www.lua.org/images/",
 		"guidelines": "https://www.lua.org/images/"
 	},

--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -9627,7 +9627,7 @@
 	},
 	{
 		"title": "Lua",
-		"hex": "00007C",
+		"hex": "000080",
 		"source": "https://www.lua.org/images/",
 		"guidelines": "https://www.lua.org/images/"
 	},


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://simpleicons.org/preview
-->

### Description
The current color for the Lua logo is #00007C, but the color listed on Simple Icons is #2C2D72. This PR fixes that.

The color is sourced from this page:
[Lua: Logos](https://www.lua.org/images/)

### Preview:
**Old Color:**  
<img width="925" height="612" alt="lua (2)" src="https://github.com/user-attachments/assets/97ee3532-5df2-4ef7-90fc-9e6ae849cd06" />
**New Color:**  
<img width="925" height="612" alt="lua" src="https://github.com/user-attachments/assets/c0857a44-c6c4-4d8c-9e82-f83c1e66dcb3" />