### PR TITLE
Refactor redundant Object.assign wrappers and fix JSDoc types in  scripts/utils.js

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -100,13 +100,12 @@ const sortIconOrDuplicate = (icon) => {
 		'loc',
 	];
 
-	/** @type {T} */
-	const sortedIcon = Object.assign(
+	const sortedIcon = /** @type {T} */ (
 		Object.fromEntries(
 			Object.entries(icon).sort(
 				([key1], [key2]) => keyOrder.indexOf(key1) - keyOrder.indexOf(key2),
 			),
-		),
+		)
 	);
 
 	return sortedIcon;
@@ -124,13 +123,12 @@ const sortLicense = (license) => {
 
 	const keyOrder = ['type', 'url'];
 
-	/** @type {IconData['license']} */
-	const sortedLicense = Object.assign(
+	const sortedLicense = /** @type {IconData['license']} */ (
 		Object.fromEntries(
 			Object.entries(license).sort(
 				([key1], [key2]) => keyOrder.indexOf(key1) - keyOrder.indexOf(key2),
 			),
-		),
+		)
 	);
 
 	return sortedLicense;
@@ -146,10 +144,10 @@ const sortAlphabetically = (object) => {
 		return undefined;
 	}
 
-	const sorted = Object.assign(
+	const sorted = /** @type {any} */ (
 		Object.fromEntries(
 			Object.entries(object).sort(([key1], [key2]) => (key1 > key2 ? 1 : -1)),
-		),
+		)
 	);
 	return sorted;
 };


### PR DESCRIPTION
This PR removes three redundant `Object.assign()` wrappers around `Object.fromEntries()` inside `scripts/utils.js`. Because `Object.assign` invoked with a single argument simply returns the argument untouched, this wrapper served no functional purpose at runtime.

Previously, `Object.assign()` implicitly swallowed TypeScript check errors caused by sorting by letting the result infer as `any`. With its removal, the implicit TypeScript bypass fails under `npm run tslint`. To correct this, standard and strict JSDoc inline casts (`/** @type {T} */ ( ... )`) are introduced. This provides clean syntactic JavaScript, maintains strong static type analysis, and avoids an unnecessary runtime function call.

- Passes all tests
- Passes all standard linting checks and pre-commit hooks