### PR TITLE
fix(types): support dual module exports

### DIFF
--- a/data/simple-icons.d.ts
+++ b/data/simple-icons.d.ts
@@ -56,4 +56,5 @@ export type CustomLicense = {
 declare const icons: IconData[];
 
 export default icons;
+// @ts-expect-error TS2309: Preserve CommonJS compatibility alongside the default export.
 export = icons;


### PR DESCRIPTION
## Summary
- Preserve both ESM and CommonJS exports for the data JSON entrypoint.
- Suppress TS2309 caused by TypeScript rejecting the intentional combination of ESM and CommonJS-compatible declarations.

## Details
`data/simple-icons.d.ts` intentionally exposes both `export default` and `export =` for compatibility. TypeScript reports TS2309 when checking this declaration with `skipLibCheck: false`.
The `@ts-expect-error` preserves the CommonJS declaration while documenting and suppressing the expected diagnostic.

## Validation
- `npm ci --ignore-scripts`
- `npm test`
- `npm run lint`
- Type-checked the data JSON entrypoint with `skipLibCheck: false`

## AI disclosure

I am the author of this change.
However, an LLM coding agent assisted during validation of a Backstage dependency upgrade using `@dweber019/backstage-plugin-simple-icons`. It identified the upstream TypeScript declaration conflict, investigated the module-export compatibility issue, and suggested a patch to resolve it.
After reviewing the findings and patch, I decided to open this pull request.
I reviewed the diagnosis, code change, and validation results and take responsibility for the submitted change.

<hr>

Not sure whether I should have used any templates, but what I found was only applicable for adding icons, not for changes like the one I am proposing here.
Please let me know if I should have formatted my PR description differently.