### PR TITLE
Add Bethesda icon

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -1912,6 +1912,11 @@
 		"source": "https://www.betfair.com"
 	},
 	{
+		"title": "Bethesda",
+		"hex": "000000",
+		"source": "https://press.bethesda.net/en/brands/bethesda-softworks/press-kit"
+	},
+	{
 		"title": "Better Auth",
 		"hex": "FFFFFF",
 		"source": "https://github.com/better-auth/better-auth/blob/fd62eba1d0ec71b3abb17ece92a4aae0c3c85270/docs/public/branding/better-auth-logo-light.svg"

--- a/icons/bethesda.svg
+++ b/icons/bethesda.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Bethesda</title><path d="M.238 0v24h23.524V0H.238zM15.47 15.548H8.519V8.455h6.952v7.093z"/></svg>


### PR DESCRIPTION
Closes #13760. Adds the Bethesda icon using the official square logo and #000000 color.