### PR TITLE
fix: correct 'Typescript' typo to 'TypeScript' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you need to iterate over all icons, use:
 import * as icons from 'simple-icons';
 ```
 
-#### TypeScript Usage <img src="https://cdn.simpleicons.org/typescript/000/fff" alt="Typescript" align=left width=19 height=19>
+#### TypeScript Usage <img src="https://cdn.simpleicons.org/typescript/000/fff" alt="TypeScript" align=left width=19 height=19>
 
 Type definitions are bundled with the package.
 


### PR DESCRIPTION
This PR fixes a minor typo in the README.md file.

## Changes
- Fixed the alt text 'Typescript' to 'TypeScript' (correct casing with capital 'S') in the TypeScript Usage section.

The official name of the language is 'TypeScript' with a capital 'S'.