### PR TITLE
Add Coolify icon

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -3564,6 +3564,11 @@
 		"guidelines": "https://www.coolermaster.com/branding"
 	},
 	{
+		"title": "Coolify",
+		"hex": "6B16ED",
+		"source": "https://github.com/coollabsio/coolify/blob/ac1d98f6035caff10f36fa10508326b4791dec07/public/coolify-logo-monochrome.svg"
+	},
+	{
 		"title": "Copa Airlines",
 		"hex": "0032A0",
 		"source": "https://www.copaair.com"

--- a/icons/coolify.svg
+++ b/icons/coolify.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Coolify</title><path d="M4.364 4.364V0h17.454v4.364zm0 13.09H0V4.365h4.364zm0 0h17.454v4.364H4.364ZM6.545 6.546v-1.7H22.3V2.182H24v4.363zm0 0v10.4h-1.7v-10.4ZM3.882 17.936v1.7h-1.7v-1.7ZM24 24H6.545v-1.7H22.3v-2.664H24Z"/></svg>


### PR DESCRIPTION
<img width="740" height="520" alt="image" src="https://github.com/user-attachments/assets/37616543-031d-48d3-834b-a9856eb1a774" />

**Issue:**

- Closes #11187
- Closes #11308

**Popularity metric:**

- [Traffic.cv global rank ~101k](https://traffic.cv/coolify.io)
- [500k Docker pulls](https://hub.docker.com/r/coollabsio/coolify)
- [2.5k+ cloud customers according to official website](https://coolify.io/)
- [289k self-hosted instances according to official website](https://coolify.io/)
- [46k+ stars on GitHub](https://github.com/coollabsio/coolify)
- [Multiple corporate sponsors according to official website](https://coolify.io/)

**Terms of Service link:**

No official brand guidelines as far as I know, but I've [discussed adding logo to Simple Icons](https://github.com/coollabsio/coolify/discussions/6409) with lead maintainer and [contributed updated logo files](https://github.com/coollabsio/coolify/pull/6541).

<!--
As part of the checklist below, you acknowledge you have reviewed the terms of service of a brand, to ensure we are granted permission to include this brand. Please link here to the terms you have reviewed, to make maintainer review easier. Ideally link to a section and/or paragraph.
-->

### Checklist

- [x] I have reviewed the [forbidden brands](https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#forbidden-brands) list and confirm the brand I am submitting a PR for is not one of them, nor is it a subsidiary of one of those brands
- [x] I have reviewed the brand's terms of service, and am confident we can add this icon
- [x] I updated the JSON data in `data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description

The color hex is based on the primary brand color hex used in various places. This color is different from the primary and secondary colors of [the official logo](https://github.com/coollabsio/coolify/blob/ac1d98f6035caff10f36fa10508326b4791dec07/public/coolify-logo.svg).

Brand color sources:

- [CSS variable in main project repository](https://github.com/coollabsio/coolify/blob/ac1d98f6035caff10f36fa10508326b4791dec07/resources/css/app.css#L24)
- [Official website Tailwind color theme](https://github.com/coollabsio/coolify.io/blob/1badbb994581a1aa82fb8c01d1c87bc50ddc234c/tailwind.config.cjs#L35C16-L35C22)
- [Official documentation CTA button](https://github.com/coollabsio/coolify-docs/blob/c95de3376913e8257da7cefa0ccef97a5c20eee0/docs/index.md?plain=1#L13)