### PR TITLE
Update YouTube icon color

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -19133,38 +19133,38 @@
 	},
 	{
 		"title": "YouTube",
-		"hex": "FF0000",
-		"source": "https://www.youtube.com/howyoutubeworks/resources/brand-resources/#logos-icons-and-colors",
-		"guidelines": "https://www.youtube.com/howyoutubeworks/resources/brand-resources/#logos-icons-and-colors"
+		"hex": "FF0033",
+		"source": "https://brand.youtube",
+		"guidelines": "https://brand.youtube"
 	},
 	{
 		"title": "YouTube Gaming",
-		"hex": "FF0000",
+		"hex": "FF0033",
 		"source": "https://gaming.youtube.com"
 	},
 	{
 		"title": "YouTube Kids",
-		"hex": "FF0000",
+		"hex": "FF0033",
 		"source": "https://www.youtube.com/intl/ALL_us/kids"
 	},
 	{
 		"title": "YouTube Music",
-		"hex": "FF0000",
+		"hex": "FF0033",
 		"source": "https://partnermarketinghub.withgoogle.com/#/brands"
 	},
 	{
 		"title": "YouTube Shorts",
-		"hex": "FF0000",
+		"hex": "FF0033",
 		"source": "https://www.youtube.com/shorts"
 	},
 	{
 		"title": "YouTube Studio",
-		"hex": "FF0000",
+		"hex": "FF0033",
 		"source": "https://www.youtube.com"
 	},
 	{
 		"title": "YouTube TV",
-		"hex": "FF0000",
+		"hex": "FF0033",
 		"source": "https://partnermarketinghub.withgoogle.com/#/brands"
 	},
 	{


### PR DESCRIPTION
Update all YouTube icons color from `#FF0000` to `#FF0033`, following the [official change](https://design.google/library/youtube-new-red-color).

I also changed the [source link](https://brand.youtube) for the main YouTube icon (the previous link redirects here).

<img width="740" height="520" alt="image" src="https://github.com/user-attachments/assets/7c7d842d-1f57-40d0-9142-0eec3d4e8644" />

### Checklist

- [x] I have reviewed the [forbidden brands](https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#forbidden-brands) list and confirm the brand I am submitting a PR for is not one of them, nor is it a subsidiary of one of those brands
- [x] I have reviewed the brand's terms of service, and am confident we can add this icon
- [x] I confirm that I did not use AI tools to create this PR, or that any AI assistance has been fully disclosed in this PR
- [x] I updated the JSON data in `data/simple-icons.json`
- [x] I optimized the icon with SVGO or SVGOMG~~
- [x] The SVG `viewbox` is `0 0 24 24`

