### PR TITLE
Add Supercell icon

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -15999,6 +15999,12 @@
 		"guidelines": "https://stackoverflow.com/legal/trademark-guidance"
 	},
 	{
+		"title": "Supercell",
+		"hex": "FFFFFF",
+		"source": "https://supercell.com",
+		"guidelines": "https://brand.supercell.com/media#/supercell-brand/supercell-logo"
+	},
+	{
 		"title": "Supercrease",
 		"hex": "000000",
 		"source": "https://supercrease.com/wp-content/themes/super-crease/assets/svgs/super-crease.svg"

--- a/icons/supercell.svg
+++ b/icons/supercell.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Supercell</title><path d="M0 0h24v24H0z"/></svg>


### PR DESCRIPTION
This PR adds the Supercell icon.

Fixes #13538

- Added official monochrome SVG
- Added metadata in data/simple-icons.json
- Based on brand assets: https://brand.supercell.com/media#/supercell-brand/supercell-logo
