### PR TITLE
Restrict icon removal PRs to maintainers only

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -48,6 +48,8 @@ Should a brand wish for their icon or data to be updated, please [submit an issu
 
 Should a brand wish for their icon to be removed from the package, contact `removals at simpleicons dot org` explaining your affiliation with the company, and reasons for removal. Alternatively, it is also possible to [submit an issue][removal-issues] on [the Simple Icons GitHub repository] with the same information. We generally remove icons that no longer [meet our criteria] twice a year in our major releases - but can occasionally make exceptions for immediate removal of brands.
 
+The pull request of icon removal must be submitted by the Simple Icons maintainer.
+
 [meet our criteria]: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#requesting-an-icon
 [icon-outdated-issues]: https://github.com/simple-icons/simple-icons/issues/new?assignees=&labels=update+icon%2Fdata&template=icon_update.yml&title=Update%3A+
 [removal-issues]: https://github.com/simple-icons/simple-icons/issues/new?assignees=&labels=breaking+change&template=icon_removal.yml&title=Remove%3A+


### PR DESCRIPTION
 It always feels strange when I see a random person when I reference a past icon removal PR.