### PR TITLE
Update Kuma icon

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -9137,7 +9137,7 @@
 	{
 		"title": "Kuma",
 		"hex": "290B53",
-		"source": "https://cncf-branding.netlify.app/projects/kuma/"
+		"source": "https://kuma.io"
 	},
 	{
 		"title": "Kununu",


### PR DESCRIPTION
## Description

This PR fixes the severely outdated and broken `source` URL for the **Kuma** icon, which was pointing to a defunct Netlify domain. It has been updated to point directly to the officially maintained [Kuma website](https://kuma.io).

This addresses one of the actively broken URLs documented in #11901.

- **Old URL**: `https://cncf-branding.netlify.app/projects/kuma/` (Broken/Unavailable)
- **New URL**: `https://kuma.io` (Verified Live)

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I checked that the updated URL is live and points to the official maintainers.
- [x] I ran the required linter commands (`npm run lint`) and all checks passed perfectly without trailing format errors.
- [x] The `source` URL does not contain any tracking identifiers.
