### PR TITLE
Update broken source URLs for Qi, containerd, Kuma, Linkerd, and Vitess

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -3487,7 +3487,7 @@
 	{
 		"title": "containerd",
 		"hex": "575757",
-		"source": "https://cncf-branding.netlify.app/projects/containerd/"
+		"source": "https://github.com/containerd/containerd.io/blob/main/static/img/logos/icon/black/containerd-icon-black.svg"
 	},
 	{
 		"title": "Contao",
@@ -9089,7 +9089,7 @@
 	{
 		"title": "Kuma",
 		"hex": "290B53",
-		"source": "https://cncf-branding.netlify.app/projects/kuma/"
+		"source": "https://kuma.io/"
 	},
 	{
 		"title": "Kununu",
@@ -9515,7 +9515,7 @@
 	{
 		"title": "Linkerd",
 		"hex": "2BEDA7",
-		"source": "https://cncf-branding.netlify.app/projects/linkerd/"
+		"source": "https://linkerd.io/"
 	},
 	{
 		"title": "Linkfire",
@@ -13555,8 +13555,8 @@
 	{
 		"title": "Qi",
 		"hex": "000000",
-		"source": "https://www.wirelesspowerconsortium.com/knowledge-base/retail/qi-logo-guidelines-and-artwork.html",
-		"guidelines": "https://www.wirelesspowerconsortium.com/knowledge-base/retail/qi-logo-guidelines-and-artwork.html"
+		"source": "https://www.wirelesspowerconsortium.com/knowledge-base/for-retail-and-brands/qi-logo-guidelines-and-artwork/",
+		"guidelines": "https://www.wirelesspowerconsortium.com/knowledge-base/for-retail-and-brands/qi-logo-guidelines-and-artwork/"
 	},
 	{
 		"title": "Qiita",
@@ -18134,7 +18134,7 @@
 	{
 		"title": "Vitess",
 		"hex": "F16728",
-		"source": "https://cncf-branding.netlify.app/projects/vitess/"
+		"source": "https://vitess.io/"
 	},
 	{
 		"title": "Vitest",


### PR DESCRIPTION
Fixes some of the broken links listed in #11901.

### Changes

Updated the following broken source/guidelines URLs in `data/simple-icons.json`:

- **Qi**: Updated Wireless Power Consortium URL from the old `/knowledge-base/retail/` path to the current `/knowledge-base/for-retail-and-brands/` path
- **containerd**: Replaced deprecated `cncf-branding.netlify.app` link with the SVG source from the [containerd.io GitHub repository](https://github.com/containerd/containerd.io/blob/main/static/img/logos/icon/black/containerd-icon-black.svg)
- **Kuma**: Replaced deprecated `cncf-branding.netlify.app` link with https://kuma.io/
- **Linkerd**: Replaced deprecated `cncf-branding.netlify.app` link with https://linkerd.io/
- **Vitess**: Replaced deprecated `cncf-branding.netlify.app` link with https://vitess.io/

All the replacement URLs are accessible and serve as valid sources for the respective icons.

Closes part of #11901