### PR TITLE
Replace Prettier by Oxfmt

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 		"vscode": {
 			"extensions": [
 				"EditorConfig.EditorConfig",
-				"esbenp.prettier-vscode",
+				"oxc.oxc-vscode",
 				"samverschueren.linter-xo",
 				"rvben.rumdl"
 			]

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,9 @@
+{
+	"useTabs": true,
+	"singleQuote": true,
+	"bracketSpacing": false,
+	"proseWrap": "never",
+	"embeddedLanguageFormatting": "off",
+	"printWidth": 80,
+	"ignorePatterns": ["LICENSE.md", "slugs.md", "data/simple-icons.json"]
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,0 @@
-# We prefer our own custom formatting for MarkDown files.
-# See the following thread for the discussion:
-#   https://github.com/simple-icons/simple-icons-font/pull/73
-LICENSE.md
-slugs.md
-
-# We use our own formatting for the data files.
-data/simple-icons.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,8 +1,0 @@
-{
-	"plugins": ["prettier-plugin-packagejson"],
-	"useTabs": true,
-	"singleQuote": true,
-	"bracketSpacing": false,
-	"proseWrap": "never",
-	"embeddedLanguageFormatting": "off"
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"jsonschema": "1.5.0",
 				"mocha": "11.7.5",
 				"named-html-entities-json": "1.0.0",
-				"prettier-plugin-packagejson": "2.5.19",
+				"oxfmt": "0.32.0",
 				"rumdl": "0.1.12",
 				"spdx-license-ids": "3.0.22",
 				"svg-path-bbox": "2.1.0",
@@ -1802,6 +1802,329 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@oxfmt/binding-android-arm-eabi": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.32.0.tgz",
+			"integrity": "sha512-DpVyuVzgLH6/MvuB/YD3vXO9CN/o9EdRpA0zXwe/tagP6yfVSFkFWkPqTROdqp0mlzLH5Yl+/m+hOrcM601EbA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-android-arm64": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.32.0.tgz",
+			"integrity": "sha512-w1cmNXf9zs0vKLuNgyUF3hZ9VUAS1hBmQGndYJv1OmcVqStBtRTRNxSWkWM0TMkrA9UbvIvM9gfN+ib4Wy6lkQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-darwin-arm64": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.32.0.tgz",
+			"integrity": "sha512-m6wQojz/hn94XdZugFPtdFbOvXbOSYEqPsR2gyLyID3BvcrC2QsJyT1o3gb4BZEGtZrG1NiKVGwDRLM0dHd2mg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-darwin-x64": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.32.0.tgz",
+			"integrity": "sha512-hN966Uh6r3Erkg2MvRcrJWaB6QpBzP15rxWK/QtkUyD47eItJLsAQ2Hrm88zMIpFZ3COXZLuN3hqgSlUtvB0Xw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-freebsd-x64": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.32.0.tgz",
+			"integrity": "sha512-g5UZPGt8tJj263OfSiDGdS54HPa0KgFfspLVAUivVSdoOgsk6DkwVS9nO16xQTDztzBPGxTvrby8WuufF0g86Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.32.0.tgz",
+			"integrity": "sha512-F4ZY83/PVQo9ZJhtzoMqbmjqEyTVEZjbaw4x1RhzdfUhddB41ZB2Vrt4eZi7b4a4TP85gjPRHgQBeO0c1jbtaw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.32.0.tgz",
+			"integrity": "sha512-olR37eG16Lzdj9OBSvuoT5RxzgM5xfQEHm1OEjB3M7Wm4KWa5TDWIT13Aiy74GvAN77Hq1+kUKcGVJ/0ynf75g==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-arm64-gnu": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.32.0.tgz",
+			"integrity": "sha512-eZhk6AIjRCDeLoXYBhMW7qq/R1YyVi+tGnGfc3kp7AZQrMsFaWtP/bgdCJCTNXMpbMwymtVz0qhSQvR5w2sKcg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-arm64-musl": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.32.0.tgz",
+			"integrity": "sha512-UYiqO9MlipntFbdbUKOIo84vuyzrK4TVIs7Etat91WNMFSW54F6OnHq08xa5ZM+K9+cyYMgQPXvYCopuP+LyKw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.32.0.tgz",
+			"integrity": "sha512-IDH/fxMv+HmKsMtsjEbXqhScCKDIYp38sgGEcn0QKeXMxrda67PPZA7HMfoUwEtFUG+jsO1XJxTrQsL+kQ90xQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.32.0.tgz",
+			"integrity": "sha512-bQFGPDa0buYWJFeK2I7ah8wRZjrAgamaG2OAGv+Ua5UMYEnHxmHcv+r8lWUUrwP2oqQGvp1SB8JIVtBbYuAueQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-riscv64-musl": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.32.0.tgz",
+			"integrity": "sha512-3vFp9DW1ItEKWltADzCFqG5N7rYFToT4ztlhg8wALoo2E2VhveLD88uAF4FF9AxD9NhgHDGmPCV+WZl/Qlj8cQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-s390x-gnu": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.32.0.tgz",
+			"integrity": "sha512-Fub2y8S9ImuPzAzpbgkoz/EVTWFFBolxFZYCMRhRZc8cJZI2gl/NlZswqhvJd/U0Jopnwgm/OJ2x128vVzFFWA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-x64-gnu": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.32.0.tgz",
+			"integrity": "sha512-XufwsnV3BF81zO2ofZvhT4FFaMmLTzZEZnC9HpFz/quPeg9C948+kbLlZnsfjmp+1dUxKMCpfmRMqOfF4AOLsA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-linux-x64-musl": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.32.0.tgz",
+			"integrity": "sha512-u2f9tC2qYfikKmA2uGpnEJgManwmk0ZXWs5BB4ga4KDu2JNLdA3i634DGHeMLK9wY9+iRf3t7IYpgN3OVFrvDw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-openharmony-arm64": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.32.0.tgz",
+			"integrity": "sha512-5ZXb1wrdbZ1YFXuNXNUCePLlmLDy4sUt4evvzD4Cgumbup5wJgS9PIe5BOaLywUg9f1wTH6lwltj3oT7dFpIGA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-win32-arm64-msvc": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.32.0.tgz",
+			"integrity": "sha512-IGSMm/Agq+IA0++aeAV/AGPfjcBdjrsajB5YpM3j7cMcwoYgUTi/k2YwAmsHH3ueZUE98pSM/Ise2J7HtyRjOA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-win32-ia32-msvc": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.32.0.tgz",
+			"integrity": "sha512-H/9gsuqXmceWMsVoCPZhtJG2jLbnBeKr7xAXm2zuKpxLVF7/2n0eh7ocOLB6t+L1ARE76iORuUsRMnuGjj8FjQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxfmt/binding-win32-x64-msvc": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.32.0.tgz",
+			"integrity": "sha512-fF8VIOeligq+mA6KfKvWtFRXbf0EFy73TdR6ZnNejdJRM8VWN1e3QFhYgIwD7O8jBrQsd7EJbUpkAr/YlUOokg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {
@@ -3728,32 +4051,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/detect-indent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.2.tgz",
-			"integrity": "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/detect-newline": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-4.0.1.tgz",
-			"integrity": "sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/diff": {
@@ -5781,16 +6078,6 @@
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
-		"node_modules/git-hooks-list": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-4.1.1.tgz",
-			"integrity": "sha512-cmP497iLq54AZnv4YRAEMnEyQ1eIn4tGKbmswqwmFV4GBnAqE8NLtWxxdXa++AalfgL5EBH4IxTPyquEuGY/jA==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/fisker/git-hooks-list?sponsor=1"
-			}
-		},
 		"node_modules/glob": {
 			"version": "10.4.5",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -7742,6 +8029,46 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/oxfmt": {
+			"version": "0.32.0",
+			"resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.32.0.tgz",
+			"integrity": "sha512-KArQhGzt/Y8M1eSAX98Y8DLtGYYDQhkR55THUPY5VNcpFQ+9nRZkL3ULXhagHMD2hIvjy8JSeEQEP5/yYJSrLA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinypool": "2.1.0"
+			},
+			"bin": {
+				"oxfmt": "bin/oxfmt"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxfmt/binding-android-arm-eabi": "0.32.0",
+				"@oxfmt/binding-android-arm64": "0.32.0",
+				"@oxfmt/binding-darwin-arm64": "0.32.0",
+				"@oxfmt/binding-darwin-x64": "0.32.0",
+				"@oxfmt/binding-freebsd-x64": "0.32.0",
+				"@oxfmt/binding-linux-arm-gnueabihf": "0.32.0",
+				"@oxfmt/binding-linux-arm-musleabihf": "0.32.0",
+				"@oxfmt/binding-linux-arm64-gnu": "0.32.0",
+				"@oxfmt/binding-linux-arm64-musl": "0.32.0",
+				"@oxfmt/binding-linux-ppc64-gnu": "0.32.0",
+				"@oxfmt/binding-linux-riscv64-gnu": "0.32.0",
+				"@oxfmt/binding-linux-riscv64-musl": "0.32.0",
+				"@oxfmt/binding-linux-s390x-gnu": "0.32.0",
+				"@oxfmt/binding-linux-x64-gnu": "0.32.0",
+				"@oxfmt/binding-linux-x64-musl": "0.32.0",
+				"@oxfmt/binding-openharmony-arm64": "0.32.0",
+				"@oxfmt/binding-win32-arm64-msvc": "0.32.0",
+				"@oxfmt/binding-win32-ia32-msvc": "0.32.0",
+				"@oxfmt/binding-win32-x64-msvc": "0.32.0"
+			}
+		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8076,25 +8403,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/prettier-plugin-packagejson": {
-			"version": "2.5.19",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.19.tgz",
-			"integrity": "sha512-Qsqp4+jsZbKMpEGZB1UP1pxeAT8sCzne2IwnKkr+QhUe665EXUo3BAvTf1kAPCqyMv9kg3ZmO0+7eOni/C6Uag==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"sort-package-json": "3.4.0",
-				"synckit": "0.11.11"
-			},
-			"peerDependencies": {
-				"prettier": ">= 1.16.0"
-			},
-			"peerDependenciesMeta": {
-				"prettier": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/pretty-ms": {
@@ -8763,35 +9071,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/sort-object-keys": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
-			"integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/sort-package-json": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.4.0.tgz",
-			"integrity": "sha512-97oFRRMM2/Js4oEA9LJhjyMlde+2ewpZQf53pgue27UkbEXfHJnDzHlUxQ/DWUkzqmp7DFwJp8D+wi/TYeQhpA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"detect-indent": "^7.0.1",
-				"detect-newline": "^4.0.1",
-				"git-hooks-list": "^4.0.0",
-				"is-plain-obj": "^4.1.0",
-				"semver": "^7.7.1",
-				"sort-object-keys": "^1.1.3",
-				"tinyglobby": "^0.2.12"
-			},
-			"bin": {
-				"sort-package-json": "cli.js"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -9390,52 +9669,14 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/tinyglobby": {
-			"version": "0.2.15",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/SuperchupuDev"
-			}
-		},
-		"node_modules/tinyglobby/node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+		"node_modules/tinypool": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+			"integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
+				"node": "^20.0.0 || >=22.0.0"
 			}
 		},
 		"node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
 	"version": "16.8.0",
 	"description": "SVG icons for popular brands https://simpleicons.org",
 	"keywords": [
-		"svg",
-		"icons"
+		"icons",
+		"svg"
 	],
 	"homepage": "https://simpleicons.org",
 	"bugs": {
 		"url": "https://github.com/simple-icons/simple-icons/issues"
 	},
