### PR TITLE
Fix Corsair brand asset link

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -3592,7 +3592,7 @@
 		"title": "Corsair",
 		"hex": "000000",
 		"source": "https://www.corsair.com",
-		"guidelines": "https://www.corsair.com/press"
+		"guidelines": "https://cwsmgmt.corsair.com/press/CORSAIR_Brand_Book_Lite.pdf"
 	},
 	{
 		"title": "Couchbase",
@@ -10815,7 +10815,7 @@
 	{
 		"title": "MyAnimeList",
 		"hex": "2E51A2",
-		"source": "https://myanimelist.net/wrap-up/anime-logo-mobile.svg",
+		"source": "https://myanimelist.net",
 		"aliases": {
 			"aka": [
 				"MAL"


### PR DESCRIPTION
**Issue:** closes #14252

**Popularity metric:**
Corsair is a globally recognized PC hardware and gaming peripherals brand with a strong online presence and widespread use in the gaming and tech community.

**Terms of Service link:**
https://www.corsair.com/us/en/s/terms-of-use

### Checklist

- [x] I have reviewed the forbidden brands list and confirm the brand I am submitting a PR for is not one of them, nor is it a subsidiary of one of those brands
- [x] I have reviewed the brand's terms of service, and am confident we can add this icon
- [x] I confirm that I did not use AI tools to create this PR, or that any AI assistance has been fully disclosed in this PR
- [x] I updated the JSON data in `data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG
- [x] The SVG `viewbox` is `0 0 24 24`

### Description

The previous newsroom link did not include the required brand assets mentioned in the issue.  
I have replaced it with the official Corsair brand guideline PDF link, which directly provides the logo and guiding assets referenced in issue #14252.
