### PR TITLE
Add devEngines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,5 +120,15 @@
 	},
 	"engines": {
 		"node": ">=0.12.18"
+	},
+	"devEngines": {
+		"runtime": {
+			"name": "node",
+			"version": ">=22.18.0"
+		},
+		"packageManager": {
+			"name": "npm",
+			"version": ">=10.0.0"
+		}
 	}
 }


### PR DESCRIPTION
This PR add `devEngines` to package.json, this was original proposed in https://github.com/openjs-foundation/package-metadata-interoperability-working-group/issues/15, this also prepare for upcoming TypeScript rewrite.

- https://nodejs.org/learn/typescript/run-natively