+	"license": "CC0-1.0",
+	"author": "Simple Icons Collaborators",
 	"repository": {
 		"type": "git",
 		"url": "git+ssh://git@github.com/simple-icons/simple-icons.git"
@@ -24,9 +26,9 @@
 			"url": "https://github.com/sponsors/simple-icons"
 		}
 	],
-	"license": "CC0-1.0",
-	"author": "Simple Icons Collaborators",
 	"sideEffects": false,
+	"main": "index.js",
+	"types": "index.d.ts",
 	"exports": {
 		".": {
 			"types": "./index.d.ts",
@@ -60,24 +62,22 @@
 			"default": "./data/simple-icons.json"
 		}
 	},
-	"main": "index.js",
-	"types": "index.d.ts",
 	"scripts": {
 		"add-icon-data": "node scripts/add-icon-data.js",
 		"build": "node scripts/build/package.js",
 		"clean": "node scripts/build/clean.js",
-		"format": "node --run format:icondata && node --run prettier -- --write && node --run xo:fix",
+		"format": "node --run format:icondata && node --run oxfmt -- --write && node --run xo:fix",
 		"format:icondata": "node scripts/format-icon-data.js",
 		"get-filename": "node scripts/get-filename.js",
 		"jslint": "xo",
 		"jsonlint": "node scripts/lint/jsonlint.js",
-		"lint": "node --run ourlint && node --run prettierlint && node --run jslint && node --run jsonlint && node --run svglint && node --run wslint && node --run tslint && node --run markdownlint",
+		"lint": "node --run ourlint && node --run oxfmtlint && node --run jslint && node --run jsonlint && node --run svglint && node --run wslint && node --run tslint && node --run markdownlint",
 		"markdownlint": "rumdl check .",
 		"ourlint": "node scripts/lint/ourlint.js",
 		"prepare": "node -e \"process.exit(process.env.CI ? 0 : 1)\" || prek install",
 		"prepublishOnly": "node --run build",
-		"prettier": "prettier --ignore-unknown \"**/*.!(js|jsx|mjs|cjs|ts|tsx|mts|cts|svg)\"",
-		"prettierlint": "node --run prettier -- --check --cache",
+		"oxfmt": "oxfmt",
+		"oxfmtlint": "node --run oxfmt -- --check",
 		"postpublish": "node --run clean",
 		"remove-icon": "node scripts/remove-icon.js",
 		"svglint": "node --run svglint:base -- \"icons/*.svg\"",
@@ -107,7 +107,7 @@
 		"jsonschema": "1.5.0",
 		"mocha": "11.7.5",
 		"named-html-entities-json": "1.0.0",
-		"prettier-plugin-packagejson": "2.5.19",
+		"oxfmt": "0.32.0",
 		"rumdl": "0.1.12",
 		"spdx-license-ids": "3.0.22",
 		"svg-path-bbox": "2.1.0",

--- a/prek.toml
+++ b/prek.toml
@@ -10,9 +10,9 @@ pass_filenames = false
 files.glob = "data/simple-icons.json"
 
 [[repos.hooks]]
-id = "prettier"
-name = "Prettier"
-entry = "node --run prettier -- --write"
+id = "oxfmt"
+name = "Oxfmt"
+entry = "node --run oxfmt"
 language = "system"
 pass_filenames = false
 


### PR DESCRIPTION
This PR replaces Prettier with Oxfmt. Oxfmt is about 2× faster than Prettier on warm runs. On cold start, Prettier takes 4.366s, making it nearly 9× slower.

Oxfmt also sort package.json by default, i think it's good.

Tested using [hyperfine](https://github.com/sharkdp/hyperfine):

```
❯ hyperfine "node --run oxfmt"
Benchmark 1: node --run oxfmt
  Time (mean ± σ):     528.1 ms ±  34.1 ms    [User: 3321.3 ms, System: 1526.6 ms]
  Range (min … max):   488.0 ms … 591.6 ms    10 runs

❯ hyperfine "node --run prettier"
Benchmark 1: node --run prettier
  Time (mean ± σ):      1.168 s ±  1.124 s    [User: 0.973 s, System: 0.405 s]
  Range (min … max):    0.797 s …  4.366 s    10 runs

  Warning: The first benchmarking run for this command was significantly slower than the rest (4.366 s). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.
```