### PR TITLE
Remove ToC from documentations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,17 +34,6 @@ Simple Icons welcomes contributions and corrections. Before contributing, please
 1. Commit and push to the new branch
 1. Make a pull request
 
-## Table of contents
-
-- [Requesting an Icon](#requesting-an-icon)
-  - [Forbidden Brands](#forbidden-brands)
-  - [Assessing Popularity](#assessing-popularity)
-  - [Opening an Issue](#opening-an-issue)
-- [Adding or Updating an Icon](#adding-or-updating-an-icon)
-  - [Requesting Permission](#requesting-permission)
-- [Testing Package Locally](#testing-package-locally)
-- [Using Docker](#using-docker)
-
 ## Requesting an Icon
 
 We welcome icon requests. Before you submit a new issue please make sure the icon:

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -2,13 +2,6 @@
 
 Simple Icons asks that its users read this disclaimer fully before including an icon in their project.
 
-## Table of Contents
-
-- [Licenses, Copyrights & Trademarks](#licenses-copyrights--trademarks)
-- [Brand Guidelines](#brand-guidelines)
-- [Update of Brands](#update-of-brands)
-- [Removal of Brands](#removal-of-brands)
-
 ## Licenses, Copyrights & Trademarks
 
 > [!IMPORTANT]\


### PR DESCRIPTION
The ToC is lacking in maintenance, and GitHub has a built-in [outline feature](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for markdown.

