### PR TITLE
Add PicoCTF icon

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -12462,6 +12462,12 @@
 		"source": "https://picnic.app/nl/feestdagen/"
 	},
 	{
+		"title": "PicoCTF",
+		"slug": "picoctf",
+		"hex": "C41230",
+		"source": "https://picoctf.org/"
+	},
+	{
 		"title": "PicPay",
 		"hex": "21C25E",
 		"source": "https://www.picpay.com/site/sobre-nos"

--- a/icons/picoctf.svg
+++ b/icons/picoctf.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>PicoCTF</title><path d="M12 0L24 6.7v10.6L12 24 0 17.3V6.7L12 0Zm0 3.8L4 8.4v7.2l8 4.6 8-4.6V8.4l-8-4.6Zm3 5.3v5l-3 1.7-3-1.7v-5l3-1.7 3 1.7Z"/></svg>


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://simpleicons.org/preview
-->

**Issue:** closes #10524

**Popularity metric:**
SimilarWeb global rank for picoCTF.org: **#108,758**  
Source: https://www.similarweb.com/website/picoctf.org/#overview

**Terms of Service link:**
PicoCTF does not have explicit icon/brand usage restrictions.  
General site ToS: https://picoctf.org/

### Checklist

- [x] I have reviewed the forbidden brands list and confirm the brand is not listed
- [x] I have reviewed the brand's terms of service and am confident we can add this icon
- [x] I updated the JSON data in `data/simple-icons.json`
- [x] I optimized the icon with SVGO and ensured a single path
- [x] The SVG `viewBox` is `0 0 24 24`

### Description

This PR adds the PicoCTF brand icon.

- Extracted the logo from the official website (https://picoctf.org/).
- Rebuilt the mark as a single combined path to follow Simple Icons requirements.
- Normalized to a 24×24 `viewBox`.
- Chosen brand color: **#C41230**, used by PicoCTF in their primary branding.
- All tests pass successfully using `npm test`.
