### PR TITLE
Bump `editorconfig-checker@7.0.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"@types/mocha": "10.0.10",
 				"@types/node": "25.8.0",
 				"chalk": "5.6.2",
-				"editorconfig-checker": "6.1.1",
+				"editorconfig-checker": "7.0.0",
 				"esbuild": "0.28.0",
 				"eslint-plugin-headers": "1.3.4",
 				"eslint-plugin-jsdoc": "62.9.0",
@@ -4173,9 +4173,9 @@
 			"license": "MIT"
 		},
 		"node_modules/editorconfig-checker": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/editorconfig-checker/-/editorconfig-checker-6.1.1.tgz",
-			"integrity": "sha512-kiOb6qaWpMNt7Z/43ba0Pa1Inhr2/t9nKbvEKtCeXJ5AesztoM9AgLOOQVB4QUv/nGjgz3xkbx4pcogVRD2NWw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/editorconfig-checker/-/editorconfig-checker-7.0.0.tgz",
+			"integrity": "sha512-bqTCyzjz6Qbah4hBO032mQiwGstrHL/jwsnlFvlqrDcpv8rv2pSgLo00Fnji1u6PGtSdY6uydzVLUdHupbpNBQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -4183,7 +4183,7 @@
 				"editorconfig-checker": "dist/index.js"
 			},
 			"engines": {
-				"node": ">=20.11.0"
+				"node": ">=24.14.0"
 			},
 			"funding": {
 				"type": "buymeacoffee",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
 		"@types/mocha": "10.0.10",
 		"@types/node": "25.8.0",
 		"chalk": "5.6.2",
-		"editorconfig-checker": "6.1.1",
+		"editorconfig-checker": "7.0.0",
 		"esbuild": "0.28.0",
 		"eslint-plugin-headers": "1.3.4",
 		"eslint-plugin-jsdoc": "62.9.0",


### PR DESCRIPTION
Related to:
- https://github.com/simple-icons/simple-icons/actions/runs/33882379930/job/101063946183?pr=14989
- https://github.com/editorconfig-checker/editorconfig-checker.javascript/pull/435
- https://github.com/editorconfig-checker/editorconfig-checker.javascript/issues/434

editorconfig-checker release v4 and change package name, JavaScript wrapper download binary when linting, now we are affected by this breaking change, update to fix.