### PR TITLE
chore(data): update broken source/guidelines links

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -4453,7 +4453,7 @@
 	{
 		"title": "Dribbble",
 		"hex": "EA4C89",
-		"source": "https://dribbble.com/branding"
+		"source": "https://dribbble.com/media-kit"
 	},
 	{
 		"title": "Drizzle",
@@ -4974,7 +4974,7 @@
 	{
 		"title": "etcd",
 		"hex": "419EDA",
-		"source": "https://cncf-branding.netlify.app/projects/etcd/"
+		"source": "https://github.com/etcd-io/etcd/blob/main/logos/etcd-glyph-color.svg"
 	},
 	{
 		"title": "Ethereum",
@@ -5503,7 +5503,7 @@
 	{
 		"title": "Flipboard",
 		"hex": "E12828",
-		"source": "https://about.flipboard.com/brand-guidelines"
+		"source": "https://about.flipboard.com/press"
 	},
 	{
 		"title": "Floatplane",
@@ -5652,7 +5652,7 @@
 	{
 		"title": "Formstack",
 		"hex": "21B573",
-		"source": "https://www.formstack.com/brand/guidelines"
+		"source": "https://webflow-prod.formstack.com/brand"
 	},
 	{
 		"title": "Fortinet",
@@ -6047,7 +6047,7 @@
 		"title": "Ghostery",
 		"hex": "00AEF0",
 		"source": "https://www.ghostery.com",
-		"guidelines": "https://www.ghostery.com/press/"
+		"guidelines": "https://www.ghostery.com/design"
 	},
 	{
 		"title": "Ghostty",
@@ -7730,7 +7730,7 @@
 	{
 		"title": "ImageJ",
 		"hex": "00D8E0",
-		"source": "https://github.com/imagej/imagej/blob/0667395bcac20e5d7a371ac9f468522c74367d59/logo/inkscape_image_logo_src.svg"
+		"source": "https://github.com/imagej/imagej.github.io/blob/main/safari-pinned-tab.svg"
 	},
 	{
 		"title": "IMDb",
@@ -9183,8 +9183,8 @@
 	{
 		"title": "LG",
 		"hex": "A50034",
-		"source": "https://www.lg.com/global/our-brand/brand-expression/elements/logo/index.jsp",
-		"guidelines": "https://www.lg.com/global/our-brand/brand-expression/elements/logo/index.jsp"
+		"source": "https://www.lg.com/global/our-brand/brand-expression/logo/",
+		"guidelines": "https://www.lg.com/global/our-brand/brand-expression/logo/"
 	},
 	{
 		"title": "Li-Ning",
@@ -9512,6 +9512,11 @@
 		"title": "LocalXpose",
 		"hex": "6023C0",
 		"source": "https://localxpose.io"
+	},
+	{
+		"title": "Locust",
+		"hex": "B8EE4B",
+		"source": "https://cdn.prod.website-files.com/66596d70fa45b7e4c8ec4997/66596f508591cfabd5026f65_Frame%2045.svg"
 	},
 	{
 		"title": "Lodash",
@@ -14275,8 +14280,8 @@
 	{
 		"title": "ROS",
 		"hex": "22314E",
-		"source": "https://www.ros.org/press-kit/",
-		"guidelines": "https://www.ros.org/press-kit/"
+		"source": "https://www.ros.org/blog/media/",
+		"guidelines": "https://www.ros.org/blog/media/"
 	},
 	{
 		"title": "Rossmann",
@@ -15998,8 +16003,8 @@
 	{
 		"title": "Sumo Logic",
 		"hex": "000099",
-		"source": "https://sites.google.com/sumologic.com/sumo-logic-brand/home",
-		"guidelines": "https://sites.google.com/sumologic.com/sumo-logic-brand/home"
+		"source": "https://sumologic.com/brand-guidelines",
+		"guidelines": "https://sumologic.com/brand-guidelines"
 	},
 	{
 		"title": "Suno",


### PR DESCRIPTION
Fixes #11901

## Summary
Updated broken source/guidelines URLs for 9 brands:
- Dribbble: `dribbble.com/branding` → `dribbble.com/media-kit`
- etcd: `cncf-branding.netlify.app/projects/etcd/` → GitHub logo asset
- Flipboard: `about.flipboard.com/brand-guidelines` → `about.flipboard.com/press`
- Formstack: `formstack.com/brand/guidelines` → `webflow-prod.formstack.com/brand`
- Ghostery: `ghostery.com/press/` → `ghostery.com/design`
- ImageJ: old GitHub commit → imagej.github.io
- LG: updated URL path
- ROS: `ros.org/press-kit/` → `ros.org/blog/media/`
- Sumo Logic: Google Sites → `sumologic.com/brand-guidelines`