### PR TITLE
Fix typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -538,7 +538,7 @@ docker run -it --rm --entrypoint "/bin/ash" simple-icons
 
 ## Developing Third-Party Extensions
 
-A SDK is included in the `simple-icons/sdk` entrypoint of the npm package to make it easier the development of third party extensions with JavaScript and TypeScript.
+An SDK is included in the `simple-icons/sdk` entrypoint of the npm package to make it easier the development of third party extensions with JavaScript and TypeScript.
 
 ```typescript
 import {getIconsData, type IconData} from 'simple-icons/sdk';


### PR DESCRIPTION
## Description
Fixed a grammar error in CONTRIBUTING.md where "A SDK" was incorrectly used instead of "An SDK". Since "SDK" starts with a vowel sound (ess-dee-kay), it requires the article "an" instead of "a".

## Changes Made
- Changed "A SDK" to "An SDK" in the "Developing Third-Party Extensions" section

## Testing
- [x] All tests pass (`npm test`)
- [x] All linting passes (`npm run lint`)
- [x] No other files modified

## Type of Change
- [x] Documentation fix