### PR TITLE
fix: update broken source URLs  (17 broken source/guidelines URLs)

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -5037,7 +5037,7 @@
 	{
 		"title": "Equinix Metal",
 		"hex": "ED2224",
-		"source": "https://metal.equinix.com"
+		"source": "https://brand.equinix.com"
 	},
 	{
 		"title": "Eraser",
@@ -15465,7 +15465,7 @@
 	{
 		"title": "SlideShare",
 		"hex": "008ED2",
-		"source": "https://www.slideshare.net/ss/creators/"
+		"source": "https://www.slideshare.net"
 	},
 	{
 		"title": "Slint",


### PR DESCRIPTION
 **Issue:** relates to #11901

  ### Checklist

  - [x] I have reviewed the [forbidden brands](https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#forbidden-brands) list
  - [x] I have reviewed the brand's terms of service
  - [x] I confirm that any AI assistance has been fully disclosed in this PR
  - [x] I updated the JSON data in `data/simple-icons.json`

  ### Description
  Fixes 14 broken source/guidelines URLs from #11901:

  | Icon | Old URL | New URL |
  |------|---------|---------|
  | Qi | wirelesspowerconsortium.com/.../retail/... (404) | .../for-retail-and-brands/... |
  | Vitess | cncf-branding.netlify.app (dead) | CNCF artwork repo permalink |
  | containerd | cncf-branding.netlify.app (dead) | CNCF artwork repo permalink |
  | etcd | cncf-branding.netlify.app (dead) | CNCF artwork repo permalink |
  | kuma | cncf-branding.netlify.app (dead) | CNCF artwork repo permalink |
  | linkerd | cncf-branding.netlify.app (dead) | CNCF artwork repo permalink |
  | OpenTelemetry | cncf-branding.netlify.app (dead) | CNCF artwork repo permalink |
  | CentOS | wiki.centos.org/ArtWork/Brand/Logo (404) | wiki.centos.org new URL format |
  | Litecoin | litecoin-foundation.org (redirects) | litecoin.com/resources |
  | TUI | design.tui (403) | tui-brandhub.com |
  | Wolfram | press-center/wolfram-corporate (broken) | press-center base URL |
  | Wolfram Language | press-center/language (broken) | press-center base URL |
  | Wolfram Mathematica | press-center/mathematica (broken) | press-center base URL |
  | Groupon | about.groupon.com/press/ (dead) | groupon.com/articles/press |
  | SmugMug | smugmughelp.com/articles/409-... (404) | smugmughelp.com/hc/en-us/articles/... |
  | SlideShare | slideshare.net/ss/creators/ (404) | slideshare.net homepage |
  | Equinix Metal | metal.equinix.com (sunsetting) | brand.equinix.com |

  All new URLs verified to return HTTP 200.

  ### Not addressed

  | Icon | Reason |
  |------|--------|
  | DeviantArt | No replacement found (noted in #11901) |
  | Ford, Fujitsu, SNCF | False positives — existing URLs still return 200 |