### PR TITLE
Fix typos and grammar errors in comments and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -453,7 +453,7 @@ Where the `locale` is an [IETF language tag] and each localized title is **diffe
 
 ##### Old Names
 
-We collect old names to make it possible to find the brand by it's old name. To add an old name you add the following to the icon data:
+We collect old names to make it possible to find the brand by its old name. To add an old name you add the following to the icon data:
 
 ```json
 {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -3,7 +3,7 @@
 /**
  * @file Internal utilities.
  *
- * Here resides all the functionality that does not qualifies to reside
+ * Here resides all the functionality that does not qualify to reside
  * in the SDK because is not publicly exposed.
  */
 
@@ -96,7 +96,7 @@ const sortIconOrDuplicate = (icon) => {
 		'guidelines',
 		'license',
 		'aliases',
-		// This is not appears in icon data but it's in the alias object.
+		// This does not appear in icon data but it's in the alias object.
 		'loc',
 	];
 

--- a/svglint.config.mjs
+++ b/svglint.config.mjs
@@ -12,7 +12,7 @@ import svgpath from 'svgpath';
 import {SVG_PATH_REGEX, getIconsData, htmlFriendlyToTitle} from './sdk.mjs';
 
 /**
- * The svgpath library does not includes a `segments` property on their interface.
+ * The svgpath library does not include a `segments` property on their interface.
  * See https://github.com/fontello/svgpath/pull/67/files for more information.
  * @typedef {import('svg-path-segments').Segment & {segments: [string, ...number[]][]}} Segment
  */
@@ -214,7 +214,7 @@ const config = {
 				];
 				if (namedEntitiesCodepoints.length > 0) {
 					for (const match of namedEntitiesCodepoints) {
-						const namedEntiyReprIndex =
+						const namedEntityReprIndex =
 							getTitleTextIndex(ast.source) + match.index + 1;
 
 						if (!xmlNamedEntities.includes(match[1].toLowerCase())) {
@@ -237,7 +237,7 @@ const config = {
 
 							reporter.error(
 								'Named entity representation of encoded character' +
-									` "${match[0]}" found at index ${namedEntiyReprIndex}.` +
+									` "${match[0]}" found at index ${namedEntityReprIndex}.` +
 									` Replace it with ${replacement}.`,
 							);
 						}
@@ -409,11 +409,11 @@ const config = {
 				];
 				const upperMovementCommands = ['M', 'L'];
 				const upperHorDirectionCommand = 'H';
-				const upperVersionDirectionCommand = 'V';
+				const upperVerticalDirectionCommand = 'V';
 				/** @type {(string | number | undefined)[]} */
 				const upperDirectionCommands = [
 					upperHorDirectionCommand,
-					upperVersionDirectionCommand,
+					upperVerticalDirectionCommand,
 				];
 				const upperCurveCommand = 'C';
 				const upperShorthandCurveCommand = 'S';
@@ -504,7 +504,7 @@ const config = {
 
 									// If the previous command was a vertical movement,
 									// we need to consider the single coordinate as y
-									if (upperVersionDirectionCommand === xPreviousCoordDeep) {
+									if (upperVerticalDirectionCommand === xPreviousCoordDeep) {
 										xPreviousCoordDeep = undefined;
 									}
 
@@ -560,7 +560,7 @@ const config = {
 									x1Coord === xPreviousCoord) ||
 								// Absolute vertical direction (V) having
 								// the same y coordinate as the previous segment
-								(upperVersionDirectionCommand === command &&
+								(upperVerticalDirectionCommand === command &&
 									x1Coord === yPreviousCoord) ||
 								// Absolute movement (M or L) having the same
 								// coordinate as the previous segment
@@ -641,7 +641,7 @@ const config = {
 				reporter.name = 'collinear-segments';
 				/**
 				 * Extracts collinear coordinates from SVG path straight lines
-				 * (does not extracts collinear coordinates from curves).
+				 * (does not extract collinear coordinates from curves).
 				 * @returns {import('svg-path-segments').Segment[]} The collinear segments.
 				 */
 				// eslint-disable-next-line complexity


### PR DESCRIPTION
## Summary

This PR fixes various typos and grammar errors found across comments and documentation files.

### Changes

**`svglint.config.mjs`:**
- Fix grammar: "does not includes" → "does not include" (line 15)
- Fix variable name typo: `namedEntiyReprIndex` → `namedEntityReprIndex` (missing 't' in "Entity")
- Fix variable name typo: `upperVersionDirectionCommand` → `upperVerticalDirectionCommand` ('V' is the SVG vertical direction command, not "version")
- Fix grammar: "does not extracts" → "does not extract" (line 644)

**`scripts/utils.js`:**
- Fix grammar: "does not qualifies" → "does not qualify" (line 6)
- Fix grammar: "This is not appears" → "This does not appear" (line 99)

**`CONTRIBUTING.md`:**
- Fix grammar: "it's old name" → "its old name" (possessive pronoun, no apostrophe)

### Verification

- All existing lint checks pass (`ourlint`, `jslint`, `jsonlint`, `svglint` — 3408 SVGs validated)
- No behavioral changes — only comments, documentation, and variable names are updated
- The renamed variable `upperVerticalDirectionCommand` maintains the same value (`'V'`) and all references are updated consistently