### PR TITLE
Use `actions/create-github-app-token@v3`

### DIFF
--- a/.github/workflows/add-labels-priority.yml
+++ b/.github/workflows/add-labels-priority.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: simple-icons/labeler@v1
         with:
@@ -32,10 +32,10 @@ jobs:
 #      github.event.pull_request.base.ref != 'master'
 #    needs: add-labels
 #    steps:
-#      - uses: actions/create-github-app-token@v1
+#      - uses: actions/create-github-app-token@v3
 #        id: app-token
 #        with:
-#          app-id: ${{ vars.BOT_APP_ID }}
+#          client-id: ${{ secrets.BOT_CLIENT_ID }}
 #          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
 #      - name: Checkout
@@ -146,10 +146,10 @@ jobs:
 #      github.event.pull_request.merged == false &&
 #      github.event.pull_request.base.ref != 'master'
 #    steps:
-#      - uses: actions/create-github-app-token@v1
+#      - uses: actions/create-github-app-token@v3
 #        id: app-token
 #        with:
-#          app-id: ${{ vars.BOT_APP_ID }}
+#          client-id: ${{ secrets.BOT_CLIENT_ID }}
 #          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 #      - name: Assign closed pull requests to "Completed or Abandoned"
 #        uses: srggrs/assign-one-project-github-action@1.3.1

--- a/.github/workflows/autoclose-issues.yml
+++ b/.github/workflows/autoclose-issues.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: simple-icons/release-action@v3
         id: release
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/merge-release.yml
+++ b/.github/workflows/merge-release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: simple-icons/release-action@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v6
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
           repositories: 'simple-icons-font'
       - name: Trigger simple-icons-font release
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
           repositories: 'simple-icons-website-rs'
       - name: Trigger simpleicons.org website update

--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: mondeja/remove-labels-gh-action@v2
         with:
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: mondeja/remove-labels-gh-action@v2
         with:
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - uses: mondeja/remove-labels-gh-action@v2
         with:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
The `app-id` has been deprecated. I've replaced them with `client-id`.

See https://github.com/actions/create-github-app-token#client-id-or-app-id.

I will remove the `BOT_APP_ID` variable from the organization settings after this PR.