### PR TITLE
Remove `permission in review` when closing PRs/issues

### DIFF
--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -34,6 +34,7 @@ jobs:
             invalid
             out of scope
             pending
+            permission in review
             permission required
             won't add
 
@@ -56,6 +57,7 @@ jobs:
             in discussion
             pending
             assessing
+            permission in review
 
   remove-closed-issue-labels:
     name: Remove closed issue labels
@@ -74,3 +76,4 @@ jobs:
             in discussion
             pending
             assessing
+            permission in review


### PR DESCRIPTION
Here is an example: https://github.com/simple-icons/simple-icons/issues/13832.

~~We don't need a https://github.com/simple-icons/simple-icons/labels/permissions%20in%20review label for autoclose issues. I've changed the labeling method to set.~~

~~The https://github.com/simple-icons/simple-icons/labels/new%20icon label is not needed either since we have the https://github.com/simple-icons/simple-icons/labels/won%27t%20add label.~~