### PR TITLE
Update Corsair brand guidelines link

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -3592,7 +3592,7 @@
 		"title": "Corsair",
 		"hex": "000000",
 		"source": "https://www.corsair.com",
-		"guidelines": "https://www.corsair.com/press"
+		"guidelines": "https://www.corsair.com/newsroom"
 	},
 	{
 		"title": "Couchbase",


### PR DESCRIPTION
**Issue:** closes #14252

**Popularity metric:**
Corsair is a globally recognized PC hardware and gaming peripherals brand with strong presence across gaming, streaming, and PC enthusiast communities.

**Terms of Service link:**
https://www.corsair.com/us/en/s/terms-of-use

### Checklist

- [x] I have reviewed the forbidden brands list and confirm the brand I am submitting a PR for is not one of them, nor is it a subsidiary of one of those brands
- [x] I have reviewed the brand's terms of service, and am confident we can add this icon
- [x] I updated the JSON data in `data/simple-icons.json`
- [ ] I optimized the icon with SVGO or SVGOMG
- [ ] The SVG `viewbox` is `0 0 24 24`

### Description

This PR updates the outdated Corsair brand guidelines link.  
The previous link redirected through the deprecated `/press` page.  
It has been replaced with a direct and current link to Corsair’s newsroom page that hosts the official company logos and brand assets.
