### PR TITLE
Add Helium10 icon

### DIFF
--- a/data/simple-icons.json
+++ b/data/simple-icons.json
@@ -7442,6 +7442,11 @@
 		"source": "https://github.com/imputnet/helium-macos/blob/0567a6078847e7dd11ce3c4f2eedcf49aa327dfe/resources/assets/AppIcon.icon/Assets/logo.svg"
 	},
 	{
+		"title": "Helium10",
+		"hex": "003873",
+		"source": "https://helium10.com"
+	},
+	{
 		"title": "Helix",
 		"hex": "281733",
 		"source": "https://helix-editor.com"

--- a/icons/helium10.svg
+++ b/icons/helium10.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Helium10</title><path d="M0 5.351v7.587h5.779V8.509Zm9.109 3.158v4.429h5.782V5.351Zm9.112-4.974v9.403H24V.379ZM0 16.036h5.779v7.585H0Zm9.109 0h5.779v7.585H9.109Zm9.112 0H24v7.585h-5.779Z"/></svg>


### PR DESCRIPTION
Closes #12255

## Source

- SVG: [official Helium 10 header logo](https://www.helium10.com/app/themes/helium10/assets/img/logos/logo-blue-duotone.svg), linked from the [official homepage](https://helium10.com). The icon is the exact six-block symbol extracted from the published wordmark.
- Color: `#003873`, used in the published SVG and provided in the issue’s official resources.

## Checklist

- Followed the Simple Icons contribution guidelines: one icon, official source, monochrome single path, optimized and annotated SVG, and alphabetized metadata.
- `npm run lint` and `npm test` pass locally.

SVG extraction/optimization assisted by AI tools; I reviewed the geometry, sources, and metadata and verified lint.
