### PR TITLE
Fix rendering of README table icons in released packages

### DIFF
--- a/scripts/release/reformat-markdown.js
+++ b/scripts/release/reformat-markdown.js
@@ -26,8 +26,9 @@ const reformat = async (filePath) => {
 		fileContent
 			// Add &nbsp; spaces after icons that are inside a CDN link before text
 			// Fixes rendering in npmjs.com and packagist.org
+			// Reference: https://github.com/simple-icons/simple-icons/pull/14248
 			.replaceAll(
-				/<img src="https:\/\/cdn.simpleicons.org\/([^\/]+)\/000\/fff"([^>]+)>([^<]+)<\/a>/g,
+				/<img src="https:\/\/cdn.simpleicons.org\/([^/]+)\/000\/fff"([^>]+)>([^<]+)<\/a>/g,
 				'<img src="https://cdn.simpleicons.org/$1/000/fff"$2>&nbsp;$3</a>',
 			)
 			// Replace all CDN links with raw links


### PR DESCRIPTION
Add a `&nbsp;` space after icons that are inside a HTML link and placed before the text that the link contains. In theory, this fixes the bad rendering in npmjs and Packagist:

<img width="550" height="468" alt="image" src="https://github.com/user-attachments/assets/7d6a3ecc-e0cc-4e07-83da-730bc11aa82f" />


Should render like:

<img width="565" height="366" alt="image" src="https://github.com/user-attachments/assets/a36f03b8-a38b-451e-accc-639eb95720f9" />