### PR TITLE
Add Zephyr Project icon (#13922)

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -19108,6 +19108,18 @@
 		"source": "https://www.zensar.com/about/our-story/our-brand/#logo"
 	},
 	{
+		"title": "Zephyr Project",
+		"slug": "zephyrproject",
+		"hex": "0070C5",
+		"source": "https://www.zephyrproject.org",
+		"svg": "<path d=\"M0 22.412L16.557 7.18L24 17.042L0 22.412ZM0 22.412L7.071 0L16.557 7.18L0 22.412ZM7.071 0H24L16.557 7.18L7.071 0ZM24 17.042V0L16.557 7.18L24 17.042Z\"/>",
+		"license": {
+			"type": "custom",
+			"url": "https://www.linuxfoundation.org/trademark-usage"
+		}
+	},
+
+	{
 		"title": "Zerodha",
 		"hex": "387ED1",
 		"source": "https://zerodha.com"

--- a/icons/zephyrproject.svg
+++ b/icons/zephyrproject.svg
@@ -1,0 +1,4 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <title>Zephyr Project</title>
+  <path d="M0 22.412L16.557 7.18L24 17.042L0 22.412ZM0 22.412L7.071 0L16.557 7.18L0 22.412ZM7.071 0H24L16.557 7.18L7.071 0ZM24 17.042V0L16.557 7.18L24 17.042Z"/>
+</svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://simpleicons.org/preview
-->

**Issue:** closes #13922

**Popularity metric:**
Traffic.cv global rank for https://www.zephyrproject.org: **118,501**  
(Source provided in the referenced issue)

**Terms of Service link:**
https://www.linuxfoundation.org/trademark-usage  
(Zephyr Project is under the Linux Foundation, so its trademark guidelines apply. Reviewed to ensure we are permitted to add the icon.)

### Checklist

- [x] I have reviewed the forbidden brands list and confirm the brand is not listed
- [x] I have reviewed the brand's terms of service and am confident we can add this icon
- [x] I updated the JSON data in `data/simple-icons.json`
- [x] I optimized the icon with SVGO/SVGOMG
- [x] The SVG `viewBox` is `0 0 24 24`

### Description

This PR adds the **Zephyr Project** icon, using the official SVG asset:

`https://zephyrproject.org/wp-content/uploads/2021/11/zephyr_logo_r_color_negative_big.svg`

Only the primary kite mark is included, following the Simple Icons guidelines:
- removed text elements  
- removed gradients and color  
- merged multiple polygons into a single `<path>`  
- scaled and centered within the 24×24 grid  

Brand color `#0070C5` was chosen from the primary color set listed in the issue.

The resulting icon is a faithful, monochrome, simplified silhouette of the official Zephyr Project mark and complies fully with Simple Icons contribution requirements.
